### PR TITLE
Improve listens and feedback download pages

### DIFF
--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -45,7 +45,7 @@ export default function DeleteListens() {
           title="Error"
           message={
             <>
-              Error while deleting listens for user {name}:{error.toString()}
+              Error while deleting listens for user {name}: {error.toString()}
               <button
                 type="button"
                 onClick={() => {

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -5,52 +5,11 @@ import { toast } from "react-toastify";
 import { Helmet } from "react-helmet";
 import { ToastMsg } from "../../notifications/Notifications";
 import GlobalAppContext from "../../utils/GlobalAppContext";
-import { downloadFile } from "../export/ExportData";
+import ExportButtons from "../export/ExportButtons";
 
 export default function DeleteAccount() {
   const { currentUser } = React.useContext(GlobalAppContext);
   const { name } = currentUser;
-  const downloadListens = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      await downloadFile("/settings/export/");
-      toast.success(
-        <ToastMsg
-          title="Success"
-          message="Your listens have been downloaded."
-        />
-      );
-    } catch (error) {
-      toast.error(
-        <ToastMsg
-          title="Error"
-          message={`Failed to download listens: ${error}`}
-        />
-      );
-    }
-  };
-
-  const downloadFeedback = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      await downloadFile("/settings/export-feedback/");
-      toast.success(
-        <ToastMsg
-          title="Success"
-          message="Your feedback has been downloaded."
-        />
-      );
-    } catch (error) {
-      toast.error(
-        <ToastMsg
-          title="Error"
-          message={`Failed to download feedback: ${error}`}
-        />
-      );
-    }
-  };
 
   // eslint-disable-next-line consistent-return
   const deleteAccount = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -95,30 +54,13 @@ export default function DeleteAccount() {
       </p>
 
       <p>
-        The data will not be recoverable. Please consider exporting your
+        <b>The data will not be recoverable.</b> Please consider exporting your
         ListenBrainz data before deleting your account.
       </p>
 
-      <form onSubmit={downloadListens}>
-        <button
-          className="btn btn-warning btn-lg"
-          type="submit"
-          style={{ width: "250px" }}
-        >
-          Export listens
-        </button>
-      </form>
-
-      <form onSubmit={downloadFeedback}>
-        <button
-          className="btn btn-warning btn-lg"
-          type="submit"
-          style={{ width: "250px" }}
-        >
-          Export feedback
-        </button>
-      </form>
-
+      <ExportButtons />
+      <br />
+      <p className="text-brand text-danger">This cannot be undone!</p>
       <form onSubmit={deleteAccount}>
         <button
           id="btn-delete-user"

--- a/frontend/js/src/settings/export/ExportButtons.tsx
+++ b/frontend/js/src/settings/export/ExportButtons.tsx
@@ -102,7 +102,7 @@ export default function ExportButtons({ listens = true, feedback = true }) {
       )}
       {loading && (
         <div
-          className="alert alert-info"
+          className="mt-15 alert alert-info"
           role="alert"
           style={{ maxWidth: "fit-content" }}
         >

--- a/frontend/js/src/settings/export/ExportButtons.tsx
+++ b/frontend/js/src/settings/export/ExportButtons.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+
+import { toast } from "react-toastify";
+import { ToastMsg } from "../../notifications/Notifications";
+import Loader from "../../components/Loader";
+
+export const downloadFile = async (url: string) => {
+  const response = await fetch(url, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const jsonBody = await response.json();
+    throw jsonBody?.error;
+  }
+  const fileData = await response.blob();
+  const filename = response.headers
+    ?.get("Content-Disposition")
+    ?.split(";")[1]
+    .trim()
+    .split("=")[1];
+  const downloadUrl = URL.createObjectURL(fileData);
+  const link = document.createElement("a");
+  link.href = downloadUrl;
+  link.setAttribute("download", filename!);
+  link.click();
+  URL.revokeObjectURL(downloadUrl);
+};
+
+export default function ExportButtons({ listens = true, feedback = true }) {
+  const [loading, setLoading] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState();
+  const downloadListens = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setErrorMessage(undefined);
+    try {
+      await downloadFile(window.location.href);
+    } catch (error) {
+      setErrorMessage(error);
+      toast.error(
+        <ToastMsg
+          title="Error"
+          message={`Failed to download listens: ${error}`}
+        />
+      );
+    }
+    setLoading(false);
+  };
+
+  const downloadFeedback = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    setLoading(true);
+    setErrorMessage(undefined);
+    try {
+      await downloadFile("/settings/export-feedback/");
+    } catch (error) {
+      setErrorMessage(error);
+      toast.error(
+        <ToastMsg
+          title="Error"
+          message={`Failed to download feedback: ${error}`}
+        />
+      );
+    }
+    setLoading(false);
+  };
+
+  return (
+    <>
+      {listens && (
+        <>
+          <p>Export and download your listen history in JSON format:</p>
+          <form onSubmit={downloadListens}>
+            <button
+              className="btn btn-warning btn-lg"
+              type="submit"
+              disabled={loading}
+            >
+              Download listens
+            </button>
+          </form>
+          <br />
+        </>
+      )}
+      {feedback && (
+        <>
+          <p>
+            Export and download your recording feedback (your loved and hated
+            recordings) in JSON format:
+          </p>
+          <form onSubmit={downloadFeedback}>
+            <button
+              className="btn btn-warning btn-lg"
+              type="submit"
+              disabled={loading}
+            >
+              Download feedback
+            </button>
+          </form>{" "}
+        </>
+      )}
+      {loading && (
+        <div
+          className="alert alert-info"
+          role="alert"
+          style={{ maxWidth: "fit-content" }}
+        >
+          <h4 className="alert-heading">Download started</h4>
+          <p className="flex">
+            <Loader isLoading={loading} style={{ margin: "0 1em" }} />
+            Please keep this page open while your download is being prepared.
+            This can take up to a minute.
+          </p>
+        </div>
+      )}
+      {errorMessage && (
+        <div
+          className="mt-15 alert alert-danger alert-dismissable"
+          role="alert"
+          style={{ maxWidth: "fit-content" }}
+        >
+          <button
+            type="button"
+            className="close"
+            onClick={() => {
+              setErrorMessage(undefined);
+            }}
+            aria-label="Close"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 className="alert-heading">Download failed </h4>
+          <p>
+            Something went wrong with your download. Please try again or let us
+            know if the issue persists.
+          </p>
+          <hr />
+          <p className="mb-0">{errorMessage}</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/js/src/settings/export/ExportData.tsx
+++ b/frontend/js/src/settings/export/ExportData.tsx
@@ -1,59 +1,11 @@
 import * as React from "react";
 
-import { toast } from "react-toastify";
 import { Helmet } from "react-helmet";
-import { ToastMsg } from "../../notifications/Notifications";
 import GlobalAppContext from "../../utils/GlobalAppContext";
-
-export const downloadFile = async (url: string) => {
-  const response = await fetch(url, {
-    method: "POST",
-  });
-  const fileData = await response.blob();
-  const filename = response.headers
-    ?.get("Content-Disposition")
-    ?.split(";")[1]
-    .trim()
-    .split("=")[1];
-  const downloadUrl = URL.createObjectURL(fileData);
-  const link = document.createElement("a");
-  link.href = downloadUrl;
-  link.setAttribute("download", filename!);
-  link.click();
-  URL.revokeObjectURL(downloadUrl);
-};
+import ExportButtons from "./ExportButtons";
 
 export default function Export() {
   const { currentUser } = React.useContext(GlobalAppContext);
-  const downloadListens = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      await downloadFile(window.location.href);
-    } catch (error) {
-      toast.error(
-        <ToastMsg
-          title="Error"
-          message={`Failed to download listens: ${error}`}
-        />
-      );
-    }
-  };
-
-  const downloadFeedback = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      await downloadFile("/settings/export-feedback/");
-    } catch (error) {
-      toast.error(
-        <ToastMsg
-          title="Error"
-          message={`Failed to download feedback: ${error}`}
-        />
-      );
-    }
-  };
 
   return (
     <>
@@ -61,22 +13,7 @@ export default function Export() {
         <title>Export for {currentUser?.name}</title>
       </Helmet>
       <h3>Export from ListenBrainz</h3>
-      <p>Export and download your listen history in JSON format.</p>
-      <form onSubmit={downloadListens}>
-        <button className="btn btn-warning btn-lg" type="submit">
-          Download listens
-        </button>
-      </form>
-      <br />
-      <p>
-        Export and download your recording feedback (your loved and hated
-        recordings) in JSON format.
-      </p>
-      <form onSubmit={downloadFeedback}>
-        <button className="btn btn-warning btn-lg" type="submit">
-          Download feedback
-        </button>
-      </form>
+      <ExportButtons />
     </>
   );
 }


### PR DESCRIPTION
- Adds a loader indicator and an error alert
- Disables buttons while a download is in progress to avoid repeated queries
- Refactors buttons+mechanism into separate component to be reused in various places instead of reimplementing it on other pages (delete listens, delete account)
- Review warnings and phrasing in delete page

![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/92f869d3-aeb3-4ec2-8015-f73ddece9fb4)

![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/26bb3296-6590-4030-9544-faf3d65a8c9b)
