### PR TITLE
Enable fetch-mock selectively

### DIFF
--- a/enzyme.config.ts
+++ b/enzyme.config.ts
@@ -6,7 +6,6 @@ import { enableFetchMocks } from "jest-fetch-mock";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-enableFetchMocks();
 
 // In Node > v15 unhandled promise rejections will terminate the process
 if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {

--- a/frontend/js/tests/common/brainzplayer/BrainzPlayer.test.tsx
+++ b/frontend/js/tests/common/brainzplayer/BrainzPlayer.test.tsx
@@ -89,6 +89,7 @@ describe("BrainzPlayer", () => {
     window.location = {
       href: "http://nevergonnagiveyouup.com",
     } as Window["location"];
+    fetchMock.enableMocks();
   });
 
   it("renders correctly", () => {

--- a/frontend/js/tests/common/listens/ListensControls.test.tsx
+++ b/frontend/js/tests/common/listens/ListensControls.test.tsx
@@ -36,25 +36,25 @@ const props: ListensProps = {
   user,
 };
 
-fetchMock.mockIf(
-  (input) => input.url.endsWith("/listen-count"),
-  () => {
-    return Promise.resolve(JSON.stringify({ payload: { count: 42 } }));
-  }
-);
-
-fetchMock.mockIf(
-  (input) => input.url.endsWith("/delete-listen"),
-  () => Promise.resolve({ status: 200, statusText: "ok" })
-);
-
 // const userEventSession = userEvent.setup();
 
 // eslint-disable-next-line jest/no-disabled-tests
 xdescribe("ListensControls", () => {
   describe("removeListenFromListenList", () => {
     beforeAll(() => {
+      fetchMock.enableMocks();
       fetchMock.doMock();
+      fetchMock.mockIf(
+        (input) => input.url.endsWith("/listen-count"),
+        () => {
+          return Promise.resolve(JSON.stringify({ payload: { count: 42 } }));
+        }
+      );
+
+      fetchMock.mockIf(
+        (input) => input.url.endsWith("/delete-listen"),
+        () => Promise.resolve({ status: 200, statusText: "ok" })
+      );
     });
     it("updates the listens state for particular recording", async () => {});
     // it("updates the listens state for particular recording", async () => {

--- a/frontend/js/tests/lastfm/LastFMImporter.test.tsx
+++ b/frontend/js/tests/lastfm/LastFMImporter.test.tsx
@@ -44,6 +44,7 @@ describe("LastFMImporter", () => {
 
   describe("getNumberOfPages", () => {
     beforeAll(()=>{
+      fetchMock.enableMocks();
       // Mock function for fetch
       fetchMock.mockResponse(JSON.stringify(page));
     })

--- a/frontend/js/tests/recent/RecentListens.test.tsx
+++ b/frontend/js/tests/recent/RecentListens.test.tsx
@@ -78,20 +78,22 @@ const propsOneListen = {
   ...recentListensPropsOneListen,
 };
 
-fetchMock.mockIf(
-  (input) => input.url.endsWith("/listen-count"),
-  () => {
-    return Promise.resolve(JSON.stringify({ payload: { count: 42 } }));
-  }
-);
-fetchMock.mockIf(
-  (input) => input.url.startsWith("https://api.spotify.com"),
-  () => {
-    return Promise.resolve(JSON.stringify({}));
-  }
-);
-
 describe("Recentlistens", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+    fetchMock.mockIf(
+      (input) => input.url.endsWith("/listen-count"),
+      () => {
+        return Promise.resolve(JSON.stringify({ payload: { count: 42 } }));
+      }
+    );
+    fetchMock.mockIf(
+      (input) => input.url.startsWith("https://api.spotify.com"),
+      () => {
+        return Promise.resolve(JSON.stringify({}));
+      }
+    );
+  });
   it("renders the page correctly", () => {
     const wrapper = mount<RecentListens>(
       <GlobalAppContext.Provider value={mountOptions.context}>

--- a/frontend/js/tests/user/Dashboard.test.tsx
+++ b/frontend/js/tests/user/Dashboard.test.tsx
@@ -56,12 +56,6 @@ const propsOneListen = {
   ...recentListensPropsOneListen,
 };
 
-fetchMock.mockIf(
-  (input) => input.url.endsWith("/listen-count"),
-  () => {
-    return Promise.resolve(JSON.stringify({ payload: { count: 42 } }));
-  }
-);
 const getComponent = (componentProps: ListensProps) => (
   <BrowserRouter>
     <Listens />
@@ -75,6 +69,13 @@ xdescribe("Listens page", () => {
   let userEventSession: UserEvent;
   beforeAll(async () => {
     userEventSession = await userEvent.setup();
+    fetchMock.enableMocks();
+    fetchMock.mockIf(
+      (input) => input.url.endsWith("/listen-count"),
+      () => {
+        return Promise.resolve(JSON.stringify({ payload: { count: 42 } }));
+      }
+    );
   });
   it("renders correctly on the profile page", async () => {});
 

--- a/frontend/js/tests/user/taste/UserFeedback.test.tsx
+++ b/frontend/js/tests/user/taste/UserFeedback.test.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 import fetchMock from "jest-fetch-mock";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import UserFeedback, { UserFeedbackProps } from "../../../src/user/taste/components/UserFeedback";
+import UserFeedback, {
+  UserFeedbackProps,
+} from "../../../src/user/taste/components/UserFeedback";
 import * as userFeedbackProps from "../../__mocks__/userFeedbackProps.json";
 import * as userFeedbackAPIResponse from "../../__mocks__/userFeedbackAPIResponse.json";
 
@@ -26,6 +28,10 @@ const props: UserFeedbackProps = {
 jest.spyOn(global.Math, "random").mockImplementation(() => 0);
 
 describe("UserFeedback", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+
   it("renders ListenCard items for each feedback item", async () => {
     render(<UserFeedback {...props} />);
     const listensContainer = screen.getByTestId("userfeedback-listens");


### PR DESCRIPTION
[jest-fetch-mock](https://github.com/jefflau/jest-fetch-mock) is currently enabled for the entire test suite, as we were previously using it everywhere.
With new technologies such as react-query we are moving to using [MSW](https://mswjs.io/) to mock a server response rather than mocking fetch itself.
jest-fetch-mock enabled globally is causing some issues with some of those newer new tests using MSW, and is not needed globally as we will progressively replace fetch-mock.
Basically, with it enabled, fetch is broken for some other parts of the test suite, causing some hard to understand warnings in the console but just broken,
