### PR TITLE
LB-1597: 'New listens since you arrived' carries over between profiles

### DIFF
--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -106,31 +106,34 @@ export default function Listen() {
 
   const queryClient = useQueryClient();
 
-  const receiveNewListen = (newListen: string): void => {
-    let json;
-    try {
-      json = JSON.parse(newListen);
-    } catch (error) {
-      toast.error(
-        <ToastMsg
-          title="Coudn't parse the new listen as JSON: "
-          message={error?.toString()}
-        />,
-        { toastId: "parse-listen-error" }
-      );
-      return;
-    }
-    const listen = formatWSMessageToListen(json);
+  const receiveNewListen = React.useCallback(
+    (newListen: string): void => {
+      let json;
+      try {
+        json = JSON.parse(newListen);
+      } catch (error) {
+        toast.error(
+          <ToastMsg
+            title="Coudn't parse the new listen as JSON: "
+            message={error?.toString()}
+          />,
+          { toastId: "parse-listen-error" }
+        );
+        return;
+      }
+      const listen = formatWSMessageToListen(json);
 
-    if (listen) {
-      setWebSocketListens((prevWebSocketListens) => {
-        return [
-          listen,
-          ..._.take(prevWebSocketListens, maxWebsocketListens - 1),
-        ];
-      });
-    }
-  };
+      if (listen) {
+        setWebSocketListens((prevWebSocketListens) => {
+          return [
+            listen,
+            ..._.take(prevWebSocketListens, maxWebsocketListens - 1),
+          ];
+        });
+      }
+    },
+    [setWebSocketListens]
+  );
 
   const receiveNewPlayingNow = React.useCallback(
     async (receivedPlayingNow: Listen): Promise<Listen> => {
@@ -243,6 +246,8 @@ export default function Listen() {
   React.useEffect(() => {
     // On first load, run the function to load the metadata for the playing_now listen
     if (playingNow) updatePlayingNowMutation(playingNow);
+    // no exhaustive-deps because we only want ot run this on initial start
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -114,7 +114,7 @@ export default function Listen() {
       } catch (error) {
         toast.error(
           <ToastMsg
-            title="Coudn't parse the new listen as JSON: "
+            title="Couldn't parse the new listen as JSON: "
             message={error?.toString()}
           />,
           { toastId: "parse-listen-error" }
@@ -246,7 +246,7 @@ export default function Listen() {
   React.useEffect(() => {
     // On first load, run the function to load the metadata for the playing_now listen
     if (playingNow) updatePlayingNowMutation(playingNow);
-    // no exhaustive-deps because we only want ot run this on initial start
+    // no exhaustive-deps because we only want to run this on initial start
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -220,7 +220,9 @@ export default function Listen() {
           );
         });
     }
-  }, [APIService, user]);
+    // Navigated to another user's dashboard, reset WS listens
+    setWebSocketListens([]);
+  }, [APIService, user?.name]);
 
   React.useEffect(() => {
     getFollowing();
@@ -252,7 +254,7 @@ export default function Listen() {
     });
 
     const connectHandler = () => {
-      if (user) {
+      if (user?.name) {
         socket.emit("json", { user: user.name });
       }
     };
@@ -274,7 +276,7 @@ export default function Listen() {
       socket.off("playing_now", newPlayingNowHandler);
       socket.close();
     };
-  }, [updatePlayingNowMutation, user, websocketsUrl]);
+  }, [receiveNewListen, updatePlayingNowMutation, user?.name, websocketsUrl]);
 
   const updateFollowingList = (
     follower: ListenBrainzUser,


### PR DESCRIPTION
# Problem

When you load a user's dashboard and they are listening to music, you will see new listens arrive in a separate list.
Now if you navigate to another user's page the list will stay, showing the first user's listens.

# Solution
Reset the webSocketListens array when user name changes

Also did some minimal cleanup of some react dependencies warnings and memoized a function.