### PR TITLE
Fix search bar icon position in navigation tray

### DIFF
--- a/frontend/css/search.less
+++ b/frontend/css/search.less
@@ -4,28 +4,29 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  display: initial;
+  display: flex;
   max-width: 400px;
-  width: 45%;
-  input {
-    padding-right: calc(45px + 10px + 0.5em);
+  align-items: stretch;
+  input,
+  button {
     background-color: @nav-tabs-border-color;
     color: @nav-link-color;
-    border-radius: 33px;
     border: none;
+  }
+  input {
+    border-radius: 33px 0 0 33px;
     &:focus {
-      -webkit-box-shadow: inset 1px 2px 4px darkgrey;
-      box-shadow: inset 1px 2px 4px darkgrey;
+      box-shadow: inset 3px 2px 4px darkgrey;
+      & ~ button {
+        // Adjacent sibling button
+        box-shadow: inset -3px 2px 4px darkgrey;
+      }
     }
   }
   button {
-    position: absolute;
-    right: 0.5em;
-    top: 0;
-    background: none;
-    border: none;
-    height: 100%;
     font-size: 1.2em;
+    border-radius: 0 33px 33px 0;
+    padding-right: 0.5em;
   }
 }
 


### PR DESCRIPTION
Reported by outsidecontext [in the community forums](https://community.metabrainz.org/t/search-for-artists-albums-and-tracks-on-listenbrainz/699675/4).

The absolute positioning did not work in this case on Firefox, so I reworked the CSS for this element to use flexbox instead, and a couple of changes to make it look and act like before (especially the inset shadows).

Before:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/799a95a2-56e6-4ce6-9b3b-79283722b86b)
After:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/3c4362a0-08dc-45a5-a13a-720f5bdbedfa)

