### PR TITLE
Reference Mopidy music player in "add data" page

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -248,6 +248,15 @@ export default function AddData() {
           , a ListenBrainz scrobbler for Swinsian and Music.app on macOS
           devices.
         </li>
+        <li>
+          <em>
+            <a href="https://mopidy.com/">Mopidy</a>
+          </em>
+          , an extensible music player written in Python:{" "}
+          <a href="https://github.com/suaviloquence/mopidy-listenbrainz">
+            <code>Mopidy-Listenbrainz extension</code>
+          </a>
+        </li>
       </ul>
 
       <h4>Browser extensions</h4>


### PR DESCRIPTION
# Problem

At current time, there's no reference to [Mopidy](mopidy.com/) music player or its [Mopidy-Listenbrainz extension](https://github.com/suaviloquence/mopidy-listenbrainz) on the page dedicated to application to add listens data.

# Solution

Add a link to Mopidy website and the related extension.



