### PR TITLE
LB-1587: Fix incorrect image dimensions for last row/column in cover art grid

### DIFF
--- a/listenbrainz/art/cover_art_generator.py
+++ b/listenbrainz/art/cover_art_generator.py
@@ -148,9 +148,9 @@ class CoverArtGenerator:
         y2 = int((y + 1) * self.tile_size)
 
         if x == self.dimension - 1:
-            x2 = self.image_size - 1
+            x2 = self.image_size
         if y == self.dimension - 1:
-            y2 = self.image_size - 1
+            y2 = self.image_size
 
         return (x1, y1, x2, y2)
 


### PR DESCRIPTION
# Problem

The CoverArtGenerator seems to use incorrect dimensions for the last row and column when generating the SVG grid. For example, when creating a (monthly) 4x4 albums chart through the ListenBrainz API with a size of 1024x1024, the first three rows/columns correctly use a 256x256 size, the last row and column are 256x255 and 255x256 respectively, however.

See also: LB-1587

# Solution

Changing the `y2`/`x2` for the last row/column to `self.image_size` fixes this issue.