### PR TITLE
Add soundcloud metadata cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,6 +183,12 @@ COPY ./docker/services/apple_metadata_cache/apple_metadata_cache.service /etc/se
 COPY ./docker/services/apple_metadata_cache/apple_metadata_cache.finish /etc/service/apple_metadata_cache/finish
 RUN touch /etc/service/apple_metadata_cache/down
 
+# Soundcloud Metadata Cache
+COPY ./docker/services/soundcloud_metadata_cache/consul-template-soundcloud-metadata-cache.conf /etc/consul-template-soundcloud-metadata-cache.conf
+COPY ./docker/services/soundcloud_metadata_cache/soundcloud_metadata_cache.service /etc/service/soundcloud_metadata_cache/run
+COPY ./docker/services/soundcloud_metadata_cache/soundcloud_metadata_cache.finish /etc/service/soundcloud_metadata_cache/finish
+RUN touch /etc/service/soundcloud_metadata_cache/down
+
 # uwsgi (website)
 COPY ./docker/services/uwsgi/uwsgi.ini.ctmpl /etc/uwsgi/uwsgi.ini.ctmpl
 COPY ./docker/services/uwsgi/consul-template-uwsgi.conf /etc/consul-template-uwsgi.conf

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -64,6 +64,9 @@ CREATE UNIQUE INDEX apple_cache_track_apple_id_idx ON apple_cache.track (track_i
 CREATE INDEX apple_cache_rel_album_artist_track_id_idx ON apple_cache.rel_album_artist (album_id);
 CREATE INDEX apple_cache_rel_track_artist_track_id_idx ON apple_cache.rel_track_artist (track_id);
 
+CREATE UNIQUE INDEX soundcloud_cache_track_soundcloud_id_idx ON soundcloud_cache.track (track_id);
+CREATE UNIQUE INDEX soundcloud_cache_artist_soundcloud_id_idx ON soundcloud_cache.artist (artist_id);
+
 CREATE UNIQUE INDEX similar_recordings_dev_uniq_idx ON similarity.recording_dev (mbid0, mbid1);
 CREATE UNIQUE INDEX similar_recordings_dev_reverse_uniq_idx ON similarity.recording_dev (mbid1, mbid0);
 CREATE INDEX similar_recordings_algorithm_dev_idx ON similarity.recording_dev USING gin (metadata);

--- a/admin/timescale/create_schemas.sql
+++ b/admin/timescale/create_schemas.sql
@@ -3,6 +3,7 @@ CREATE SCHEMA messybrainz;
 CREATE SCHEMA mapping;
 CREATE SCHEMA spotify_cache;
 CREATE SCHEMA apple_cache;
+CREATE SCHEMA soundcloud_cache;
 CREATE SCHEMA similarity;
 CREATE SCHEMA tags;
 CREATE SCHEMA popularity;

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -224,6 +224,21 @@ CREATE TABLE apple_cache.rel_track_artist (
     position        INTEGER NOT NULL
 );
 
+CREATE TABLE soundcloud_cache.artist (
+    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    artist_id               TEXT NOT NULL,
+    name                    TEXT NOT NULL,
+    data                    JSONB NOT NULL
+);
+
+CREATE TABLE soundcloud_cache.track (
+    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    track_id                TEXT NOT NULL,
+    name                    TEXT NOT NULL,
+    artist_id               TEXT NOT NULL,
+    data                    JSONB NOT NULL
+);
+
 CREATE TABLE background_worker_state (
     key     TEXT NOT NULL,
     value   TEXT

--- a/admin/timescale/updates/2024-06-26-add-soundcloud-metadata-cache.sql
+++ b/admin/timescale/updates/2024-06-26-add-soundcloud-metadata-cache.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+CREATE SCHEMA soundcloud_cache;
+CREATE TABLE soundcloud_cache.artist (
+    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    artist_id               TEXT NOT NULL,
+    name                    TEXT NOT NULL,
+    data                    JSONB NOT NULL
+);
+
+CREATE TABLE soundcloud_cache.track (
+    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    track_id                TEXT NOT NULL,
+    name                    TEXT NOT NULL,
+    artist_id               TEXT NOT NULL,
+    data                    JSONB NOT NULL
+);
+CREATE UNIQUE INDEX soundcloud_cache_track_soundcloud_id_idx ON soundcloud_cache.track (track_id);
+CREATE UNIQUE INDEX soundcloud_cache_artist_soundcloud_id_idx ON soundcloud_cache.artist (artist_id);
+
+COMMIT;

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -177,6 +177,7 @@ SPARK_REQUEST_QUEUE = '''{{template "KEY" "spark_request_queue"}}'''
 EXTERNAL_SERVICES_EXCHANGE = '''{{template "KEY" "external_services_exchange"}}'''
 EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE = '''{{template "KEY" "external_services_spotify_cache"}}'''
 EXTERNAL_SERVICES_APPLE_CACHE_QUEUE = '''{{template "KEY" "external_services_apple_cache"}}'''
+EXTERNAL_SERVICES_SOUNDCLOUD_CACHE_QUEUE = '''{{template "KEY" "external_services_soundcloud_cache"}}'''
 
 MUSICBRAINZ_CLIENT_ID = '''{{template "KEY" "musicbrainz/client_id"}}'''
 MUSICBRAINZ_CLIENT_SECRET = '''{{template "KEY" "musicbrainz/client_secret"}}'''

--- a/docker/rc.local
+++ b/docker/rc.local
@@ -77,3 +77,8 @@ then
     rm -f /etc/service/apple_metadata_cache/down
 fi
 
+if [ "${CONTAINER_NAME}" = "listenbrainz-soundcloud-metadata-cache-${DEPLOY_ENV}" ]
+then
+    rm -f /etc/service/soundcloud_metadata_cache/down
+fi
+

--- a/docker/services/soundcloud_metadata_cache/consul-template-soundcloud-metadata-cache.conf
+++ b/docker/services/soundcloud_metadata_cache/consul-template-soundcloud-metadata-cache.conf
@@ -1,0 +1,12 @@
+template {
+    source = "/code/listenbrainz/consul_config.py.ctmpl"
+    destination = "/code/listenbrainz/listenbrainz/config.py"
+}
+
+exec {
+    command = ["run-lb-command", "python3", "-u", "-m", "listenbrainz.metadata_cache.soundcloud.runner"]
+    splay = "60s"
+    reload_signal = "SIGHUP"
+    kill_signal = "SIGTERM"
+    kill_timeout = "30s"
+}

--- a/docker/services/soundcloud_metadata_cache/soundcloud_metadata_cache.finish
+++ b/docker/services/soundcloud_metadata_cache/soundcloud_metadata_cache.finish
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export service="soundcloud-metadata-cache"
+
+. /etc/lb-startup-common.sh
+
+
+generate_message "$service" "$@"
+
+log "$message"
+
+send_sentry_message "$message"
+
+if [ "$1" != "0" ]; then
+  log "Exited with non-0 status, sleeping 10 seconds"
+  sleep 10
+fi

--- a/docker/services/soundcloud_metadata_cache/soundcloud_metadata_cache.service
+++ b/docker/services/soundcloud_metadata_cache/soundcloud_metadata_cache.service
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sleep 1
+exec run-consul-template -config /etc/consul-template-soundcloud-metadata-cache.conf

--- a/listenbrainz/metadata_cache/album_handler.py
+++ b/listenbrainz/metadata_cache/album_handler.py
@@ -1,0 +1,98 @@
+import abc
+from datetime import datetime, timedelta
+
+from brainzutils import cache
+
+from listenbrainz.db import timescale
+from listenbrainz.mbid_mapping_writer.job_queue import JobItem
+from listenbrainz.metadata_cache.handler import BaseHandler
+from listenbrainz.metadata_cache.models import Album
+from listenbrainz.metadata_cache.store import insert
+
+CACHE_TIME = 180  # in days
+
+
+class AlbumHandler(BaseHandler):
+
+    def __init__(self, name, external_service_queue, schema_name, cache_key_prefix):
+        """
+            A base class that abstracts common functionality for working with metadata service crawler
+            for external services that have albums as an easy discovery point.
+
+            Args:
+                name: the name of crawler service
+                external_service_queue: the name of the queue to which the associated seeder writes to
+                schema_name: the name of the schema in which the associated metadata cache tables are stored
+                cache_key_prefix: the prefix added to service identifiers when generating the cache keys
+        """
+        super().__init__(name, external_service_queue)
+        self.schema_name = schema_name
+        self.cache_key_prefix = cache_key_prefix
+
+    def get_cache_key(self, item_id: str) -> str:
+        """ Get the cache key for the given item_id """
+        return self.cache_key_prefix + item_id
+
+    @abc.abstractmethod
+    def get_items_from_listen(self, listen) -> list[JobItem]:
+        """ Convert a listen to job items to be enqueued to the crawler. """
+        pass
+
+    @abc.abstractmethod
+    def get_items_from_seeder(self, message) -> list[JobItem]:
+        """ Convert a message from the seeder to job items to be enqueued to the crawler. """
+        pass
+
+    @abc.abstractmethod
+    def fetch_albums(self, album_ids: list[str]) -> tuple[list[Album], list[JobItem]]:
+        """ For the given album_ids, return a tuple of the metadata retrieved from external service
+         and a list of newly discovered items.
+        """
+        pass
+
+    def check_and_fetch_albums(self, album_ids) -> tuple[list[Album], list[JobItem]]:
+        """ Checks if the albums are present in the cache and not expired yet before querying external services """
+        filtered_ids = []
+        for album_id in album_ids:
+            cache_key = self.get_cache_key(album_id)
+            if cache.get(cache_key) is None:
+                filtered_ids.append(album_id)
+        if not filtered_ids:
+            return [], []
+
+        albums, new_items = self.fetch_albums(filtered_ids)
+        filtered_albums = [x for x in albums if x is not None]
+        return filtered_albums, new_items
+
+    def update_cache(self, albums: list[Album]):
+        """ Insert multiple albums in database and update their status in redis cache. """
+        last_refresh = datetime.now()
+        expires_at = datetime.now() + timedelta(days=CACHE_TIME)
+
+        conn = timescale.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                for album in albums:
+                    insert(curs, self.schema_name, album, last_refresh, expires_at)
+
+                    cache_key = self.get_cache_key(album.id)
+                    cache.set(cache_key, 1, expirein=0)
+                    cache.expireat(cache_key, int(expires_at.timestamp()))
+
+                    self.metrics["albums_inserted"] += 1
+                    conn.commit()
+        finally:
+            conn.close()
+
+    def process(self, album_ids: list[str]) -> list[JobItem]:
+        """ Processes the list of items (example: album ids) received from the crawler.
+
+            During processing new items maybe found for processing, for example discovering a new artist
+            and then their albums.
+
+            Returns a list of job items to be enqueued to the crawler for processing in the future.
+        """
+        albums, new_items = self.check_and_fetch_albums(album_ids)
+        if albums:
+            self.update_cache(albums)
+        return new_items

--- a/listenbrainz/metadata_cache/apple/handler.py
+++ b/listenbrainz/metadata_cache/apple/handler.py
@@ -2,8 +2,8 @@ import traceback
 
 import sentry_sdk
 
+from listenbrainz.metadata_cache.album_handler import AlbumHandler
 from listenbrainz.metadata_cache.apple.client import Apple
-from listenbrainz.metadata_cache.handler import BaseHandler
 from listenbrainz.metadata_cache.models import Album, Artist, Track, AlbumType
 from listenbrainz.metadata_cache.unique_queue import JobItem
 
@@ -17,7 +17,7 @@ INCOMING_ALBUM_PRIORITY = 0
 CACHE_KEY_PREFIX = "apple:album:"
 
 
-class AppleCrawlerHandler(BaseHandler):
+class AppleCrawlerHandler(AlbumHandler):
 
     def __init__(self, app):
         super().__init__(
@@ -31,7 +31,7 @@ class AppleCrawlerHandler(BaseHandler):
         self.discovered_artists = set()
         self.client = Apple()
 
-    def get_seed_albums(self) -> list[str]:
+    def get_seed_ids(self) -> list[str]:
         """ Retrieve apple album ids from new releases for all markets"""
         client = Apple()
         storefronts = client.get("https://api.music.apple.com/v1/storefronts")

--- a/listenbrainz/metadata_cache/consumer.py
+++ b/listenbrainz/metadata_cache/consumer.py
@@ -81,7 +81,7 @@ class ServiceMetadataCache(ConsumerMixin):
                 self.crawler = Crawler(self.app, self.handler)
                 self.crawler.start()
 
-                self.app.logger.info(f"Starting {self.crawler.name} Metadata Cache ...")
+                self.app.logger.info(f"Starting {self.handler.name} Metadata Cache ...")
                 self.init_rabbitmq_connection()
                 self.run()
             except KeyboardInterrupt:

--- a/listenbrainz/metadata_cache/crawler.py
+++ b/listenbrainz/metadata_cache/crawler.py
@@ -56,7 +56,7 @@ class Crawler(threading.Thread):
                         continue
 
                 try:
-                    items = self.handler.process_albums(item_ids)
+                    items = self.handler.process(item_ids)
                     for item in items:
                         self.put(item)
                 except Exception as e:

--- a/listenbrainz/metadata_cache/handler.py
+++ b/listenbrainz/metadata_cache/handler.py
@@ -1,38 +1,22 @@
 import abc
 from collections import Counter
-from datetime import datetime, timedelta
 
-from brainzutils import cache
-
-from listenbrainz.db import timescale
 from listenbrainz.mbid_mapping_writer.job_queue import JobItem
-from listenbrainz.metadata_cache.models import Album
-from listenbrainz.metadata_cache.store import insert
-
-CACHE_TIME = 180  # in days
 
 
 class BaseHandler(abc.ABC):
 
-    def __init__(self, name, external_service_queue, schema_name, cache_key_prefix):
+    def __init__(self, name, external_service_queue):
         """
             A base class that abstracts common functionality for working with metadata service crawler.
 
             Args:
                 name: the name of crawler service
                 external_service_queue: the name of the queue to which the associated seeder writes to
-                schema_name: the name of the schema in which the associated metadata cache tables are stored
-                cache_key_prefix: the prefix added to service identifiers when generating the cache keys
         """
         self.metrics = Counter()
         self.name = name
         self.external_service_queue = external_service_queue
-        self.schema_name = schema_name
-        self.cache_key_prefix = cache_key_prefix
-
-    def get_cache_key(self, item_id: str) -> str:
-        """ Get the cache key for the given item_id """
-        return self.cache_key_prefix + item_id
 
     @abc.abstractmethod
     def get_items_from_listen(self, listen) -> list[JobItem]:
@@ -45,60 +29,17 @@ class BaseHandler(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def fetch_albums(self, album_ids: list[str]) -> tuple[list[Album], list[JobItem]]:
-        """ For the given album_ids, return a tuple of the metadata retrieved from external service
-         and a list of newly discovered items.
-        """
+    def get_seed_ids(self) -> list[str]:
+        """ Query the external metadata service to discover newly added items. """
         pass
 
     @abc.abstractmethod
-    def get_seed_albums(self) -> list[str]:
-        """ Query the metadata service API to discover newly added albums """
-        pass
-
-    def check_and_fetch_albums(self, album_ids) -> tuple[list[Album], list[str]]:
-        """ Checks if the albums are present in the cache and not expired yet before querying external services """
-        filtered_ids = []
-        for album_id in album_ids:
-            cache_key = self.get_cache_key(album_id)
-            if cache.get(cache_key) is None:
-                filtered_ids.append(album_id)
-        if not filtered_ids:
-            return [], []
-
-        albums, new_items = self.fetch_albums(filtered_ids)
-        filtered_albums = [x for x in albums if x is not None]
-        return filtered_albums, new_items
-
-    def update_cache(self, albums: list[Album]):
-        """ Insert multiple albums in database and update their status in redis cache. """
-        last_refresh = datetime.utcnow()
-        expires_at = datetime.utcnow() + timedelta(days=CACHE_TIME)
-
-        conn = timescale.engine.raw_connection()
-        try:
-            with conn.cursor() as curs:
-                for album in albums:
-                    insert(curs, self.schema_name, album, last_refresh, expires_at)
-
-                    cache_key = self.get_cache_key(album.id)
-                    cache.set(cache_key, 1, expirein=0)
-                    cache.expireat(cache_key, int(expires_at.timestamp()))
-
-                    self.metrics["albums_inserted"] += 1
-                    conn.commit()
-        finally:
-            conn.close()
-
-    def process_albums(self, album_ids: list[str]) -> list[JobItem]:
-        """ Processes the list of items (example: album ids) received from the crawler.
+    def process(self, item_ids: list[str]) -> list[JobItem]:
+        """ Processes the list of items (example: album ids or track ids) received from the crawler.
 
             During processing new items maybe found for processing, for example discovering a new artist
             and then their albums.
 
             Returns a list of job items to be enqueued to the crawler for processing in the future.
         """
-        albums, new_items = self.check_and_fetch_albums(album_ids)
-        if albums:
-            self.update_cache(albums)
-        return new_items
+        pass

--- a/listenbrainz/metadata_cache/seeder.py
+++ b/listenbrainz/metadata_cache/seeder.py
@@ -3,6 +3,7 @@ from kombu import Connection, Exchange
 from kombu.entity import PERSISTENT_DELIVERY_MODE
 
 from listenbrainz.metadata_cache.apple.handler import AppleCrawlerHandler
+from listenbrainz.metadata_cache.soundcloud.handler import SoundcloudCrawlerHandler
 from listenbrainz.metadata_cache.spotify.handler import SpotifyCrawlerHandler
 from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
@@ -34,16 +35,32 @@ def submit_new_releases_to_cache():
             transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
         )
 
-        current_app.logger.info("Searching new album ids to seed spotify metadata cache")
-        spotify_handler = SpotifyCrawlerHandler(app)
-        spotify_album_ids = spotify_handler.get_seed_albums()
-        current_app.logger.info("Found %d album ids", len(spotify_album_ids))
-        submit_albums(connection, spotify_handler.external_service_queue, {"spotify_album_ids": spotify_album_ids})
-        current_app.logger.info("Submitted new release album ids")
+        try:
+            current_app.logger.info("Searching new album ids to seed spotify metadata cache")
+            spotify_handler = SpotifyCrawlerHandler(app)
+            spotify_album_ids = spotify_handler.get_seed_ids()
+            current_app.logger.info("Found %d album ids", len(spotify_album_ids))
+            submit_albums(connection, spotify_handler.external_service_queue, {"spotify_album_ids": spotify_album_ids})
+            current_app.logger.info("Submitted new release album ids")
+        except Exception:
+            app.logger.error("Unable to generate seeds for spotify:", exc_info=True)
 
-        current_app.logger.info("Searching new album ids to seed apple metadata cache")
-        apple_handler = AppleCrawlerHandler(app)
-        album_ids = apple_handler.get_seed_albums()
-        current_app.logger.info("Found %d album ids", len(album_ids))
-        submit_albums(connection, apple_handler.external_service_queue, {"apple_album_ids": album_ids})
-        current_app.logger.info("Submitted new release album ids")
+        try:
+            current_app.logger.info("Searching new album ids to seed apple metadata cache")
+            apple_handler = AppleCrawlerHandler(app)
+            album_ids = apple_handler.get_seed_ids()
+            current_app.logger.info("Found %d album ids", len(album_ids))
+            submit_albums(connection, apple_handler.external_service_queue, {"apple_album_ids": album_ids})
+            current_app.logger.info("Submitted new release album ids")
+        except Exception:
+            app.logger.error("Unable to generate seeds for apple:", exc_info=True)
+
+        try:
+            current_app.logger.info("Searching new track ids to seed soundcloud metadata cache")
+            soundcloud_handler = SoundcloudCrawlerHandler(app)
+            track_ids = soundcloud_handler.get_seed_ids()
+            current_app.logger.info("Found %d track ids", len(track_ids))
+            submit_albums(connection, soundcloud_handler.external_service_queue, {"soundcloud_track_ids": track_ids})
+            current_app.logger.info("Submitted new release track ids")
+        except Exception:
+            app.logger.error("Unable to generate seeds for soundcloud:", exc_info=True)

--- a/listenbrainz/metadata_cache/soundcloud/handler.py
+++ b/listenbrainz/metadata_cache/soundcloud/handler.py
@@ -29,7 +29,7 @@ class SoundcloudCrawlerHandler(BaseHandler):
     def __init__(self, app):
         super().__init__(
             name="listenbrainz-soundcloud-metadata-cache",
-            external_service_queue=app.config["EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE"]
+            external_service_queue=app.config["EXTERNAL_SERVICES_SOUNDCLOUD_CACHE_QUEUE"]
         )
         self.app = app
 
@@ -49,6 +49,7 @@ class SoundcloudCrawlerHandler(BaseHandler):
         self.session.mount("https://", self.adapter)
 
     def make_request(self, endpoint, **kwargs):
+        """ Make an API request to a soundcloud partner api endpoint"""
         response = self.session.get(
             PARTNER_API_URL + endpoint,
             params={**kwargs, "client_id": self.app.config["SOUNDCLOUD_CLIENT_ID"]}
@@ -57,8 +58,11 @@ class SoundcloudCrawlerHandler(BaseHandler):
         return response.json()
 
     def make_paginated_request(self, endpoint, **kwargs):
+        """ Make an API request to a soundcloud partner api endpoint that supports pagination and retrieve all
+         items in the collection.
+        """
         tracks = []
-        data = self.make_request(endpoint, **kwargs)
+        data = self.make_request(endpoint, limit=100, **kwargs)
         tracks.extend(data["collection"])
 
         while True:
@@ -98,13 +102,13 @@ class SoundcloudCrawlerHandler(BaseHandler):
         )
 
     def fetch_track_from_track_urn(self, track_urn: str) -> SoundcloudTrack:
-        """ retrieve album data from spotify to store in the spotify metadata cache """
+        """ retrieve track data from soundcloud to store in the soundcloud metadata cache """
         data = self.make_request("/tracks/" + track_urn)
         track = self.transform_track(data)
         return track
 
     def fetch_tracks_from_user_urn(self, user_urn: str) -> list[SoundcloudTrack]:
-        """ lookup tracks of the given artist """
+        """ lookup tracks uploaded by the given user """
         if user_urn not in self.discovered_artists:
             self.discovered_artists.add(user_urn)
             self.metrics["discovered_artists_count"] += 1
@@ -121,6 +125,7 @@ class SoundcloudCrawlerHandler(BaseHandler):
         return tracks
 
     def discover_users_from_user_urn(self, user_urn: str) -> set[str]:
+        """ search for new users to crawl in the given user's liked tracks and followings """
         new_user_urns = set()
         user_likes = self.make_paginated_request("/users/" + user_urn + "/likes/tracks")
         for track in user_likes:
@@ -132,7 +137,7 @@ class SoundcloudCrawlerHandler(BaseHandler):
 
 
     def get_seed_ids(self) -> list[str]:
-        """ Retrieve spotify track ids from new releases for all markets"""
+        """ Retrieve soundcloud track ids from new releases for all markets"""
         data = self.make_request("/trending")
         genres = data["categories"]["music"]
 
@@ -146,6 +151,7 @@ class SoundcloudCrawlerHandler(BaseHandler):
 
     @staticmethod
     def insert(curs, tracks: list[SoundcloudTrack]):
+        """ insert a list of soundcloud tracks in the database """
         query = SQL("""
             INSERT INTO soundcloud_cache.artist (artist_id, name, data)
                  VALUES %s
@@ -176,7 +182,7 @@ class SoundcloudCrawlerHandler(BaseHandler):
         execute_values(curs, query, values)
 
     def update_cache(self, tracks: list[SoundcloudTrack]):
-        """ Insert multiple tracks from the same *user* in database and update their status in redis cache. """
+        """ Insert multiple tracks from in database and update their status in redis cache. """
         track_expires_at = datetime.now() + timedelta(days=TRACK_CACHE_TIME)
         track_expires_at_ts = int(track_expires_at.timestamp())
 
@@ -218,7 +224,6 @@ class SoundcloudCrawlerHandler(BaseHandler):
         """ Processes the list of items (example: track ids) received from the crawler. """
         all_items = set()
         for item_id in item_ids:
-            self.app.logger.info("Processing %s", item_id)
             if item_id.startswith(SOUNDCLOUD_TRACK_PREFIX):
                 items = self.process_track(item_id)
             elif item_id.startswith(SOUNDCLOUD_USER_PREFIX):

--- a/listenbrainz/metadata_cache/soundcloud/handler.py
+++ b/listenbrainz/metadata_cache/soundcloud/handler.py
@@ -211,7 +211,8 @@ class SoundcloudCrawlerHandler(BaseHandler):
         if cache.get(user_urn):
             return set()
         user_tracks = self.fetch_tracks_from_user_urn(user_urn)
-        self.update_cache(user_tracks)
+        if user_tracks:
+            self.update_cache(user_tracks)
 
         artist_expires_at = datetime.now() + timedelta(days=USER_CACHE_TIME)
         artist_expires_at_ts = int(artist_expires_at.timestamp())

--- a/listenbrainz/metadata_cache/soundcloud/handler.py
+++ b/listenbrainz/metadata_cache/soundcloud/handler.py
@@ -1,0 +1,234 @@
+from datetime import datetime, timedelta
+
+import orjson
+import urllib3
+from brainzutils import cache
+from psycopg2.extras import execute_values
+from psycopg2.sql import SQL
+from requests import Session
+from requests.adapters import HTTPAdapter
+
+from listenbrainz.db import timescale
+from listenbrainz.metadata_cache.handler import BaseHandler
+from listenbrainz.metadata_cache.soundcloud.models import SoundcloudTrack, SoundcloudArtist
+from listenbrainz.metadata_cache.unique_queue import JobItem
+
+DISCOVERED_USER_PRIORITY = 3
+INCOMING_TRACK_PRIORITY = 0
+
+PARTNER_API_URL = "https://api-partners.soundcloud.com"
+TRACK_CACHE_TIME = 30 # days
+USER_CACHE_TIME = 30 # days
+
+SOUNDCLOUD_TRACK_PREFIX = "soundcloud:tracks:"
+SOUNDCLOUD_USER_PREFIX = "soundcloud:users:"
+
+
+class SoundcloudCrawlerHandler(BaseHandler):
+
+    def __init__(self, app):
+        super().__init__(
+            name="listenbrainz-soundcloud-metadata-cache",
+            external_service_queue=app.config["EXTERNAL_SERVICES_SPOTIFY_CACHE_QUEUE"]
+        )
+        self.app = app
+
+        self.discovered_artists = set()
+        self.discovered_tracks = set()
+
+        self.retry = urllib3.Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=(429, 500, 502, 503, 504),
+            respect_retry_after_header=False
+        )
+        self.session = Session()
+        self.session.headers.update({"Accept": "application/json; charset=utf-8"})
+        self.adapter = HTTPAdapter(max_retries=self.retry)
+        self.session.mount("http://", self.adapter)
+        self.session.mount("https://", self.adapter)
+
+    def make_request(self, endpoint, **kwargs):
+        response = self.session.get(
+            PARTNER_API_URL + endpoint,
+            params={**kwargs, "client_id": self.app.config["SOUNDCLOUD_CLIENT_ID"]}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def make_paginated_request(self, endpoint, **kwargs):
+        tracks = []
+        data = self.make_request(endpoint, **kwargs)
+        tracks.extend(data["collection"])
+
+        while True:
+            if len(data["collection"]) > 0 and "next_href" in data:
+                url = data["next_href"]
+                response = self.session.get(url)
+                response.raise_for_status()
+                data = response.json()
+                tracks.extend(data["collection"])
+            else:
+                break
+
+        return tracks
+
+    def get_items_from_listen(self, listen) -> list[JobItem]:
+        track_id = listen["track_metadata"]["additional_info"].get("soundcloud_track_id")
+        if track_id:
+            return [JobItem(INCOMING_TRACK_PRIORITY, track_id)]
+        return []
+
+    def get_items_from_seeder(self, message) -> list[JobItem]:
+        return [JobItem(INCOMING_TRACK_PRIORITY, track_id) for track_id in message["soundcloud_track_ids"]]
+
+    @staticmethod
+    def transform_track(track) -> SoundcloudTrack:
+        user = track.pop("user")
+        artist = SoundcloudArtist(
+            id=str(user["id"]),
+            name=user["username"],
+            data=user
+        )
+        return SoundcloudTrack(
+            id=str(track["id"]),
+            name=track["title"],
+            artist=artist,
+            data=track
+        )
+
+    def fetch_track_from_track_urn(self, track_urn: str) -> SoundcloudTrack:
+        """ retrieve album data from spotify to store in the spotify metadata cache """
+        data = self.make_request("/tracks/" + track_urn)
+        track = self.transform_track(data)
+        return track
+
+    def fetch_tracks_from_user_urn(self, user_urn: str) -> list[SoundcloudTrack]:
+        """ lookup tracks of the given artist """
+        if user_urn not in self.discovered_artists:
+            self.discovered_artists.add(user_urn)
+            self.metrics["discovered_artists_count"] += 1
+
+        user_uploads = self.make_paginated_request("/users/" + user_urn + "/tracks/uploads")
+        tracks = []
+        for item in user_uploads:
+            track = self.transform_track(item)
+            if track.data["urn"] not in self.discovered_tracks:
+                self.discovered_tracks.add(track.data["urn"])
+                self.metrics["discovered_tracks_count"] += 1
+            tracks.append(track)
+
+        return tracks
+
+    def discover_users_from_user_urn(self, user_urn: str) -> set[str]:
+        new_user_urns = set()
+        user_likes = self.make_paginated_request("/users/" + user_urn + "/likes/tracks")
+        for track in user_likes:
+            new_user_urns.add(track["user"]["urn"])
+        followings = self.make_paginated_request("/users/" + user_urn + "/followings")
+        for user in followings:
+            new_user_urns.add(user["urn"])
+        return new_user_urns
+
+
+    def get_seed_ids(self) -> list[str]:
+        """ Retrieve spotify track ids from new releases for all markets"""
+        data = self.make_request("/trending")
+        genres = data["categories"]["music"]
+
+        track_urns = set()
+        for genre in genres:
+            response = self.make_request("/trending/music", anonymous_id=self.name, genres=genre, limit=100)
+            for track in response["collection"]:
+                track_urns.add(track["urn"])
+
+        return list(track_urns)
+
+    @staticmethod
+    def insert(curs, tracks: list[SoundcloudTrack]):
+        query = SQL("""
+            INSERT INTO soundcloud_cache.artist (artist_id, name, data)
+                 VALUES %s
+            ON CONFLICT (artist_id)
+              DO UPDATE
+                    SET name = EXCLUDED.name
+                      , data = EXCLUDED.data
+        """)
+        artist_ids = set()
+        values = []
+        for track in tracks:
+            artist = track.artist
+            if artist.id not in artist_ids:
+                values.append((artist.id, artist.name, orjson.dumps(artist.data).decode("utf-8")))
+                artist_ids.add(artist.id)
+        execute_values(curs, query, values)
+
+        query = SQL("""
+            INSERT INTO soundcloud_cache.track (track_id, name, artist_id, data)
+                 VALUES %s
+            ON CONFLICT (track_id)
+              DO UPDATE
+                    SET name = EXCLUDED.name
+                      , artist_id = EXCLUDED.artist_id
+                      , data = EXCLUDED.data
+        """)
+        values = [(t.id, t.name, t.artist.id, orjson.dumps(t.data).decode("utf-8")) for t in tracks]
+        execute_values(curs, query, values)
+
+    def update_cache(self, tracks: list[SoundcloudTrack]):
+        """ Insert multiple tracks from the same *user* in database and update their status in redis cache. """
+        track_expires_at = datetime.now() + timedelta(days=TRACK_CACHE_TIME)
+        track_expires_at_ts = int(track_expires_at.timestamp())
+
+        conn = timescale.engine.raw_connection()
+        try:
+            with conn.cursor() as curs:
+                self.insert(curs, tracks)
+                for track in tracks:
+                    cache.set(track.data["urn"], 1, expirein=0)
+                    cache.expireat(track.data["urn"], track_expires_at_ts)
+                    self.metrics["tracks_inserted_count"] += 1
+                conn.commit()
+        finally:
+            conn.close()
+
+    def process_track(self, track_urn) -> set[str]:
+        """ Process a track_urn received from the crawler """
+        if cache.get(track_urn):
+            return set()
+        track = self.fetch_track_from_track_urn(track_urn)
+        self.update_cache([track])
+        return {track.artist.data["urn"]}
+
+    def process_user(self, user_urn) -> set[str]:
+        """ Process a user_urn received from the crawler """
+        if cache.get(user_urn):
+            return set()
+        user_tracks = self.fetch_tracks_from_user_urn(user_urn)
+        self.update_cache(user_tracks)
+
+        artist_expires_at = datetime.now() + timedelta(days=USER_CACHE_TIME)
+        artist_expires_at_ts = int(artist_expires_at.timestamp())
+        cache.set(user_urn, 1, expirein=0)
+        cache.expireat(user_urn, artist_expires_at_ts)
+
+        return self.discover_users_from_user_urn(user_urn)
+
+    def process(self, item_ids: list[str]) -> list[JobItem]:
+        """ Processes the list of items (example: track ids) received from the crawler. """
+        all_items = set()
+        for item_id in item_ids:
+            self.app.logger.info("Processing %s", item_id)
+            if item_id.startswith(SOUNDCLOUD_TRACK_PREFIX):
+                items = self.process_track(item_id)
+            elif item_id.startswith(SOUNDCLOUD_USER_PREFIX):
+                items = self.process_user(item_id)
+            else:
+                items = set()
+                self.app.logger.info("Invalid soundcloud urn: %s, skipping.", item_id)
+            all_items |= items
+
+        items = []
+        for item in all_items:
+            items.append(JobItem(DISCOVERED_USER_PRIORITY, item))
+        return items

--- a/listenbrainz/metadata_cache/soundcloud/handler.py
+++ b/listenbrainz/metadata_cache/soundcloud/handler.py
@@ -78,12 +78,14 @@ class SoundcloudCrawlerHandler(BaseHandler):
         return tracks
 
     def get_items_from_listen(self, listen) -> list[JobItem]:
+        """ Extract soundcloud ids from incoming listen """
         track_id = listen["track_metadata"]["additional_info"].get("soundcloud_track_id")
         if track_id:
             return [JobItem(INCOMING_TRACK_PRIORITY, track_id)]
         return []
 
     def get_items_from_seeder(self, message) -> list[JobItem]:
+        """ Extract soundcloud ids from messages enqueued by seeder """
         return [JobItem(INCOMING_TRACK_PRIORITY, track_id) for track_id in message["soundcloud_track_ids"]]
 
     @staticmethod

--- a/listenbrainz/metadata_cache/soundcloud/models.py
+++ b/listenbrainz/metadata_cache/soundcloud/models.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class SoundcloudArtist(BaseModel):
+    id: str
+    name: str
+    data: dict
+
+class SoundcloudTrack(BaseModel):
+    id: str
+    name: str
+    artist: SoundcloudArtist
+    data: dict

--- a/listenbrainz/metadata_cache/soundcloud/runner.py
+++ b/listenbrainz/metadata_cache/soundcloud/runner.py
@@ -1,0 +1,11 @@
+from listenbrainz.metadata_cache.consumer import ServiceMetadataCache
+from listenbrainz.metadata_cache.soundcloud.handler import SoundcloudCrawlerHandler
+from listenbrainz.webserver import create_app
+
+
+if __name__ == "__main__":
+    app = create_app()
+    with app.app_context():
+        handler = SoundcloudCrawlerHandler(app)
+        smc = ServiceMetadataCache(app, handler)
+        smc.start()

--- a/listenbrainz/metadata_cache/spotify/handler.py
+++ b/listenbrainz/metadata_cache/spotify/handler.py
@@ -5,7 +5,7 @@ import spotipy
 import urllib3
 from spotipy import SpotifyClientCredentials
 
-from listenbrainz.metadata_cache.handler import BaseHandler
+from listenbrainz.metadata_cache.album_handler import AlbumHandler
 from listenbrainz.metadata_cache.models import Album, Artist, Track
 from listenbrainz.metadata_cache.unique_queue import JobItem
 
@@ -14,7 +14,7 @@ INCOMING_ALBUM_PRIORITY = 0
 CACHE_KEY_PREFIX = "spotify:album:"
 
 
-class SpotifyCrawlerHandler(BaseHandler):
+class SpotifyCrawlerHandler(AlbumHandler):
 
     def __init__(self, app):
         super().__init__(
@@ -134,7 +134,7 @@ class SpotifyCrawlerHandler(BaseHandler):
 
         return new_items
 
-    def get_seed_albums(self) -> list[str]:
+    def get_seed_ids(self) -> list[str]:
         """ Retrieve spotify album ids from new releases for all markets"""
         markets = self.sp.available_markets()["markets"]
 


### PR DESCRIPTION
Similar to the spotify and apple metadata caches, add a metadata cache for Soundcloud. Unlike other services, Soundcloud does not have albums as a primitive. Most of the API endpoints revolve around users (artists) and tracks.

The initial seeding of the crawler is done using tracks trending across various categories/genres in Soundcloud. The track's artist is retrieved and then the artist's all uploaded tracks are fetched and inserted in the cache. The artist's following lists and likes are also scanned to find new users for the crawler to scan.

Also, refactor the base handlers and crawler as soundcloud cache is created without albums.