### PR TITLE
Settings text fixes

### DIFF
--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -96,20 +96,14 @@ function BrainzPlayerSettings() {
       <Helmet>
         <title>BrainzPlayer Settings</title>
       </Helmet>
-      <h2 className="page-title">BrainzPlayer Settings</h2>
-      <h4 className="page-title">Music Players</h4>
+      <h2 className="page-title">BrainzPlayer settings</h2>
       <p>
-        You can choose which music services to play music from on listenBrainz.
-        To sign in and authorize your account please go to the{" "}
-        <Link to="/settings/music-services/details/">
-          &quot;connect services&quot; page
-        </Link>
-        . <br />
-        If you don&apos;t have a subscription to a music service listed below,
-        Youtube will be used by default as it does not require an account.
-        However the search results from Youtube are often inaccurate, and for a
-        better listening experience we recommend one of the other services (if
-        you have one available).
+        Choose which music services to use for playback in ListenBrainz.
+      </p>
+      
+      <p?
+        YouTube is enabled by default. For a better listening experience we recommend
+        enabling another service.
       </p>
       <div
         className="mb-15"
@@ -136,8 +130,9 @@ function BrainzPlayerSettings() {
         />
         <br />
         <small>
-          Spotify requires a premium account to play full songs on third-party
-          websites. To sign in, please go to the{" "}
+          Spotify requires a premium account.
+        <br />
+          Sign in on the{" "}
           <Link to="/settings/music-services/details/">
             &quot;connect services&quot; page
           </Link>
@@ -169,12 +164,13 @@ function BrainzPlayerSettings() {
         />
         <br />
         <small>
-          Apple Music requires a premium account to play full songs on
-          third-party websites. To sign in, please go to the{" "}
+          Apple Music requires a premium account.
+        <br />
+          Sign in on the{" "}
           <Link to="/settings/music-services/details/">
             &quot;connect services&quot; page
           </Link>
-          . You will need to sign in every 6 months as the authorization
+          . You will need to sign in every 6 months, as the authorization
           expires.
         </small>
       </div>
@@ -197,14 +193,15 @@ function BrainzPlayerSettings() {
               <span className={soundcloudEnabled ? "text-success" : ""}>
                 <FontAwesomeIcon icon={faSoundcloud} />
               </span>
-              <span>&nbsp;Soundcloud</span>
+              <span>&nbsp;SoundCloud</span>
             </span>
           }
         />
         <br />
         <small>
-          Soundcloud requires a free account to play full songs on third-party
-          websites. To sign in, please go to the{" "}
+          SoundCloud requires a free account.
+        <br />
+          Sign in on the{" "}
           <Link to="/settings/music-services/details/">
             &quot;connect services&quot; page
           </Link>
@@ -223,17 +220,17 @@ function BrainzPlayerSettings() {
               <span className={youtubeEnabled ? "text-success" : ""}>
                 <FontAwesomeIcon icon={faYoutube} />
               </span>
-              <span>&nbsp;Youtube</span>
+              <span>&nbsp;YouTube</span>
             </span>
           }
         />
         <br />
         <small>
-          Youtube does not require signing in and provides a good fallback. Be
-          aware the search results from Youtube are often inaccurate.
+          YouTube does not require an account and is the default fallback.
+          Search results from YouTube are often inaccurate.
           <br />
-          By using Youtube to play music, you agree to be bound by the YouTube
-          Terms of Service. See their terms of service and privacy policy below:
+          By using YouTube you agree to be bound by the YouTube Terms of
+          Service:
           <ul>
             <li>
               <a
@@ -262,7 +259,7 @@ function BrainzPlayerSettings() {
         type="button"
         onClick={saveSettings}
       >
-        Save preferences
+        Save BrainzPlayer settings
       </button>
       <ReactTooltip id="login-first" aria-haspopup="true" delayHide={500}>
         You must login to this service in the &quot;Connect services&quot;

--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -72,24 +72,21 @@ export default function DeleteListens() {
       <Helmet>
         <title>Delete Listens</title>
       </Helmet>
-      <h3 className="page-title">Delete your listens</h3>
+      <h3 className="page-title">Delete listens: {name}</h3>
       <p>
-        Hi {name}, are you sure you want to delete listens imported into your
-        ListenBrainz account?
-      </p>
-
-      <p>Once deleted, all your listens data will be removed PERMANENTLY.</p>
-
-      <p>
-        Warning: if you are still connected to Spotify, the last 50 Spotify
-        tracks might be auto-reimported.{" "}
-        <Link to="/settings/music-services/details/">Disconnect</Link> before
-        deleting.
+        <b>This will permanently delete all ListenBrainz listens for user {name}.</b>
       </p>
 
       <p>
-        Note: you can export your ListenBrainz data before deleting your
-        listens.
+        If you are still connected to Spotify, the last 50 Spotify
+        tracks may be auto-reimported. You can {" "}
+        <Link to="/settings/music-services/details/">Disconnect</Link> Spotify
+        before deleting.
+      </p>
+
+      <p>
+        The listens will not be recoverable. Please consider exporting
+        your ListenBrainz data before deleting your account.
       </p>
 
       <form onSubmit={downloadListens}>
@@ -98,11 +95,10 @@ export default function DeleteListens() {
           type="submit"
           style={{ width: "250px" }}
         >
-          Export my listens.
+          Export listens
         </button>
       </form>
       <br />
-      <p>Yes, I am sure I want to erase my entire listening history</p>
 
       <form onSubmit={deleteListens}>
         <button
@@ -111,7 +107,7 @@ export default function DeleteListens() {
           type="submit"
           style={{ width: "250px" }}
         >
-          Delete my listens.
+          Delete listens
         </button>
       </form>
     </>

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -39,7 +39,7 @@ export default function DeleteAccount() {
       toast.success(
         <ToastMsg
           title="Success"
-          message="Your feedback have been downloaded."
+          message="Your feedback has been downloaded."
         />
       );
     } catch (error) {
@@ -87,19 +87,14 @@ export default function DeleteAccount() {
       <Helmet>
         <title>Delete Account</title>
       </Helmet>
-      <h3 className="page-title">Delete your account</h3>
+      <h3 className="page-title">Delete account: {name}</h3>
       <p>
-        Hi {name}, are you sure you want to delete your ListenBrainz account?
+        <b>This will permanently all ListenBrainz data for user {name}.</b>
       </p>
 
       <p>
-        Once deleted, all your ListenBrainz data will be removed PERMANENTLY and
-        will not be recoverable.
-      </p>
-
-      <p>
-        Note: you can export your ListenBrainz data before deleting your
-        account.
+        The data will not be recoverable. Please consider exporting
+        your ListenBrainz data before deleting your account.
       </p>
 
       <form onSubmit={downloadListens}>
@@ -108,7 +103,7 @@ export default function DeleteAccount() {
           type="submit"
           style={{ width: "250px" }}
         >
-          Export my listens.
+          Export listens
         </button>
       </form>
 
@@ -118,7 +113,7 @@ export default function DeleteAccount() {
           type="submit"
           style={{ width: "250px" }}
         >
-          Export my feedback.
+          Export feedback
         </button>
       </form>
 
@@ -129,7 +124,7 @@ export default function DeleteAccount() {
           type="submit"
           style={{ width: "250px" }}
         >
-          Delete my account.
+          Delete account
         </button>
       </form>
     </>

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -89,7 +89,7 @@ export default function DeleteAccount() {
       </Helmet>
       <h3 className="page-title">Delete account: {name}</h3>
       <p>
-        <b>This will permanently all ListenBrainz data for user {name}.</b>
+        <b>This will permanently delete all ListenBrainz data for user {name}.</b>
       </p>
 
       <p>

--- a/frontend/js/src/settings/export/ExportData.tsx
+++ b/frontend/js/src/settings/export/ExportData.tsx
@@ -62,25 +62,21 @@ export default function Export() {
       </Helmet>
       <h3>Export from ListenBrainz</h3>
       <p>
-        <strong> Notes about the ListenBrainz export process : </strong>
-      </p>
-      <p>
-        Export your listen history in JSON format and download it. Click
-        Download to proceed.
+        Export and download your listen history in JSON format.
       </p>
       <form onSubmit={downloadListens}>
         <button className="btn btn-warning btn-lg" type="submit">
-          Download Listens
+          Download listens
         </button>
       </form>
       <br />
       <p>
-        Export your recording feedback (your loved and hated recordings) in JSON
-        format and download it. Click Download to proceed.
+        Export and download your recording feedback (your loved and hated recordings) in JSON
+        format.
       </p>
       <form onSubmit={downloadFeedback}>
         <button className="btn btn-warning btn-lg" type="submit">
-          Download Feedback
+          Download feedback
         </button>
       </form>
     </>

--- a/frontend/js/src/settings/import/ImportListens.tsx
+++ b/frontend/js/src/settings/import/ImportListens.tsx
@@ -38,10 +38,11 @@ export default function Import() {
         <div className="alert alert-danger">
           You have not provided an email address. Please provide an{" "}
           <a href="https://musicbrainz.org/account/edit">email address</a> and{" "}
-          <em>verify it</em> to submit listens. Read this
-          <a href="https://blog.metabrainz.org/?p=8915">blog post</a>
+          <em>verify it</em>{" "}
+          to submit listens. Read this{" "}
+          <a href="https://blog.metabrainz.org/?p=8915">blog post</a>{" "}
           to understand why we need your email. You can provide us with an email
-          on your
+          on your{" "}
           <a href="https://musicbrainz.org/account/edit">
             MusicBrainz account
           </a>{" "}
@@ -50,13 +51,13 @@ export default function Import() {
       )}
       <p>
         Import your existing listen history from other databases. To submit{" "}
-        <em>new</em>
+        <em>new</em>{" "}
         listens, please visit the{" "}
-        <a href="https://listenbrainz.org/add-data/">Connect services</a>
+        <a href="https://listenbrainz.org/add-data/">Connect services</a>{" "}
         and{" "}
         <a href="https://listenbrainz.org/settings/music-services/details/">
           Submitting data
-        </a>
+        </a>{" "}
         pages.
         <br />
         Fun Fact: The term <strong>scrobble</strong> is a trademarked term by
@@ -93,7 +94,7 @@ export default function Import() {
         </li>
         <li>
           Clicking the &quot;Import listens&quot; button will import your
-          profile without the need to open LastFM.
+          profile without the need to open Last.fm.
         </li>
         <li>
           Your listen counts may not be accurate for up to 24 hours after you
@@ -110,7 +111,7 @@ export default function Import() {
 
       <p>
         You need to keep this page open while it is importing, which may take a
-        while to complete.
+        while.
       </p>
 
       {userHasEmail && (
@@ -130,18 +131,18 @@ export default function Import() {
       )}
 
       <br />
-      <h4> Reset Last.FM Import timestamp </h4>
+      <h4> Reset Last.fm import timestamp </h4>
       <p>
-        If you think that a partial import has missed listens, you may reset
+        If you think that a import has missed listens, you can reset
         your previous import timestamp. This will cause your next import to be a
-        complete import which should add any missing listens, without adding
+        complete import, which will add missing listens without adding
         duplicates to your history.
       </p>
 
       <p>
-        <span className="btn btn-info btn-lg" style={{ width: "300px" }}>
+        <span className="btn btn-info btn-lg" style={{ width: "250px" }}>
           <Link to="/settings/resetlatestimportts/" style={{ color: "white" }}>
-            Reset Import Timestamp
+            Reset import timestamp
           </Link>
         </span>
       </p>

--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -167,7 +167,7 @@ export default function MusicServices() {
         <title>External Music Services</title>
       </Helmet>
       <div id="user-profile">
-        <h2 className="page-title">Connect with third-party music services</h2>
+        <h2 className="page-title">Connect third-party music services</h2>
 
         <div className="panel panel-default">
           <div className="panel-heading">
@@ -176,16 +176,18 @@ export default function MusicServices() {
           <div className="panel-body">
             <p>
               Connect to your Spotify account to read your listening history,
-              play music on ListenBrainz (requires Spotify Premium) or both. We
-              encourage users to choose both options for the best experience,
-              but you may also choose only one option. For music playing, make
-              sure your browser allows autoplaying media on listenbrainz.org. If
-              you have a Spotify account connected, you&apos;ll have much better
-              results. Otherwise, we will search for a match on YouTube. If you
-              ever face an issue, try disconnecting and reconnecting your
-              Spotify account and make sure you select the permissions to
+              play music on ListenBrainz (requires Spotify Premium), or both.
+              <br />
+              <small>
+              Full length playback requires Spotify Premium.
+              <br />
+              To play music, your browser must allow autoplaying media on listenbrainz.org.
+              <br />
+              If you encounter issues, try disconnecting and reconnecting your
+              Spotify account and select the permissions to
               &apos;record listens and play music&apos; or &apos;play music
               only&apos;.
+              </small>
             </p>
             <br />
             <div className="music-service-selection">
@@ -194,8 +196,8 @@ export default function MusicServices() {
                   service="spotify"
                   current={permissions.spotify}
                   value="both"
-                  title="Activate both features (Recommended)"
-                  details="We will record your listening history permanently and make it available for others to view and explore. Discover and play songs directly on ListenBrainz, and import/export your playlist to and from Spotify."
+                  title="Activate both features (recommended)"
+                  details="Permanently record your listening history and make it available for others to view and explore. Discover and play songs on ListenBrainz, and import/export playlists to and from Spotify."
                   handlePermissionChange={handlePermissionChange}
                 />
                 <ServicePermissionButton
@@ -203,7 +205,7 @@ export default function MusicServices() {
                   current={permissions.spotify}
                   value="listen"
                   title="Play music on ListenBrainz"
-                  details="Discover and play songs directly on ListenBrainz, and import/export your playlist to and from Spotify. Note: Full length track playback requires Spotify Premium"
+                  details="Discover and play songs on ListenBrainz, and import/export playlists to and from Spotify."
                   handlePermissionChange={handlePermissionChange}
                 />
                 <ServicePermissionButton
@@ -211,7 +213,7 @@ export default function MusicServices() {
                   current={permissions.spotify}
                   value="import"
                   title="Record listening history"
-                  details="We will record your listening history permanently and make it available for others to view and explore."
+                  details="Record your listening history permanently and make it available for others to view and explore."
                   handlePermissionChange={handlePermissionChange}
                 />
                 <ServicePermissionButton
@@ -219,39 +221,35 @@ export default function MusicServices() {
                   current={permissions.spotify}
                   value="disable"
                   title="Disable"
-                  details="Spotify integration will be disabled. You won't be able to import your listens or listen to music on ListenBrainz using Spotify."
+                  details="You won't be able to listen to music on ListenBrainz or import listens using Spotify."
                   handlePermissionChange={handlePermissionChange}
                 />
               </form>
             </div>
 
-            <h3>A note about permissions</h3>
+            <h3>A note about Spotify permissions</h3>
 
             <p>
-              In order to enable the feature to record your listens you will
-              need to grant the permission to view your recent listens and your
-              current listen.
+              To record your listens you will need to grant permission to view
+              your recent listens and your current listen.
             </p>
 
             <p>
-              In order to play tracks on the ListenBrainz pages you will need to
+              To play music on the ListenBrainz pages you will need to
               grant the permission to play streams from your account and create
-              playlists. Oddly enough, Spotify also requires the permission to
+              playlists. Spotify also requires permission to
               read your email address, your private information and your
-              birthdate in order to play tracks. These permissions are required
-              to determine if you are a premium user and can play full length
-              tracks or will be limited to 30 second previews. However,{" "}
-              <b>ListenBrainz will never read these pieces of data</b>. We
-              promise! Please feel free to
+              birthdate, to determine if you are a premium user -{" "}
+              <b>ListenBrainz will never read these pieces of data</b>. Please feel free to{" "}
               <a href="https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz/spotify_updater/spotify_read_listens.py">
-                inspect our source
+                inspect our source code
               </a>{" "}
-              code yourself!
+              any time!
             </p>
 
             <p>
-              You can revoke these permissions whenever you want by unlinking
-              your Spotify account.
+              Revoke these permissions any time by disabling
+              your Spotify connection.
             </p>
           </div>
         </div>
@@ -262,11 +260,11 @@ export default function MusicServices() {
           </div>
           <div className="panel-body">
             <p>
-              Connect to your CritiqueBrainz account to publish reviews for your
-              Listens directly from ListenBrainz. Your reviews will be
-              independently visible on CritiqueBrainz and appear publicly on
-              your CritiqueBrainz profile unless removed. To view or delete your
-              reviews, visit your CritiqueBrainz profile.
+              Connect to your CritiqueBrainz account to publish reviews
+              directly from ListenBrainz. Reviews are public on ListenBrainz
+              and CritiqueBrainz. To view or delete your reviews, visit your
+              <a href="https://critiquebrainz.org/">
+              CritiqueBrainz profile.</a>
             </p>
             <br />
             <div className="music-service-selection">
@@ -275,8 +273,8 @@ export default function MusicServices() {
                   service="critiquebrainz"
                   current={permissions.critiquebrainz}
                   value="review"
-                  title="Publish reviews for your Listens"
-                  details="You will be able to publish mini-reviews for your Listens directly from ListenBrainz."
+                  title="Publish reviews for your listens"
+                  details="Publish reviews from ListenBrainz."
                   handlePermissionChange={handlePermissionChange}
                 />
                 <ServicePermissionButton
@@ -284,7 +282,7 @@ export default function MusicServices() {
                   current={permissions.critiquebrainz}
                   value="disable"
                   title="Disable"
-                  details="You will not be able to publish mini-reviews for your Listens directly from ListenBrainz."
+                  details="You will not be able to publish reviews from ListenBrainz."
                   handlePermissionChange={handlePermissionChange}
                 />
               </form>
@@ -333,8 +331,7 @@ export default function MusicServices() {
               Connect to your Apple Music account to play music on ListenBrainz.
               <br />
               <small>
-                Note: Full length track playback requires a paid Apple Music
-                subscription.
+                Full length track playback requires a Apple Music subscription.
                 <br />
                 You will need to repeat the sign-in process every 6 months.
               </small>
@@ -347,7 +344,7 @@ export default function MusicServices() {
                   current={permissions.appleMusic}
                   value="listen"
                   title="Play music on ListenBrainz"
-                  details="Connect to your Apple Music account to play music using Apple Music on ListenBrainz."
+                  details="Play music using Apple Music on ListenBrainz."
                   handlePermissionChange={handleAppleMusicPermissionChange}
                 />
                 <ServicePermissionButton
@@ -355,7 +352,7 @@ export default function MusicServices() {
                   current={permissions.appleMusic}
                   value="disable"
                   title="Disable"
-                  details="You will not be able to listen to music on ListenBrainz using Apple Music."
+                  details="You won't be able to listen to music on ListenBrainz using Apple Music."
                   handlePermissionChange={handleAppleMusicPermissionChange}
                 />
               </form>
@@ -369,10 +366,7 @@ export default function MusicServices() {
           </div>
           <div className="panel-body">
             <p>
-              ListenBrainz integrates with YouTube to let you play music tracks
-              from ListenBrainz pages. You do not need to do anything to enable
-              this. ListenBrainz will automatically search for tracks on YouTube
-              and play one if it finds a match.
+              Playing music using YouTube on ListenBrainz does not require an account to be connected.
             </p>
           </div>
         </div>

--- a/frontend/js/src/settings/resetlatestimportts/ResetLatestImports.tsx
+++ b/frontend/js/src/settings/resetlatestimportts/ResetLatestImports.tsx
@@ -43,12 +43,13 @@ export default function ResetImportTimestamp() {
       <p>Are you sure you want to reset your token? </p>
 
       <p>
-        ur last.fm importer keeps track of the listens you&apos;ve imported and
-        then only imports new listens added after previous imports. To do this,
-        we keep track of the timestamp of the newest listen submitted in your
-        last.fm import. By resetting this timestamp, you&apos;ll be able to
-        import your entire last.fm data again. However, this will not create
-        duplicates in your ListenBrainz listen history.
+        The Last.fm importer only checks for new Last.fm
+        listens, since your last Last.fm import. To do this,
+        it stores the timestamp of the most recent listen
+        submitted in your last import. Resetting the timestamp
+        will make the next import check your entire Last.fm
+        history. This will not create duplicates in your
+        ListenBrainz listen history.
       </p>
       <button
         type="button"
@@ -56,7 +57,7 @@ export default function ResetImportTimestamp() {
         className="btn btn-info btn-lg"
         style={{ width: "200px" }}
       >
-        Yes, reset it
+        Reset import timestamp token
       </button>
     </>
   );

--- a/frontend/js/src/settings/resetlatestimportts/ResetLatestImports.tsx
+++ b/frontend/js/src/settings/resetlatestimportts/ResetLatestImports.tsx
@@ -37,9 +37,9 @@ export default function ResetImportTimestamp() {
   return (
     <>
       <Helmet>
-        <title>Reset import timestamp</title>
+        <title>Reset your import timestamp</title>
       </Helmet>
-      <h3 className="page-title">Reset Import Timestamp</h3>
+      <h3 className="page-title">Reset your import timestamp</h3>
       <p>Are you sure you want to reset your token? </p>
 
       <p>

--- a/frontend/js/src/settings/select_timezone/SelectTimezone.tsx
+++ b/frontend/js/src/settings/select_timezone/SelectTimezone.tsx
@@ -95,22 +95,24 @@ export default class SelectTimezone extends React.Component<
     return (
       <>
         <Helmet>
-          <title>Select Timezone</title>
+          <title>Select your timezone</title>
         </Helmet>
-        <h3>Select Timezone</h3>
+        <h3>Select your timezone</h3>
         <p>
-          Your current timezone setting is{" "}
+          Your timezone is{" "}
           <span style={{ fontWeight: "bold" }}>{userTimezone}.</span>
-          <br />
-          By choosing your local time zone, you will have a local timestamps
-          part of your submitted listens. This also informs as when to generate
-          daily playlists and other recommendations for you.
+        </p>
+        
+        <p>
+          Setting your timezone allows us to generate local timestamps and
+          better statistics for your listens. It also influences when your
+          daily playlists and recommendations are generated.
         </p>
 
         <div>
           <form onSubmit={this.submitTimezone}>
             <label>
-              Select your local timezone:
+              Select your local timezone:{" "}
               <select
                 defaultValue={userTimezone}
                 onChange={(e) => this.zoneSelection(e.target.value)}
@@ -131,7 +133,7 @@ export default class SelectTimezone extends React.Component<
             <br />
             <p>
               <button type="submit" className="btn btn-info btn-lg">
-                Save Timezone
+                Save timezone
               </button>
             </p>
           </form>

--- a/frontend/js/src/settings/troi/SelectTroiPreferences.tsx
+++ b/frontend/js/src/settings/troi/SelectTroiPreferences.tsx
@@ -96,14 +96,14 @@ class SelectTroiPreferences extends React.Component<
         <Helmet>
           <title>Select Playlist Preferences</title>
         </Helmet>
-        <h3>Configure auto export of generated playlists</h3>
+        <h3>Playlist auto-export</h3>
         <p>
-          If this setting is turned on, ListenBrainz will automatically export
-          your generated playlists (Weekly Jams, Weekly Exploration, ...) to
-          Spotify everyday.
+          If auto-export is turned on, ListenBrainz will automatically export
+          your generated playlists (Weekly Jams, Weekly Exploration, etc) to
+          Spotify, daily.
           <br />
-          You can always export playlists manually regardless of whether this
-          setting is turned on or off.
+          You can export playlists manually, regardless of whether
+          auto-export is turned on or off.
         </p>
 
         <div>
@@ -125,7 +125,7 @@ class SelectTroiPreferences extends React.Component<
             </div>
             <p>
               <button type="submit" className="btn btn-info btn-lg">
-                Save Changes
+                Save changes
               </button>
             </p>
           </form>


### PR DESCRIPTION
A pass over the text in the Settings pages to:

- Fix typos, caps, and missing spaces
- Standardise headings (sentence case) and buttons (sentence case, no full stops)
- Make text clearer and more concise
- Get some more consistency across the settings pages