### PR TITLE
Pin numpy to latest v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ unidecode>=1.3.4
 Levenshtein==0.20.8
 google_auth_oauthlib==0.4.4
 google-auth==1.30.0
+numpy==1.26.4
 pandas==1.5.2
 pyarrow==14.0.1
 more-itertools==8.13.0


### PR DESCRIPTION
Some libraries aren't yet compatible with numpy 2.0.0.