### PR TITLE
LB-1418: Hide back button on entity pages if there is no previous page

### DIFF
--- a/frontend/js/src/layout/EntityPages.tsx
+++ b/frontend/js/src/layout/EntityPages.tsx
@@ -8,18 +8,22 @@ export default function EntityPageLayout() {
     navigate(-1);
   };
 
+  const hasPreviousPage = window.history.length > 1;
+
   return (
     <>
       <ScrollRestoration />
-      <div className="secondary-nav">
-        <ol className="breadcrumb">
-          <li>
-            <button type="button" onClick={goBack} style={{ border: 0 }}>
-              ← Back
-            </button>
-          </li>
-        </ol>
-      </div>
+      {hasPreviousPage && (
+        <div className="secondary-nav">
+          <ol className="breadcrumb">
+            <li>
+              <button type="button" onClick={goBack} style={{ border: 0 }}>
+                ← Back
+              </button>
+            </li>
+          </ol>
+        </div>
+      )}
       <Outlet />
     </>
   );


### PR DESCRIPTION
Check the browser history and don't show the back button or tertiary navbar/breadcrumb at the top if there is no previous page in the browser history.
