### PR TITLE
LB-1512: Display total duration of playlist

### DIFF
--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -389,8 +389,10 @@ export default class PlaylistPage extends React.Component<
               </h1>
               <div className="info">
                 <div>
-                  {playlist.track?.length} tracks&nbsp;-&nbsp;
-                  {totalDurationForDisplay}
+                  {playlist.track?.length} tracks
+                  {totalDurationForDisplay && (
+                    <>&nbsp;-&nbsp;{totalDurationForDisplay}</>
+                  )}
                 </div>
                 <div>Created: {new Date(playlist.date).toLocaleString()}</div>
                 {customFields?.collaborators &&

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -15,6 +15,7 @@ import { toast } from "react-toastify";
 import { io, Socket } from "socket.io-client";
 import { Helmet } from "react-helmet";
 import { Link, useLoaderData } from "react-router-dom";
+import { formatDuration, intervalToDuration } from "date-fns";
 import BrainzPlayer from "../common/brainzplayer/BrainzPlayer";
 import Card from "../components/Card";
 import Loader from "../components/Loader";
@@ -328,6 +329,15 @@ export default class PlaylistPage extends React.Component<
 
     const customFields = getPlaylistExtension(playlist);
 
+    const totalDurationMs = tracks
+      .filter((t) => Boolean(t.duration))
+      .reduce((total, track) => total + track.duration!, 0);
+
+    const totalDurationForDisplay = formatDuration(
+      intervalToDuration({ start: 0, end: totalDurationMs }),
+      { format: ["days", "hours", "minutes"] }
+    );
+
     return (
       <div role="main">
         <Helmet>
@@ -378,7 +388,10 @@ export default class PlaylistPage extends React.Component<
                 </small>
               </h1>
               <div className="info">
-                <div>{playlist.track?.length} tracks</div>
+                <div>
+                  {playlist.track?.length} tracks&nbsp;-&nbsp;
+                  {totalDurationForDisplay}
+                </div>
                 <div>Created: {new Date(playlist.date).toLocaleString()}</div>
                 {customFields?.collaborators &&
                   Boolean(customFields.collaborators.length) && (


### PR DESCRIPTION
Calculate the total duration of a playlist using track metadata, sum it up and display it in a human-friendly manner:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/f7d15f38-e936-416f-a841-ec94056021e9)
