### PR TITLE
Send the correct playing_now listen metadata

### DIFF
--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -623,6 +623,7 @@ export default class BrainzPlayer extends React.Component<
     album?: string,
     artwork?: Array<MediaImage>
   ): void => {
+    const { playerPaused } = this.state;
     this.setState(
       {
         currentTrackName: title,
@@ -630,9 +631,14 @@ export default class BrainzPlayer extends React.Component<
         currentTrackURL: trackURL,
         currentTrackAlbum: album,
       },
-      this.updateWindowTitle
+      () => {
+        this.updateWindowTitle();
+        if (!playerPaused) {
+          this.submitNowPlayingToListenBrainz();
+        }
+      }
     );
-    const { playerPaused } = this.state;
+
     if (playerPaused) {
       // Don't send notifications or any of that if the player is not playing
       // (Avoids getting notifications upon pausing a track)
@@ -670,8 +676,6 @@ export default class BrainzPlayer extends React.Component<
         this.handleInfoMessage(message, `Playing a track`);
       }
     });
-
-    this.submitNowPlayingToListenBrainz();
   };
 
   // eslint-disable-next-line react/sort-comp


### PR DESCRIPTION
...and not the metadata of the previous track *facepalm*
The issue is that even though we call `setState` earlier in the function, the state values are not updated by the time we call `submitNowPlayingToListenBrainz` and the track metadata is still that of the previous track.

Thankfully this was only an issue with playing_now listens which are by nature transient.