### PR TITLE
Improve Apple Music search with fuzzy matching

### DIFF
--- a/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
@@ -178,8 +178,9 @@ export default class AppleMusicPlayer
     const { onTrackNotFound } = this.props;
     const trackName = getTrackName(listen);
     const artistName = getArtistName(listen);
-    const releaseName = _get(listen, "track_metadata.release_name");
-    const searchTerm = `${trackName} ${artistName} ${releaseName}`;
+    // Album name can give worse results, re;oving it from search terms
+    // const releaseName = _get(listen, "track_metadata.release_name");
+    const searchTerm = `${trackName} ${artistName}`;
     if (!searchTerm) {
       onTrackNotFound();
       return;

--- a/frontend/js/src/utils/musickit.d.ts
+++ b/frontend/js/src/utils/musickit.d.ts
@@ -14,6 +14,58 @@ declare namespace MusicKit {
    */
   function getInstance(): MusicKitInstance;
 
+  interface Song {
+    attributes: {
+      albumName: string;
+      artistName: string;
+      artwork: {
+        bgColor: string;
+        height: number;
+        textColor1: string;
+        textColor2: string;
+        textColor3: string;
+        textColor4: string;
+        url: string;
+        width: number;
+      };
+      composerName: string;
+      discNumber: number;
+      durationInMillis: number;
+      genreNames: string[];
+      hasCredits: boolean;
+      hasLyrics: boolean;
+      isAppleDigitalMaster: boolean;
+      isrc: string;
+      name: string;
+      playParams: {
+        id: string;
+        kind: string;
+      };
+      previews: [
+        {
+          url: string;
+        }
+      ];
+      releaseDate: string;
+      trackNumber: number;
+      url: string;
+    };
+    href: string;
+    id: string;
+    type: string;
+  }
+
+  interface APISearchResult {
+    meta: {};
+    results: {
+      songs: {
+        data: Song[];
+        href: string;
+        next: string;
+      };
+    };
+  }
+
   /**
    * This class represents the Apple Music API.
    */
@@ -26,7 +78,11 @@ declare namespace MusicKit {
      * @param options An object with additional options to control how requests are made
      * directly to the Apple Music API.
      */
-    music(path: string, parameters?: any, options?: any): Promise<any>;
+    music(
+      path: string,
+      parameters?: any,
+      options?: any
+    ): Promise<{ data: APISearchResult }>;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "external-svg-loader": "^1.7.1",
         "fetch-retry": "^5.0.3",
         "file-saver": "^2.0.5",
+        "fuzzysort": "^3.0.1",
         "he": "^1.2.0",
         "highlight.js": "^11.6.0",
         "html2canvas": "^1.4.1",
@@ -9390,6 +9391,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.0.1.tgz",
+      "integrity": "sha512-jpiSrv+j2GwtI13z3vzdBAD5m7iVH23spSZwJrD657dfr6jUV2Jyc5YuSPKirmTp9OqnJbHudPIBGIId1bCWmA=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "external-svg-loader": "^1.7.1",
     "fetch-retry": "^5.0.3",
     "file-saver": "^2.0.5",
+    "fuzzysort": "^3.0.1",
     "he": "^1.2.0",
     "highlight.js": "^11.6.0",
     "html2canvas": "^1.4.1",


### PR DESCRIPTION
A user reported in the forums that the apple player sometimes plays the wrong track even though they have the right track in the catalog.
While testing with good examples I identified two issues:
1. having the album title in the search terms can lead to worse results because there is no way to specify it's the title; adding a bunch of words to the search makes results unpredictable. Take for example an album with named one of the songs that was a radio hit; if you are looking for a less know song, having the popular song name (album title) in the search terms will result in the popular song being the first result.
2. Considering the above and that apple music tends to push the music they want you to listen to rather than the best match (I tested that), ;I added a small fuzzy matching library to try to find the best possible match in the API results.

Regarding 1 it's no surprise: we have already removed the album title from spotify search for example, for the same reasons, even though spotify allows specifying parts for track title/album title/artist name.

Regarding 2: I will very likely be adding the fuzzy matching strategy to youtube player, whose API results are all over the place