### PR TITLE
Fix get_personal_recommendation_events_for_feed

### DIFF
--- a/listenbrainz/db/model/user_timeline_event.py
+++ b/listenbrainz/db/model/user_timeline_event.py
@@ -41,8 +41,16 @@ class RecordingRecommendationMetadata(MsidMbidModel):
     pass
 
 
-class PersonalRecordingRecommendationMetadata(MsidMbidModel):
+# while creating a personal recommendation, at least one user is required but the user might
+# delete their account in future, causing the list to become empty. use different models for
+# reading and writing to avoid errors.
+class WritePersonalRecordingRecommendationMetadata(MsidMbidModel):
     users: conlist(str, min_items=1)
+    blurb_content: Optional[str]
+
+
+class PersonalRecordingRecommendationMetadata(MsidMbidModel):
+    users: list[str]
     blurb_content: Optional[str]
 
 

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -30,7 +30,7 @@ from listenbrainz.db.model.user_timeline_event import (
     RecordingRecommendationMetadata,
     NotificationMetadata,
     HiddenUserTimelineEvent,
-    PersonalRecordingRecommendationMetadata
+    PersonalRecordingRecommendationMetadata, WritePersonalRecordingRecommendationMetadata
 )
 from listenbrainz import db
 from listenbrainz.db.exceptions import DatabaseException
@@ -114,7 +114,7 @@ def create_user_cb_review_event(db_conn, user_id: int, metadata: CBReviewTimelin
     )
 
 
-def create_personal_recommendation_event(db_conn, user_id: int, metadata: PersonalRecordingRecommendationMetadata)\
+def create_personal_recommendation_event(db_conn, user_id: int, metadata: WritePersonalRecordingRecommendationMetadata)\
         -> UserTimelineEvent:
     """ Creates a personal recommendation event in the database and returns it.
         The User ID in the table is the recommender, meanwhile the users in the

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -215,7 +215,7 @@ def get_personal_recommendation_events_for_feed(db_conn, user_id: int, min_ts: i
                 SELECT jsonb_build_object(
                             'recording_mbid', user_timeline_event.metadata->'recording_mbid',
                             'recording_msid', user_timeline_event.metadata->'recording_msid',
-                            'users', jsonb_agg("user".musicbrainz_id ORDER BY idx),
+                            'users', COALESCE(jsonb_agg("user".musicbrainz_id ORDER BY idx), '[]'::jsonb),
                             'blurb_content', user_timeline_event.metadata->'blurb_content'
                         ) AS metadata
                   FROM jsonb_array_elements_text(user_timeline_event.metadata->'users') WITH ORDINALITY AS arr (value, idx)

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -29,9 +29,11 @@ import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 import listenbrainz.db.user_timeline_event as db_user_timeline_event
 from data.model.listen import APIListen
-from listenbrainz.db.model.user_timeline_event import RecordingRecommendationMetadata, APITimelineEvent, SimilarUserTimelineEvent, UserTimelineEventType, \
+from listenbrainz.db.model.user_timeline_event import RecordingRecommendationMetadata, APITimelineEvent, \
+    SimilarUserTimelineEvent, UserTimelineEventType, \
     APIFollowEvent, NotificationMetadata, APINotificationEvent, APIPinEvent, APICBReviewEvent, \
-    CBReviewTimelineMetadata, PersonalRecordingRecommendationMetadata, APIPersonalRecommendationEvent
+    CBReviewTimelineMetadata, PersonalRecordingRecommendationMetadata, APIPersonalRecommendationEvent, \
+    WritePersonalRecordingRecommendationMetadata
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
 from listenbrainz.db.model.review import CBReviewMetadata
 from listenbrainz.db.pinned_recording import get_pins_for_feed, get_pin_by_id
@@ -600,7 +602,7 @@ def create_personal_recommendation_event(user_name):
     metadata = data['metadata']
 
     try:
-        metadata = PersonalRecordingRecommendationMetadata(**metadata)
+        metadata = WritePersonalRecordingRecommendationMetadata(**metadata)
         follower_results = db_user_relationship.multiple_users_by_username_following_user(
             db_conn,
             user['id'],


### PR DESCRIPTION
users can be null if the users to whom the recording was recommended have deleted their account, coalesce to empty array in this case.