### PR TITLE
Don't hit delete routes by accident...

### DIFF
--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -18,7 +18,7 @@ export default function DeleteListens() {
     e.preventDefault();
 
     try {
-      const response = await fetch(location.pathname, {
+      const response = await fetch("/settings/delete-listens/", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -16,7 +16,7 @@ export default function DeleteAccount() {
     e.preventDefault();
 
     try {
-      const response = await fetch(window.location.href, {
+      const response = await fetch("/settings/delete/", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/js/src/settings/export/ExportButtons.tsx
+++ b/frontend/js/src/settings/export/ExportButtons.tsx
@@ -34,7 +34,7 @@ export default function ExportButtons({ listens = true, feedback = true }) {
     setLoading(true);
     setErrorMessage(undefined);
     try {
-      await downloadFile(window.location.href);
+      await downloadFile("/settings/export/");
     } catch (error) {
       setErrorMessage(error.toString());
       toast.error(


### PR DESCRIPTION
With #2874 and refactoring the DL buttons into a reusable component for multiple pages, I did not realize our use of `window.location.href` in the existing code for the *download* button functionality was a big old bug that needed fixing.
It meant that on the delete listens/delete account pages the *download* button would hit the current route (i.e `/settings/delete/` or `/settings/delete-listens/`) endpoint instead which is the ones we use for deleting account/listens.
"Want to download your listens? Well, I'm deleting your account."

Hardcoding those danger URLs instead to ensure this doesn't happen again by mistake.