### PR TITLE
Reinstate "report user" button

### DIFF
--- a/frontend/js/src/report-user/ReportUser.tsx
+++ b/frontend/js/src/report-user/ReportUser.tsx
@@ -17,6 +17,7 @@
  */
 
 import * as React from "react";
+import { toast } from "react-toastify";
 import GlobalAppContext from "../utils/GlobalAppContext";
 import ReportUserModal from "./ReportUserModal";
 
@@ -52,6 +53,7 @@ class ReportUserButton extends React.Component<
         });
       })
       .catch((error: Error) => {
+        toast.error(error.message);
         this.setState({
           error: true,
         });

--- a/frontend/js/src/report-user/ReportUserModal.tsx
+++ b/frontend/js/src/report-user/ReportUserModal.tsx
@@ -1,5 +1,8 @@
-import * as React from "react";
-import { useCallback, useState } from "react";
+import React, { useCallback, useState, useContext } from "react";
+import { toast } from "react-toastify";
+import { Link } from "react-router-dom";
+import GlobalAppContext from "../utils/GlobalAppContext";
+import { ToastMsg } from "../notifications/Notifications";
 
 type ReportUserModalProps = {
   onSubmit: (optionalReason?: string) => void;
@@ -7,14 +10,26 @@ type ReportUserModalProps = {
 };
 
 function ReportUserModal(props: ReportUserModalProps) {
+  const { currentUser } = useContext(GlobalAppContext);
   const { reportedUserName, onSubmit } = props;
   const [optionalReason, setOptionalReason] = useState("");
   const submit = useCallback(
     (event: React.SyntheticEvent) => {
       event.preventDefault();
+      if (!currentUser?.auth_token) {
+        // user is not logged in, redirect to login page and back here afterwards
+        toast.error(
+          <ToastMsg
+            title="You need to be logged in to report a user"
+            message={<Link to={`/login/?next=${window.location.href}`}>Log in here</Link>}
+          />,
+          { toastId: "auth-error" }
+        );
+        return;
+      }
       onSubmit(optionalReason);
     },
-    [optionalReason]
+    [currentUser?.auth_token, onSubmit, optionalReason]
   );
 
   return (

--- a/frontend/js/src/report-user/ReportUserModal.tsx
+++ b/frontend/js/src/report-user/ReportUserModal.tsx
@@ -21,13 +21,19 @@ function ReportUserModal(props: ReportUserModalProps) {
         toast.error(
           <ToastMsg
             title="You need to be logged in to report a user"
-            message={<Link to={`/login/?next=${window.location.href}`}>Log in here</Link>}
+            message={
+              <Link to={`/login/?next=${window.location.href}`}>
+                Log in here
+              </Link>
+            }
           />,
           { toastId: "auth-error" }
         );
         return;
       }
-      onSubmit(optionalReason);
+      const optionalReasonTrimmed = optionalReason.trim();
+      setOptionalReason("");
+      onSubmit(optionalReasonTrimmed);
     },
     [currentUser?.auth_token, onSubmit, optionalReason]
   );

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -39,6 +39,7 @@ import {
 } from "../utils/utils";
 import FollowButton from "./components/follow/FollowButton";
 import { RouteQuery } from "../utils/Loader";
+import ReportUserButton from "../report-user/ReportUser";
 
 export type ListensProps = {
   latestListenTs: number;
@@ -47,6 +48,7 @@ export type ListensProps = {
   user: ListenBrainzUser;
   userPinnedRecording?: PinnedRecording;
   playingNow?: Listen;
+  already_reported_user: boolean;
 };
 
 type ListenLoaderData = ListensProps;
@@ -77,6 +79,7 @@ export default function Listen() {
     playingNow = undefined,
     latestListenTs = 0,
     oldestListenTs = 0,
+    already_reported_user = false,
   } = data || {};
 
   const previousListenTs = listens[0]?.listened_at;
@@ -468,6 +471,12 @@ export default function Listen() {
               />{" "}
               MusicBrainz
             </Link>
+            {user && !isCurrentUsersPage && (
+              <ReportUserButton
+                user={user}
+                alreadyReported={already_reported_user}
+              />
+            )}
           </div>
           {playingNow && getListenCard(playingNow)}
           {userPinnedRecording && (

--- a/frontend/js/tests/common/listens/ListensControls.test.tsx
+++ b/frontend/js/tests/common/listens/ListensControls.test.tsx
@@ -34,6 +34,7 @@ const props: ListensProps = {
   listens,
   oldestListenTs,
   user,
+  already_reported_user: false,
 };
 
 // const userEventSession = userEvent.setup();

--- a/frontend/js/tests/user/Dashboard.test.tsx
+++ b/frontend/js/tests/user/Dashboard.test.tsx
@@ -47,6 +47,7 @@ const props: ListensProps = {
   oldestListenTs,
   user,
   userPinnedRecording,
+  already_reported_user: false,
 };
 
 const APIService = new APIServiceClass("foo");


### PR DESCRIPTION
We removed it previously, but I do not remember the reason.
It's needed back now, I ran into a suspected bot user and was looking for the button.
I ended up using react devtools to access the APIService in the global context in order to report the user, in other words not exactly ideal for a regular user...