### PR TITLE
LB-1448: Manually submit a queue listens

### DIFF
--- a/frontend/js/src/explore/fresh-releases/components/ReleaseCard.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseCard.tsx
@@ -162,7 +162,7 @@ export default function ReleaseCard(props: ReleaseCardProps) {
     </div>
   );
   return (
-    <div className="release-card-container">
+    <div className="release-card-container" key={releaseMBID}>
       <div className="release-item">
         {showListens && listenCount ? (
           <div className="listen-count">
@@ -236,12 +236,12 @@ export default function ReleaseCard(props: ReleaseCardProps) {
       {showArtist && isArray(artistCredits) && (
         <div className="release-artist" title={artistCreditName}>
           {artistCredits.map((ac) => (
-            <>
+            <span key={ac.artist_mbid}>
               <Link to={`/artist/${ac.artist_mbid}/`}>
                 {ac.artist_credit_name}
               </Link>
               {ac.join_phrase}
-            </>
+            </span>
           ))}
         </div>
       )}

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -7,13 +7,14 @@ import { faClock } from "@fortawesome/free-regular-svg-icons";
 import SearchAlbumOrMBID from "../../utils/SearchAlbumOrMBID";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import { millisecondsToStr } from "../../playlists/utils";
-import { DEFAULT_TRACK_LENGTH_SECONDS, MBTrackWithAC } from "./AddListenModal";
+import {
+  DEFAULT_TRACK_LENGTH_SECONDS,
+  MBTrackWithAC,
+  getListenFromTrack,
+} from "./AddListenModal";
 
 interface AddAlbumListensProps {
-  onPayloadChange: (
-    tracks: Array<MBTrackWithAC>,
-    release?: MusicBrainzRelease & WithReleaseGroup
-  ) => void;
+  onPayloadChange: (listens: Listen[]) => void;
 }
 
 type MBReleaseWithMetadata = MusicBrainzRelease &
@@ -61,7 +62,11 @@ export default function AddAlbumListens({
 
   useEffect(() => {
     // Update parent on selection change
-    onPayloadChange(selectedTracks, selectedAlbum);
+    const date = new Date();
+    const listensFromTracks: Listen[] = selectedTracks.map((track) =>
+      getListenFromTrack(track, date, selectedAlbum)
+    );
+    onPayloadChange(listensFromTracks);
   }, [selectedTracks, selectedAlbum, onPayloadChange]);
 
   const artistsName = selectedAlbum?.["artist-credit"]


### PR DESCRIPTION
### Based on #2912, wait until it is merge first, or if this one is merged sooner,  please close the other one
We have been asked to add a way to queue up listens in the manual submission modal, to make it easier for users and help calculate the listening time properly based on the tracks' duration,
Build up on the work in #2894, still allow users to select a specific release for each listen in the queue.

![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/3833d7a6-ec9d-4976-83fc-72067f781dba)
