### PR TITLE
Dump improvements

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -164,7 +164,7 @@ ALTER TABLE recording_feedback
     ADD CONSTRAINT feedback_recording_msid_or_recording_mbid_check
     CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
 
-CREATE TABLE release_color(
+CREATE TABLE release_color (
     id                      SERIAL, -- PK
     caa_id                  BIGINT NOT NULL,
     release_mbid            UUID NOT NULL,
@@ -184,7 +184,7 @@ CREATE TABLE user_relationship (
     created             TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE pinned_recording(
+CREATE TABLE pinned_recording (
     id                      SERIAL, -- PK
     user_id                 INTEGER NOT NULL, -- FK to "user".id
     recording_msid          UUID,
@@ -198,7 +198,7 @@ ALTER TABLE pinned_recording
     ADD CONSTRAINT pinned_rec_recording_msid_or_recording_mbid_check
     CHECK ( recording_msid IS NOT NULL OR recording_mbid IS NOT NULL );
 
-CREATE TABLE user_setting(
+CREATE TABLE user_setting (
     id                     SERIAL, --PK
     user_id                INTEGER NOT NULL, --FK to "user".id
     timezone_name          TEXT,

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -70,7 +70,23 @@ PUBLIC_TABLES_DUMP = {
         'id',
         'user_id',
         'recording_msid',
+        'recording_mbid',
         'score',
+        'created'
+    ),
+    'pinned_recording': (
+        'id',
+        'user_id',
+        'recording_msid',
+        'recording_mbid',
+        'blurb_content',
+        'pinned_until',
+        'created'
+    ),
+    'user_relationship': (
+        'user_0',
+        'user_1',
+        'relationship_type',
         'created'
     ),
 }
@@ -139,6 +155,13 @@ PRIVATE_TABLES = {
         'gdpr_agreed',
         'email',
     ),
+    'reported_users': (
+        'id',
+        'reporter_user_id',
+        'reported_user_id',
+        'reported_at',
+        'session'
+    ),
     'external_service_oauth': (
         'id',
         'user_id',
@@ -157,6 +180,27 @@ PRIVATE_TABLES = {
         'last_updated',
         'latest_listened_at',
         'error_message'
+    ),
+    'user_setting': (
+        'id',
+        'user_id',
+        'timezone_name',
+        'troi',
+        'brainzplayer',
+    ),
+    'user_timeline_event': (
+        'id',
+        'user_id',
+        'event_type',
+        'metadata',
+        'created',
+    ),
+    'hide_user_timeline_event': (
+        'id',
+        'user_id',
+        'event_type',
+        'event_id',
+        'created',
     ),
     'api_compat.token': (
         'id',

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -160,7 +160,7 @@ PRIVATE_TABLES = {
         'reporter_user_id',
         'reported_user_id',
         'reported_at',
-        'session'
+        'reason'
     ),
     'external_service_oauth': (
         'id',


### PR DESCRIPTION
1. Some more user data tables were missing from data dumps. Add pinned_recording and user_relationship to public dumps as anyone can view the data for all users's from listenbrainz.org. reported_users, user_setting, user_timeline_event, and hide_user_timeline_event are only visible to the user they belong to and hence adding to private dumps.
2. When private dumps were separated, I forgot to update scripts that deleted temporary files and old backups. Fix that now.