### PR TITLE
Fix tests

### DIFF
--- a/docker/docker-compose.labs.api.yml
+++ b/docker/docker-compose.labs.api.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # IMPORTANT NOTE: Volume paths mounted on containers are relative to the
 # directory that this file is in (`docker/`) and so probably need to start with
 # `../` to refer to a directory in the main code checkout

--- a/docker/docker-compose.spark.override.yml
+++ b/docker/docker-compose.spark.override.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # This file is not complete in itself as it overrides the configuration specified in docker-compose.spark.yml.
 # This overridden configuration is suitable for local development.
 

--- a/docker/docker-compose.spark.yml
+++ b/docker/docker-compose.spark.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # IMPORTANT NOTE: Volume paths mounted on containers are relative to the
 # directory that this file is in (`docker/`) and so probably need to start with
 # `../` to refer to a directory in the main code checkout

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # IMPORTANT NOTE: Volume paths mounted on containers are relative to the
 # directory that this file is in (`docker/`) and so probably need to start with
 # `../` to refer to a directory in the main code checkout

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -80,5 +80,3 @@ services:
     depends_on:
       - redis
       - rabbitmq
-
-

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -43,6 +43,7 @@ class BackgroundTasks:
         current_app.logger.info("Background tasks processor started.")
         while True:
             try:
+                db_conn.rollback()
                 task = get_task()
                 if task is None:
                     time.sleep(5)
@@ -55,7 +56,6 @@ class BackgroundTasks:
                 break
             except Exception:
                 current_app.logger.error("Error in background tasks processor:", exc_info=True)
-                db_conn.rollback()
                 time.sleep(5)
 
 

--- a/listenbrainz/background/delete.py
+++ b/listenbrainz/background/delete.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
+from brainzutils import cache
+
 from data.model.external_service import ExternalServiceType
+from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT
 from listenbrainz.webserver import timescale_connection
 from listenbrainz.db import user as db_user, listens_importer
 
@@ -26,5 +29,6 @@ def delete_listens_history(db_conn, user_id: int, created: datetime):
         created: listens created before this timestamp are deleted
     """
     timescale_connection._ts.delete(user_id, created)
+    cache.delete(REDIS_USER_LISTEN_COUNT + str(user_id))
     listens_importer.update_latest_listened_at(db_conn, user_id, ExternalServiceType.LASTFM, 0)
     db_conn.commit()

--- a/listenbrainz/db/listens_importer.py
+++ b/listenbrainz/db/listens_importer.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional, Union
 
 from data.model.external_service import ExternalServiceType
-from listenbrainz import db, utils
+from listenbrainz import utils
 import sqlalchemy
 
 

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -369,9 +369,9 @@ class HandlersTestCase(DatabaseTestCase):
         )
 
     @mock.patch('listenbrainz.troi.daily_jams.get_followers_of_user')
-    @mock.patch('listenbrainz.troi.daily_jams.generate_playlist')
+    @mock.patch('listenbrainz.troi.daily_jams.RecommendationsToPlaylistPatch')
     @mock.patch('listenbrainz.spark.handlers.send_mail')
-    def test_cf_recording_recommendations_complete(self, mock_send_mail, mock_gen_playlist, mock_get_followers):
+    def test_cf_recording_recommendations_complete(self, mock_send_mail, mock_recs_patch, mock_get_followers):
         with self.app.app_context():
             active_user_count = 10
             top_artist_user_count = 5
@@ -382,7 +382,7 @@ class HandlersTestCase(DatabaseTestCase):
             self.app.config['TESTING'] = True
             self.app.config["WHITELISTED_AUTH_TOKENS"] = ["fake_token0", "fake_token1"]
 
-            mock_gen_playlist.return_value = "https://listenbrainz.org/playlist/97889d4d-1474-4a9b-925a-851148356f9d/"
+            mock_recs_patch.generate_playlist.return_value = "https://listenbrainz.org/playlist/97889d4d-1474-4a9b-925a-851148356f9d/"
             mock_get_followers.return_value = [{"musicbrainz_id": "lucifer"}]
 
             cf_recording_recommendations_complete({
@@ -394,10 +394,10 @@ class HandlersTestCase(DatabaseTestCase):
             mock_send_mail.assert_not_called()
 
             calls = [
-                call(mock.ANY, {'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'echo': False, 'type': 'top'}),
-                call(mock.ANY, {'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'echo': False, 'type': 'similar'}),
+                call({'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'echo': False, 'type': 'top'}),
+                call({'user_name': 'lucifer', 'upload': True, 'token': 'fake_token1', 'created_for': 'lucifer', 'echo': False, 'type': 'similar'}),
             ]
-            mock_gen_playlist.assert_has_calls(calls)
+            mock_recs_patch.assert_has_calls(calls, any_order=True)
 
             # in prod now, should send it
             self.app.config['TESTING'] = False

--- a/listenbrainz/tests/integration/test_settings_views.py
+++ b/listenbrainz/tests/integration/test_settings_views.py
@@ -124,7 +124,6 @@ class SettingsViewsTestCase(IntegrationTestCase):
             if json.loads(resp.data)['payload']['count'] == 0:
                 break
 
-        print("listen count:", cache.get(REDIS_USER_LISTEN_COUNT + str(self.user['id'])))
         self.assertEqual(json.loads(resp.data)['payload']['count'], 0)
 
         # check that the latest_import timestamp has been reset too

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@upgrade-deps
 spotipy>=2.22.1
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@a1e12968af93d2f296a42a8094ebff83f3ed33f3
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v2024.04.26.0
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v-2024-04-29.0
 PyYAML==6.0
 eventlet == 0.33.1
 # eventlet fails to patch dnspython >= 2.3 https://github.com/eventlet/eventlet/issues/781


### PR DESCRIPTION
1. Fix troi test due to change in imports.
2. Fix websockets tests as asserts from other threads don't work properly. move asserts to main thread.
3. Fix settings views test.
    Trying to rollback the transaction in the except clause can be problematic if it fails and raises an exception. As there is no exception handler for it, it will lead to the container stopping. In production, the container would restart because it is run with unless-stopped but that doesn't happen for tests. so move rollback to inside try as the first step.