### PR TITLE
Fix user stats navigation for special case usernames

### DIFF
--- a/frontend/js/src/user/charts/UserEntityChart.tsx
+++ b/frontend/js/src/user/charts/UserEntityChart.tsx
@@ -350,7 +350,9 @@ export const UserEntityChartLoader = async ({
   const range: UserStatsAPIRange =
     (currentURL.searchParams.get("range") as UserStatsAPIRange) ?? "all_time";
 
-  const match = currentURL.pathname.match(/\/stats\/top-(artist|album|track)s/);
+  const match = currentURL.pathname.match(
+    /\/user\/.+\/stats\/top-(artist|album|track)s/
+  );
   const urlEntityName = match?.[1] ?? "artist";
   const entity = TERMINOLOGY_ENTITY_MAP[urlEntityName];
 
@@ -373,7 +375,9 @@ export const StatisticsChartLoader = async ({
   const range: UserStatsAPIRange =
     (currentURL.searchParams.get("range") as UserStatsAPIRange) ?? "all_time";
 
-  const match = currentURL.pathname.match(/\/stats\/top-(artist|album|track)s/);
+  const match = currentURL.pathname.match(
+    /\/statistics\/top-(artist|album|track)s/
+  );
   const urlEntityName = match?.[1] ?? "artist";
   const entity = TERMINOLOGY_ENTITY_MAP[urlEntityName];
 

--- a/frontend/js/src/user/charts/UserEntityChart.tsx
+++ b/frontend/js/src/user/charts/UserEntityChart.tsx
@@ -3,13 +3,7 @@ import * as React from "react";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
-import {
-  useLoaderData,
-  Link,
-  useNavigate,
-  json,
-  useLocation,
-} from "react-router-dom";
+import { useLoaderData, Link, useNavigate, json } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import BrainzPlayer from "../../common/brainzplayer/BrainzPlayer";
@@ -29,14 +23,12 @@ import ListenCard from "../../common/listens/ListenCard";
 export type UserEntityChartProps = {
   user?: ListenBrainzUser;
   entity: Entity;
-  terminology: string;
+  terminology: "artist" | "album" | "track";
   range: UserStatsAPIRange;
   currPage: number;
 };
 
 type UserEntityChartLoaderData = UserEntityChartProps;
-
-type StatsEntity = "artist" | "album" | "track";
 
 export const TERMINOLOGY_ENTITY_MAP: Record<string, Entity> = {
   artist: "artist",
@@ -48,27 +40,9 @@ const ROWS_PER_PAGE = 25;
 
 export default function UserEntityChart() {
   const loaderData = useLoaderData() as UserEntityChartLoaderData;
-  const {
-    user,
-    entity: initialEntityType,
-    terminology,
-    range,
-    currPage,
-  } = loaderData;
+  const { user, entity, terminology, range, currPage } = loaderData;
   const prevPage = currPage - 1;
   const nextPage = currPage + 1;
-  const location = useLocation();
-  let entity: Entity = initialEntityType;
-  const entityType = /top-(artist|album|track)s/.exec(location.pathname)
-    ?.groups?.[1] as StatsEntity;
-  // Convert vernacular entity type to what the API expects
-  if (entityType === "artist") {
-    entity = "artist";
-  } else if (entityType === "album") {
-    entity = "release-group";
-  } else if (entityType === "track") {
-    entity = "recording";
-  }
 
   const { APIService, currentUser } = React.useContext(GlobalAppContext);
   const navigate = useNavigate();
@@ -162,7 +136,7 @@ export default function UserEntityChart() {
         <Loader isLoading={loading}>
           <div className="row">
             <div className="col-xs-12">
-              <Pill active={entityType === "artist"} type="secondary">
+              <Pill active={terminology === "artist"} type="secondary">
                 <Link
                   to="../top-artists/"
                   relative="route"
@@ -172,7 +146,7 @@ export default function UserEntityChart() {
                   Artists
                 </Link>
               </Pill>
-              <Pill active={entityType === "album"} type="secondary">
+              <Pill active={terminology === "album"} type="secondary">
                 <Link
                   to="../top-albums/"
                   relative="route"
@@ -182,7 +156,7 @@ export default function UserEntityChart() {
                   Albums
                 </Link>
               </Pill>
-              <Pill active={entityType === "track"} type="secondary">
+              <Pill active={terminology === "track"} type="secondary">
                 <Link
                   to="../top-tracks/"
                   relative="route"
@@ -292,7 +266,7 @@ export default function UserEntityChart() {
                   <Bar data={data} maxValue={maxListens} />
                 </div>
               </div>
-              {entityType === "album" && (
+              {terminology === "album" && (
                 <div className="row">
                   <div className="col-xs-12">
                     <small>
@@ -376,11 +350,7 @@ export const UserEntityChartLoader = async ({
   const range: UserStatsAPIRange =
     (currentURL.searchParams.get("range") as UserStatsAPIRange) ?? "all_time";
 
-  const reg = new RegExp(
-    `/user/${user?.name}/stats/top-(artist|album|track)s`,
-    "gm"
-  );
-  const match = reg.exec(currentURL.pathname);
+  const match = currentURL.pathname.match(/\/stats\/top-(artist|album|track)s/);
   const urlEntityName = match?.[1] ?? "artist";
   const entity = TERMINOLOGY_ENTITY_MAP[urlEntityName];
 
@@ -403,9 +373,7 @@ export const StatisticsChartLoader = async ({
   const range: UserStatsAPIRange =
     (currentURL.searchParams.get("range") as UserStatsAPIRange) ?? "all_time";
 
-  const match = /\/statistics\/top-(artist|album|track)s/gm.exec(
-    currentURL.pathname
-  );
+  const match = currentURL.pathname.match(/\/stats\/top-(artist|album|track)s/);
   const urlEntityName = match?.[1] ?? "artist";
   const entity = TERMINOLOGY_ENTITY_MAP[urlEntityName];
 

--- a/frontend/js/src/user/charts/utils.tsx
+++ b/frontend/js/src/user/charts/utils.tsx
@@ -1,63 +1,5 @@
 import type APIService from "../../utils/APIService";
 
-export const getInitData = async (
-  APIService: APIService,
-  entity: Entity,
-  range: UserStatsAPIRange,
-  rowsPerPage: number,
-  user: any
-): Promise<{
-  maxListens: number;
-  totalPages: number;
-  entityCount: number;
-  startDate: Date;
-  endDate: Date;
-}> => {
-  let data = await APIService.getUserEntity(
-    user?.name,
-    entity,
-    range,
-    undefined,
-    1
-  );
-
-  let maxListens = 0;
-  let totalPages = 0;
-  let entityCount = 0;
-
-  if (entity === "artist") {
-    data = data as UserArtistsResponse;
-    maxListens = data.payload.artists?.[0]?.listen_count;
-    totalPages = Math.ceil(data.payload.total_artist_count / rowsPerPage);
-    entityCount = data.payload.total_artist_count;
-  } else if (entity === "release") {
-    data = data as UserReleasesResponse;
-    maxListens = data.payload.releases?.[0]?.listen_count;
-    totalPages = Math.ceil(data.payload.total_release_count / rowsPerPage);
-    entityCount = data.payload.total_release_count;
-  } else if (entity === "recording") {
-    data = data as UserRecordingsResponse;
-    maxListens = data.payload.recordings?.[0]?.listen_count;
-    totalPages = Math.ceil(data.payload.total_recording_count / rowsPerPage);
-    entityCount = data.payload.total_recording_count;
-  } else if (entity === "release-group") {
-    data = data as UserReleaseGroupsResponse;
-    maxListens = data.payload.release_groups?.[0]?.listen_count;
-    totalPages = Math.ceil(
-      data.payload.total_release_group_count / rowsPerPage
-    );
-    entityCount = data.payload.total_release_group_count;
-  }
-
-  return {
-    maxListens,
-    totalPages,
-    entityCount,
-    startDate: new Date(data.payload.from_ts * 1000),
-    endDate: new Date(data.payload.to_ts * 1000),
-  };
-};
-
 export const getData = async (
   APIService: APIService,
   entity: Entity,
@@ -65,15 +7,62 @@ export const getData = async (
   range: UserStatsAPIRange,
   rowsPerPage: number,
   user: any
-): Promise<UserEntityResponse> => {
+): Promise<{
+  entityData: UserEntityResponse;
+  maxListens: number;
+  totalPages: number;
+  entityCount: number;
+  startDate: Date;
+  endDate: Date;
+}> => {
   const offset = (page - 1) * rowsPerPage;
-  return APIService.getUserEntity(
+  let entityData = await APIService.getUserEntity(
     user?.name,
     entity,
     range,
     offset,
     rowsPerPage
   );
+  let maxListens = 0;
+  let totalPages = 0;
+  let entityCount = 0;
+
+  if (entity === "artist") {
+    entityData = entityData as UserArtistsResponse;
+    maxListens = entityData.payload.artists?.[0]?.listen_count;
+    totalPages = Math.ceil(entityData.payload.total_artist_count / rowsPerPage);
+    entityCount = entityData.payload.total_artist_count;
+  } else if (entity === "release") {
+    entityData = entityData as UserReleasesResponse;
+    maxListens = entityData.payload.releases?.[0]?.listen_count;
+    totalPages = Math.ceil(
+      entityData.payload.total_release_count / rowsPerPage
+    );
+    entityCount = entityData.payload.total_release_count;
+  } else if (entity === "recording") {
+    entityData = entityData as UserRecordingsResponse;
+    maxListens = entityData.payload.recordings?.[0]?.listen_count;
+    totalPages = Math.ceil(
+      entityData.payload.total_recording_count / rowsPerPage
+    );
+    entityCount = entityData.payload.total_recording_count;
+  } else if (entity === "release-group") {
+    entityData = entityData as UserReleaseGroupsResponse;
+    maxListens = entityData.payload.release_groups?.[0]?.listen_count;
+    totalPages = Math.ceil(
+      entityData.payload.total_release_group_count / rowsPerPage
+    );
+    entityCount = entityData.payload.total_release_group_count;
+  }
+
+  return {
+    entityData,
+    maxListens,
+    totalPages,
+    entityCount,
+    startDate: new Date(entityData.payload.from_ts * 1000),
+    endDate: new Date(entityData.payload.to_ts * 1000),
+  };
 };
 
 export const processData = (


### PR DESCRIPTION
Issue reported [in IRC](https://chatlogs.metabrainz.org/libera/metabrainz/2024-05-24/?msg=5339030&page=3)

The code that matches the URL to determine what entity type we navigated to breaks if the user has a space or other special character in their name, because the value of the user's name in the URL will not match the value in global props.
For spaces for example`my username` will become `my%20username` in the URL, and this code will not match anything, defaulting to "artist" entity: https://github.com/metabrainz/listenbrainz-server/blob/212d4da1ce1547cc8fd7f4117aca0e752e2c35a5/frontend/js/src/user/charts/UserEntityChart.tsx#L352-L357

While I was in there modifying this code, I also removed an unnecessary duplicated API 


Deployed to test.LB for testing, note we are successfully on the the "tracks" tab, previously not working and defaulting to artists:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/7933c0e2-f19c-4909-a655-0e9ffbd4181a)
