### PR TITLE
Integrating Apple Music to Labs API && new table for Apple Metadata Index

### DIFF
--- a/listenbrainz/labs_api/labs/api/apple/__init__.py
+++ b/listenbrainz/labs_api/labs/api/apple/__init__.py
@@ -1,12 +1,7 @@
-import uuid
 from typing import Optional
 
-from pydantic import BaseModel
+from listenbrainz.labs_api.labs.api.metadata_index import BaseMetadataIndexOutput
 
 
-class AppleMusicIdFromMBIDOutput(BaseModel):
-    recording_mbid: Optional[uuid.UUID]
-    artist_name: Optional[str]
-    release_name: Optional[str]
-    track_name: Optional[str]
-    apple_track_ids: Optional[list[str]]
+class AppleMusicIdFromMBIDOutput(BaseMetadataIndexOutput):
+    apple_music_track_ids: Optional[list[str]]

--- a/listenbrainz/labs_api/labs/api/apple/__init__.py
+++ b/listenbrainz/labs_api/labs/api/apple/__init__.py
@@ -1,0 +1,12 @@
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AppleMusicIdFromMBIDOutput(BaseModel):
+    recording_mbid: Optional[uuid.UUID]
+    artist_name: Optional[str]
+    release_name: Optional[str]
+    track_name: Optional[str]
+    apple_track_ids: Optional[list[str]]

--- a/listenbrainz/labs_api/labs/api/apple/apple_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/api/apple/apple_mbid_lookup.py
@@ -1,80 +1,19 @@
-import uuid
-
-import psycopg2
-from psycopg2.extras import execute_values
-from datasethoster import Query
-from flask import current_app
-from pydantic import BaseModel
-
+from listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_mbid_lookup import MetadataIndexFromMBIDQuery
 from listenbrainz.labs_api.labs.api.apple import AppleMusicIdFromMBIDOutput
-from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
-from listenbrainz.db.recording import resolve_redirect_mbids, resolve_canonical_mbids
 
 
-class AppleMusicIdFromMBIDInput(BaseModel):
-    recording_mbid: uuid.UUID
+class AppleMusicIdFromMBIDQuery(MetadataIndexFromMBIDQuery):
+    """ Query to lookup apple music track ids using recording mbids. """
 
-
-class AppleMusicIdFromMBIDQuery(Query):
-    """ Query to lookup Apple Music track ids using recording mbids. """
+    def __init__(self):
+        super().__init__("apple_music")
 
     def names(self):
-        return "apple-id-from-mbid", "apple music track ID Lookup using recording mbid"
-
-    def inputs(self):
-        return AppleMusicIdFromMBIDInput
+        return "apple-music-id-from-mbid", "Apple Music Track ID Lookup using recording mbid"
 
     def introduction(self):
         return """Given a recording mbid, lookup its metadata using canonical metadata
-        tables and using that attempt to find a suitable match in apple music."""
+        tables and using that attempt to find a suitable match in Apple."""
 
     def outputs(self):
         return AppleMusicIdFromMBIDOutput
-
-    def fetch_metadata_from_mbids(self, curs, mbids):
-        """ Retrieve metadata from canonical tables for given mbids. Note that all mbids should be canonical mbids
-        otherwise metadata may not be found. """
-        query = """
-              WITH mbids(gid) AS (VALUES %s)
-            SELECT recording_mbid::TEXT
-                 , COALESCE(recording_name, '')
-                 , COALESCE(artist_credit_name, '')
-                 , COALESCE(release_name, '')
-              FROM mapping.canonical_musicbrainz_data
-        RIGHT JOIN mbids
-                ON recording_mbid = gid::UUID
-        """
-        execute_values(curs, query, [(mbid,) for mbid in mbids], page_size=len(mbids))
-
-        metadata = {}
-        for row in curs.fetchall():
-            metadata[row[0]] = {
-                "track_name": row[1],
-                "artist_name": row[2],
-                "release_name": row[3]
-            }
-
-        return metadata
-
-    def fetch(self, params, source, offset=-1, count=-1):
-        mbids = [str(p.recording_mbid) for p in params]
-
-        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn, conn.cursor() as curs:
-            redirected_mbids, redirect_index, _ = resolve_redirect_mbids(curs, "recording", mbids)
-
-        with psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as conn, conn.cursor() as curs:
-            canonical_mbids, canonical_index, _ = resolve_canonical_mbids(curs, redirected_mbids)
-            metadata = self.fetch_metadata_from_mbids(curs, canonical_mbids)
-
-        ordered_metadata = []
-        for mbid in mbids:
-            # check whether mbid was redirected before looking up metadata
-            redirected_mbid = redirect_index.get(mbid, mbid)
-            canonical_mbid = canonical_index.get(redirected_mbid, redirected_mbid)
-
-            mbid_metadata = metadata.get(canonical_mbid, {})
-            # regardless of whether we redirected the mbid, add the original mbid in the response returned to user
-            mbid_metadata["recording_mbid"] = mbid
-            ordered_metadata.append(mbid_metadata)
-
-        return lookup_using_metadata(ordered_metadata, "apple_music")

--- a/listenbrainz/labs_api/labs/api/apple/apple_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/api/apple/apple_mbid_lookup.py
@@ -6,30 +6,30 @@ from datasethoster import Query
 from flask import current_app
 from pydantic import BaseModel
 
-from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
+from listenbrainz.labs_api.labs.api.apple import AppleMusicIdFromMBIDOutput
 from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
 from listenbrainz.db.recording import resolve_redirect_mbids, resolve_canonical_mbids
 
 
-class SpotifyIdFromMBIDInput(BaseModel):
+class AppleMusicIdFromMBIDInput(BaseModel):
     recording_mbid: uuid.UUID
 
 
-class SpotifyIdFromMBIDQuery(Query):
-    """ Query to lookup spotify track ids using recording mbids. """
+class AppleMusicIdFromMBIDQuery(Query):
+    """ Query to lookup Apple Music track ids using recording mbids. """
 
     def names(self):
-        return "spotify-id-from-mbid", "Spotify Track ID Lookup using recording mbid"
+        return "apple-id-from-mbid", "apple music track ID Lookup using recording mbid"
 
     def inputs(self):
-        return SpotifyIdFromMBIDInput
+        return AppleMusicIdFromMBIDInput
 
     def introduction(self):
         return """Given a recording mbid, lookup its metadata using canonical metadata
-        tables and using that attempt to find a suitable match in Spotify."""
+        tables and using that attempt to find a suitable match in apple music."""
 
     def outputs(self):
-        return SpotifyIdFromMBIDOutput
+        return AppleMusicIdFromMBIDOutput
 
     def fetch_metadata_from_mbids(self, curs, mbids):
         """ Retrieve metadata from canonical tables for given mbids. Note that all mbids should be canonical mbids
@@ -77,4 +77,4 @@ class SpotifyIdFromMBIDQuery(Query):
             mbid_metadata["recording_mbid"] = mbid
             ordered_metadata.append(mbid_metadata)
 
-        return lookup_using_metadata(ordered_metadata, 'spotify')
+        return lookup_using_metadata(ordered_metadata, "apple_music")

--- a/listenbrainz/labs_api/labs/api/apple/apple_metadata_lookup.py
+++ b/listenbrainz/labs_api/labs/api/apple/apple_metadata_lookup.py
@@ -1,0 +1,32 @@
+from datasethoster import Query
+from pydantic import BaseModel
+
+from listenbrainz.labs_api.labs.api.apple import AppleMusicIdFromMBIDOutput
+from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
+
+
+class AppleMusicIdFromMetadataInput(BaseModel):
+    artist_name: str
+    release_name: str
+    track_name: str
+
+
+class AppleMusicIdFromMetadataQuery(Query):
+    """ Query to lookup Apple Music track ids using artist name, release name and track name. """
+
+    def names(self):
+        return "apple-id-from-metadata", "apple music track ID Lookup using metadata"
+
+    def inputs(self):
+        return AppleMusicIdFromMetadataInput
+
+    def introduction(self):
+        return """Given the name of an artist, the name of a release and the name of a recording (track)
+                  this query will attempt to find a suitable match in apple music."""
+
+    def outputs(self):
+        return AppleMusicIdFromMBIDOutput
+
+    def fetch(self, params, source, offset=-1, count=-1):
+        data = [p.dict() for p in params]
+        return lookup_using_metadata(data, "apple_music")

--- a/listenbrainz/labs_api/labs/api/apple/apple_metadata_lookup.py
+++ b/listenbrainz/labs_api/labs/api/apple/apple_metadata_lookup.py
@@ -1,32 +1,21 @@
-from datasethoster import Query
-from pydantic import BaseModel
-
+from listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_metadata_lookup import \
+    MetadataIndexFromMetadataQuery
 from listenbrainz.labs_api.labs.api.apple import AppleMusicIdFromMBIDOutput
-from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
 
 
-class AppleMusicIdFromMetadataInput(BaseModel):
-    artist_name: str
-    release_name: str
-    track_name: str
+class AppleMusicIdFromMetadataQuery(MetadataIndexFromMetadataQuery):
+    """ Query to lookup apple music track ids using artist name, release name and track name. """
 
 
-class AppleMusicIdFromMetadataQuery(Query):
-    """ Query to lookup Apple Music track ids using artist name, release name and track name. """
+    def __init__(self):
+        super().__init__("apple_music")
 
     def names(self):
-        return "apple-id-from-metadata", "apple music track ID Lookup using metadata"
-
-    def inputs(self):
-        return AppleMusicIdFromMetadataInput
+        return "apple-music-id-from-metadata", "Apple Music Track ID Lookup using metadata"
 
     def introduction(self):
         return """Given the name of an artist, the name of a release and the name of a recording (track)
-                  this query will attempt to find a suitable match in apple music."""
+                  this query will attempt to find a suitable match in Apple."""
 
     def outputs(self):
         return AppleMusicIdFromMBIDOutput
-
-    def fetch(self, params, source, offset=-1, count=-1):
-        data = [p.dict() for p in params]
-        return lookup_using_metadata(data, "apple_music")

--- a/listenbrainz/labs_api/labs/api/metadata_index/__init__.py
+++ b/listenbrainz/labs_api/labs/api/metadata_index/__init__.py
@@ -1,0 +1,15 @@
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class BaseMetadataIndexOutput(BaseModel):
+    recording_mbid: Optional[uuid.UUID]
+    artist_name: Optional[str]
+    release_name: Optional[str]
+    track_name: Optional[str]
+
+
+class AppleMusicIdFromMBIDOutput(BaseMetadataIndexOutput):
+    apple_music_track_ids: Optional[list[str]]

--- a/listenbrainz/labs_api/labs/api/metadata_index/metadata_index_from_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/api/metadata_index/metadata_index_from_mbid_lookup.py
@@ -1,0 +1,73 @@
+import uuid
+
+import psycopg2
+from psycopg2.extras import execute_values
+from datasethoster import Query
+from flask import current_app
+from pydantic import BaseModel
+
+from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
+from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
+from listenbrainz.db.recording import resolve_redirect_mbids, resolve_canonical_mbids
+
+
+class MetadataIdFromMBIDInput(BaseModel):
+    recording_mbid: uuid.UUID
+
+
+class MetadataIndexFromMBIDQuery(Query):
+    """ Query to lookup external service track ids using recording mbids. """
+
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+
+    def inputs(self):
+        return MetadataIdFromMBIDInput
+
+    def fetch_metadata_from_mbids(self, curs, mbids):
+        """ Retrieve metadata from canonical tables for given mbids. Note that all mbids should be canonical mbids
+        otherwise metadata may not be found. """
+        query = """
+              WITH mbids(gid) AS (VALUES %s)
+            SELECT recording_mbid::TEXT
+                 , COALESCE(recording_name, '')
+                 , COALESCE(artist_credit_name, '')
+                 , COALESCE(release_name, '')
+              FROM mapping.canonical_musicbrainz_data
+        RIGHT JOIN mbids
+                ON recording_mbid = gid::UUID
+        """
+        execute_values(curs, query, [(mbid,) for mbid in mbids], page_size=len(mbids))
+
+        metadata = {}
+        for row in curs.fetchall():
+            metadata[row[0]] = {
+                "track_name": row[1],
+                "artist_name": row[2],
+                "release_name": row[3]
+            }
+        return metadata
+
+    def fetch(self, params, source, offset=-1, count=-1):
+        mbids = [str(p.recording_mbid) for p in params]
+
+        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn, conn.cursor() as curs:
+            redirected_mbids, redirect_index, _ = resolve_redirect_mbids(curs, "recording", mbids)
+
+        with psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as conn, conn.cursor() as curs:
+            canonical_mbids, canonical_index, _ = resolve_canonical_mbids(curs, redirected_mbids)
+            metadata = self.fetch_metadata_from_mbids(curs, canonical_mbids)
+
+        ordered_metadata = []
+        for mbid in mbids:
+            # check whether mbid was redirected before looking up metadata
+            redirected_mbid = redirect_index.get(mbid, mbid)
+            canonical_mbid = canonical_index.get(redirected_mbid, redirected_mbid)
+
+            mbid_metadata = metadata.get(canonical_mbid, {})
+            # regardless of whether we redirected the mbid, add the original mbid in the response returned to user
+            mbid_metadata["recording_mbid"] = mbid
+            ordered_metadata.append(mbid_metadata)
+
+        return lookup_using_metadata(ordered_metadata, self.name)

--- a/listenbrainz/labs_api/labs/api/metadata_index/metadata_index_from_metadata_lookup.py
+++ b/listenbrainz/labs_api/labs/api/metadata_index/metadata_index_from_metadata_lookup.py
@@ -1,0 +1,25 @@
+from datasethoster import Query
+from pydantic import BaseModel
+
+from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
+
+
+class MetadataIndexFromMetadataInput(BaseModel):
+    artist_name: str
+    release_name: str
+    track_name: str
+
+
+class MetadataIndexFromMetadataQuery(Query):
+    """ Query to lookup external service track ids using artist name, release name and track name. """
+
+    def __init__(self, name):
+        super().__init__()
+        self.name = name
+
+    def inputs(self):
+        return MetadataIndexFromMetadataInput
+
+    def fetch(self, params, source, offset=-1, count=-1):
+        data = [p.dict() for p in params]
+        return lookup_using_metadata(data, self.name)

--- a/listenbrainz/labs_api/labs/api/spotify/__init__.py
+++ b/listenbrainz/labs_api/labs/api/spotify/__init__.py
@@ -1,12 +1,7 @@
-import uuid
 from typing import Optional
 
-from pydantic import BaseModel
+from listenbrainz.labs_api.labs.api.metadata_index import BaseMetadataIndexOutput
 
 
-class SpotifyIdFromMBIDOutput(BaseModel):
-    recording_mbid: Optional[uuid.UUID]
-    artist_name: Optional[str]
-    release_name: Optional[str]
-    track_name: Optional[str]
+class SpotifyIdFromMBIDOutput(BaseMetadataIndexOutput):
     spotify_track_ids: Optional[list[str]]

--- a/listenbrainz/labs_api/labs/api/spotify/spotify_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/api/spotify/spotify_mbid_lookup.py
@@ -1,28 +1,15 @@
-import uuid
-
-import psycopg2
-from psycopg2.extras import execute_values
-from datasethoster import Query
-from flask import current_app
-from pydantic import BaseModel
-
+from listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_mbid_lookup import MetadataIndexFromMBIDQuery
 from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
-from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
-from listenbrainz.db.recording import resolve_redirect_mbids, resolve_canonical_mbids
 
 
-class SpotifyIdFromMBIDInput(BaseModel):
-    recording_mbid: uuid.UUID
-
-
-class SpotifyIdFromMBIDQuery(Query):
+class SpotifyIdFromMBIDQuery(MetadataIndexFromMBIDQuery):
     """ Query to lookup spotify track ids using recording mbids. """
+
+    def __init__(self):
+        super().__init__("spotify")
 
     def names(self):
         return "spotify-id-from-mbid", "Spotify Track ID Lookup using recording mbid"
-
-    def inputs(self):
-        return SpotifyIdFromMBIDInput
 
     def introduction(self):
         return """Given a recording mbid, lookup its metadata using canonical metadata
@@ -30,51 +17,3 @@ class SpotifyIdFromMBIDQuery(Query):
 
     def outputs(self):
         return SpotifyIdFromMBIDOutput
-
-    def fetch_metadata_from_mbids(self, curs, mbids):
-        """ Retrieve metadata from canonical tables for given mbids. Note that all mbids should be canonical mbids
-        otherwise metadata may not be found. """
-        query = """
-              WITH mbids(gid) AS (VALUES %s)
-            SELECT recording_mbid::TEXT
-                 , COALESCE(recording_name, '')
-                 , COALESCE(artist_credit_name, '')
-                 , COALESCE(release_name, '')
-              FROM mapping.canonical_musicbrainz_data
-        RIGHT JOIN mbids
-                ON recording_mbid = gid::UUID
-        """
-        execute_values(curs, query, [(mbid,) for mbid in mbids], page_size=len(mbids))
-
-        metadata = {}
-        for row in curs.fetchall():
-            metadata[row[0]] = {
-                "track_name": row[1],
-                "artist_name": row[2],
-                "release_name": row[3]
-            }
-
-        return metadata
-
-    def fetch(self, params, source, offset=-1, count=-1):
-        mbids = [str(p.recording_mbid) for p in params]
-
-        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn, conn.cursor() as curs:
-            redirected_mbids, redirect_index, _ = resolve_redirect_mbids(curs, "recording", mbids)
-
-        with psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as conn, conn.cursor() as curs:
-            canonical_mbids, canonical_index, _ = resolve_canonical_mbids(curs, redirected_mbids)
-            metadata = self.fetch_metadata_from_mbids(curs, canonical_mbids)
-
-        ordered_metadata = []
-        for mbid in mbids:
-            # check whether mbid was redirected before looking up metadata
-            redirected_mbid = redirect_index.get(mbid, mbid)
-            canonical_mbid = canonical_index.get(redirected_mbid, redirected_mbid)
-
-            mbid_metadata = metadata.get(canonical_mbid, {})
-            # regardless of whether we redirected the mbid, add the original mbid in the response returned to user
-            mbid_metadata["recording_mbid"] = mbid
-            ordered_metadata.append(mbid_metadata)
-
-        return lookup_using_metadata(ordered_metadata, 'spotify')

--- a/listenbrainz/labs_api/labs/api/spotify/spotify_metadata_lookup.py
+++ b/listenbrainz/labs_api/labs/api/spotify/spotify_metadata_lookup.py
@@ -2,7 +2,7 @@ from datasethoster import Query
 from pydantic import BaseModel
 
 from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
-from listenbrainz.labs_api.labs.api.spotify.utils import lookup_using_metadata
+from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
 
 
 class SpotifyIdFromMetadataInput(BaseModel):
@@ -29,4 +29,4 @@ class SpotifyIdFromMetadataQuery(Query):
 
     def fetch(self, params, source, offset=-1, count=-1):
         data = [p.dict() for p in params]
-        return lookup_using_metadata(data)
+        return lookup_using_metadata(data, 'spotify')

--- a/listenbrainz/labs_api/labs/api/spotify/spotify_metadata_lookup.py
+++ b/listenbrainz/labs_api/labs/api/spotify/spotify_metadata_lookup.py
@@ -1,24 +1,16 @@
-from datasethoster import Query
-from pydantic import BaseModel
-
+from listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_metadata_lookup import \
+    MetadataIndexFromMetadataQuery
 from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
-from listenbrainz.labs_api.labs.api.utils import lookup_using_metadata
 
 
-class SpotifyIdFromMetadataInput(BaseModel):
-    artist_name: str
-    release_name: str
-    track_name: str
-
-
-class SpotifyIdFromMetadataQuery(Query):
+class SpotifyIdFromMetadataQuery(MetadataIndexFromMetadataQuery):
     """ Query to lookup spotify track ids using artist name, release name and track name. """
+
+    def __init__(self):
+        super().__init__("spotify")
 
     def names(self):
         return "spotify-id-from-metadata", "Spotify Track ID Lookup using metadata"
-
-    def inputs(self):
-        return SpotifyIdFromMetadataInput
 
     def introduction(self):
         return """Given the name of an artist, the name of a release and the name of a recording (track)
@@ -26,7 +18,3 @@ class SpotifyIdFromMetadataQuery(Query):
 
     def outputs(self):
         return SpotifyIdFromMBIDOutput
-
-    def fetch(self, params, source, offset=-1, count=-1):
-        data = [p.dict() for p in params]
-        return lookup_using_metadata(data, 'spotify')

--- a/listenbrainz/labs_api/labs/api/utils.py
+++ b/listenbrainz/labs_api/labs/api/utils.py
@@ -53,7 +53,7 @@ def query_combined_lookup(column: LookupType, lookups: list[tuple], service):
 
 
 def perform_lookup(column, metadata, generate_lookup, service):
-    """ Given the lookup type and a function to generate to the lookup text, query database for spotify track ids """
+    """ Given the lookup type and a function to generate to the lookup text, query database for external service track ids """
     if not metadata:
         return metadata, {}
 
@@ -72,7 +72,7 @@ def perform_lookup(column, metadata, generate_lookup, service):
             if service == 'spotify':
                 metadata[idx]["spotify_track_ids"] = track_ids
             else:
-                metadata[idx]["apple_track_ids"] = track_ids
+                metadata[idx]["apple_music_track_ids"] = track_ids
         else:
             remaining_items[idx] = item
 
@@ -118,8 +118,8 @@ def lookup_using_metadata(params: list[dict], service):
     for item in all_metadata.values():
         if service == "spotify" and "spotify_track_ids" not in item:
             item["spotify_track_ids"] = []
-        elif service == "apple_music" and "apple_track_ids" not in item:
-            item["apple_track_ids"] = []
+        elif service == "apple_music" and "apple_music_track_ids" not in item:
+            item["apple_music_track_ids"] = []
 
     if service == "spotify":
         return [SpotifyIdFromMBIDOutput(**row) for row in metadata.values()]

--- a/listenbrainz/labs_api/labs/api/utils.py
+++ b/listenbrainz/labs_api/labs/api/utils.py
@@ -9,6 +9,7 @@ from psycopg2.extras import execute_values
 from psycopg2.sql import SQL, Identifier
 
 from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
+from listenbrainz.labs_api.labs.api.apple import AppleMusicIdFromMBIDOutput
 
 
 class LookupType(Enum):
@@ -24,17 +25,26 @@ def detune(artist_name: str) -> str:
     return artist_name
 
 
-def query_combined_lookup(column: LookupType, lookups: list[tuple]):
+def query_combined_lookup(column: LookupType, lookups: list[tuple], service):
     """ Lookup track ids for the given lookups in the metadata index using the specified lookup type"""
+    if service == 'spotify':
+        table = 'mapping.spotify_metadata_index'
+        track_ids = 'spotify_track_ids'
+    elif service == 'apple_music':
+        table = 'mapping.apple_metadata_index'
+        track_ids = 'apple_music_track_ids'
+    else:
+        raise ValueError("Service must be either 'spotify' or 'apple_music'")
+
     query = SQL("""
           WITH lookups (idx, value) AS (VALUES %s)
         SELECT DISTINCT ON ({column})
-               idx, array_agg(track_id ORDER BY score DESC) AS spotify_track_ids
+               idx, array_agg(track_id ORDER BY score DESC) AS {track_ids}
           FROM lookups
-          JOIN mapping.spotify_metadata_index
+          JOIN {table}
             ON {column} = value
       GROUP BY {column}, idx      
-    """).format(column=Identifier(column.value))
+    """).format(column=Identifier(column.value), table=SQL(table), track_ids=Identifier(track_ids))
 
     with psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_URI"]) as conn, conn.cursor() as curs:
         execute_values(curs, query, lookups, page_size=len(lookups))
@@ -42,7 +52,7 @@ def query_combined_lookup(column: LookupType, lookups: list[tuple]):
         return {row[0]: row[1] for row in result}
 
 
-def perform_lookup(column, metadata, generate_lookup):
+def perform_lookup(column, metadata, generate_lookup, service):
     """ Given the lookup type and a function to generate to the lookup text, query database for spotify track ids """
     if not metadata:
         return metadata, {}
@@ -53,13 +63,16 @@ def perform_lookup(column, metadata, generate_lookup):
         lookup = unidecode(re.sub(r'[^\w]+', '', text).lower())
         lookups.append((idx, lookup))
 
-    index = query_combined_lookup(column, lookups)
+    index = query_combined_lookup(column, lookups, service)
 
     remaining_items = {}
     for idx, item in metadata.items():
-        spotify_ids = index.get(idx)
-        if spotify_ids:
-            metadata[idx]["spotify_track_ids"] = spotify_ids
+        track_ids = index.get(idx)
+        if track_ids:
+            if service == 'spotify':
+                metadata[idx]["spotify_track_ids"] = track_ids
+            else:
+                metadata[idx]["apple_track_ids"] = track_ids
         else:
             remaining_items[idx] = item
 
@@ -86,7 +99,7 @@ def combined_without_album_detuned(item) -> str:
     return detune(item["artist_name"]) + item["track_name"]
 
 
-def lookup_using_metadata(params: list[dict]):
+def lookup_using_metadata(params: list[dict], service):
     """ Given a list of dicts each having artist name, release name and track name, attempt to find spotify track
     id for each. """
     all_metadata, metadata = {}, {}
@@ -96,15 +109,19 @@ def lookup_using_metadata(params: list[dict]):
             metadata[idx] = item
 
     # first attempt matching on artist, track and release followed by trying various detunings for unmatched recordings
-    _, remaining_items = perform_lookup(LookupType.ALL, metadata, combined_all)
-    _, remaining_items = perform_lookup(LookupType.ALL, remaining_items, combined_all_detuned)
-    _, remaining_items = perform_lookup(LookupType.WITHOUT_ALBUM, remaining_items, combined_without_album)
-    _, remaining_items = perform_lookup(LookupType.WITHOUT_ALBUM, remaining_items, combined_without_album_detuned)
+    _, remaining_items = perform_lookup(LookupType.ALL, metadata, combined_all, service)
+    _, remaining_items = perform_lookup(LookupType.ALL, remaining_items, combined_all_detuned, service)
+    _, remaining_items = perform_lookup(LookupType.WITHOUT_ALBUM, remaining_items, combined_without_album, service)
+    _, remaining_items = perform_lookup(LookupType.WITHOUT_ALBUM, remaining_items, combined_without_album_detuned, service)
 
     # to the still unmatched recordings, add null value so that each item has in the response has spotify_track_id key
     for item in all_metadata.values():
-        if "spotify_track_ids" not in item:
+        if service == "spotify" and "spotify_track_ids" not in item:
             item["spotify_track_ids"] = []
-
-    return [SpotifyIdFromMBIDOutput(**row) for row in metadata.values()]
-
+        elif service == "apple_music" and "apple_track_ids" not in item:
+            item["apple_track_ids"] = []
+    
+    if service == "spotify":
+        return [SpotifyIdFromMBIDOutput(**row) for row in metadata.values()]
+    else:
+        return [AppleMusicIdFromMBIDOutput(**row) for row in metadata.values()]

--- a/listenbrainz/labs_api/labs/api/utils.py
+++ b/listenbrainz/labs_api/labs/api/utils.py
@@ -120,7 +120,7 @@ def lookup_using_metadata(params: list[dict], service):
             item["spotify_track_ids"] = []
         elif service == "apple_music" and "apple_track_ids" not in item:
             item["apple_track_ids"] = []
-    
+
     if service == "spotify":
         return [SpotifyIdFromMBIDOutput(**row) for row in metadata.values()]
     else:

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -15,6 +15,8 @@ from listenbrainz.labs_api.labs.api.similar_artists import SimilarArtistsViewerQ
 from listenbrainz.labs_api.labs.api.similar_recordings import SimilarRecordingsViewerQuery
 from listenbrainz.labs_api.labs.api.spotify.spotify_mbid_lookup import SpotifyIdFromMBIDQuery
 from listenbrainz.labs_api.labs.api.spotify.spotify_metadata_lookup import SpotifyIdFromMetadataQuery
+from listenbrainz.labs_api.labs.api.apple.apple_mbid_lookup import AppleMusicIdFromMBIDQuery
+from listenbrainz.labs_api.labs.api.apple.apple_metadata_lookup import AppleMusicIdFromMetadataQuery
 from listenbrainz.labs_api.labs.api.user_listen_sessions import UserListensSessionQuery
 from listenbrainz.labs_api.labs.api.tag_similarity import TagSimilarityQuery
 from listenbrainz.labs_api.labs.api.bulk_tag_lookup import BulkTagLookup
@@ -33,6 +35,8 @@ register_query(ArtistCreditRecordingLookupQuery())
 register_query(ArtistCreditRecordingReleaseLookupQuery())
 register_query(SpotifyIdFromMetadataQuery())
 register_query(SpotifyIdFromMBIDQuery())
+register_query(AppleMusicIdFromMBIDQuery())
+register_query(AppleMusicIdFromMetadataQuery())
 register_query(UserListensSessionQuery())
 register_query(SimilarRecordingsViewerQuery())
 register_query(SimilarArtistsViewerQuery())

--- a/listenbrainz/labs_api/labs/main.py
+++ b/listenbrainz/labs_api/labs/main.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 import psycopg2.extras
 from datasethoster.main import create_app, init_sentry, register_query
+
+from listenbrainz.labs_api.labs.api.apple.apple_mbid_lookup import AppleMusicIdFromMBIDQuery
+from listenbrainz.labs_api.labs.api.apple.apple_metadata_lookup import AppleMusicIdFromMetadataQuery
 from listenbrainz.labs_api.labs.api.artist_country_from_artist_mbid import ArtistCountryFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_from_artist_mbid import ArtistCreditIdFromArtistMBIDQuery
 from listenbrainz.labs_api.labs.api.artist_credit_recording_release_lookup import \
@@ -15,8 +18,6 @@ from listenbrainz.labs_api.labs.api.similar_artists import SimilarArtistsViewerQ
 from listenbrainz.labs_api.labs.api.similar_recordings import SimilarRecordingsViewerQuery
 from listenbrainz.labs_api.labs.api.spotify.spotify_mbid_lookup import SpotifyIdFromMBIDQuery
 from listenbrainz.labs_api.labs.api.spotify.spotify_metadata_lookup import SpotifyIdFromMetadataQuery
-from listenbrainz.labs_api.labs.api.apple.apple_mbid_lookup import AppleMusicIdFromMBIDQuery
-from listenbrainz.labs_api.labs.api.apple.apple_metadata_lookup import AppleMusicIdFromMetadataQuery
 from listenbrainz.labs_api.labs.api.user_listen_sessions import UserListensSessionQuery
 from listenbrainz.labs_api.labs.api.tag_similarity import TagSimilarityQuery
 from listenbrainz.labs_api.labs.api.bulk_tag_lookup import BulkTagLookup

--- a/mbid_mapping/docker/crontab
+++ b/mbid_mapping/docker/crontab
@@ -7,6 +7,9 @@
 # Rebuild the spotify metadata index every friday at 1 A.M.
 0 1 * * 5 listenbrainz /usr/local/bin/python /code/mapper/manage.py build-spotify-metadata-index >> /code/mapper/cron-spotify-metadata-index.log 2>&1
 
+# Rebuild the apple music metadata index every friday at 1 A.M.
+0 1 * * 5 listenbrainz /usr/local/bin/python /code/mapper/manage.py build-apple-metadata-index >> /code/mapper/cron-apple-metadata-index.log 2>&1
+
 # Rebuild similar tag data at 2am sundays
 0 2 * * 0 listenbrainz /usr/local/bin/python /code/mapper/manage.py build-tag-similarity >> /code/mapper/cron-tag-similarity.log 2>&1
 

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -20,6 +20,7 @@ from mapping.mb_metadata_cache import create_mb_metadata_cache, incremental_upda
 from mapping.mb_release_group_cache import create_mb_release_group_cache, \
     incremental_update_mb_release_group_cache
 from mapping.spotify_metadata_index import create_spotify_metadata_index
+from mapping.apple_metadata_index import create_apple_metadata_index
 from similar.tag_similarity import create_tag_similarity
 
 
@@ -200,6 +201,15 @@ def build_spotify_metadata_index(use_lb_conn):
         Build the spotify metadata index that LB uses
     """
     create_spotify_metadata_index(use_lb_conn)
+
+
+@cli.command()
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def build_apple_metadata_index(use_lb_conn):
+    """
+        Build the Apple Music metadata index that LB uses
+    """
+    create_apple_metadata_index(use_lb_conn)
 
 
 @cli.command()

--- a/mbid_mapping/mapping/album_metadata_index.py
+++ b/mbid_mapping/mapping/album_metadata_index.py
@@ -1,0 +1,98 @@
+import abc
+import re
+
+from unidecode import unidecode
+
+from mapping.bulk_table import BulkInsertTable
+
+
+
+class AlbumMetadataIndex(BulkInsertTable, abc.ABC):
+    """
+        This class creates the metadata index for external music services, that support albums,
+        using the reverse painters' algorithm.
+    """
+
+    def __init__(self, name, schema, select_conn, insert_conn=None, batch_size=None, unlogged=False):
+        super().__init__(f"mapping.{name}_metadata_index", select_conn, insert_conn, batch_size, unlogged)
+        self.name = name
+        self.row_id = 0
+        self.schema = schema
+
+    def get_create_table_columns(self):
+        return [("id",                               "SERIAL"),
+                ("artist_ids",                       "TEXT NOT NULL"),
+                ("album_id",                         "TEXT NOT NULL"),
+                ("track_id",                         "TEXT NOT NULL"),
+                ("combined_lookup_all",              "TEXT NOT NULL"),
+                ("combined_lookup_without_album",    "TEXT NOT NULL"),
+                ("score",                            "INTEGER NOT NULL")]
+
+    def get_insert_queries(self):
+        """ Retrieve the album name, track name, artist name for all tracks in spotify cache in a specific order.
+        These name fields will be used to calculate a lookup for each track which will then be used for matching
+        purposes. The order by determines the tie-breaking score in case of multiple rows have the same lookup.
+        """
+        return [f"""
+            SELECT album.album_id AS album_id
+                 , album.name AS album_name
+                 , album.type AS album_type
+                 , album.release_date AS release_date
+                 , track.track_id AS track_id
+                 , track.name AS track_name
+                 , track.track_number AS track_number
+                 -- retrieve track artists in same order as they appear on the spotify track
+                 , array_agg(ARRAY[artist.name, artist.artist_id] ORDER BY rta.position) AS artists
+                 -- prefer albums over single over compilations.
+                 , CASE 
+                    WHEN album.type = 'album' THEN 1
+                    WHEN album.type = 'single' THEN 2
+                    WHEN album.type = 'compilation' THEN 3
+                    ELSE 4 END
+                    AS album_sort_order
+              FROM {self.schema}.album album
+              JOIN {self.schema}.track track
+                ON album.album_id = track.album_id
+              JOIN {self.schema}.rel_track_artist rta
+                ON track.track_id = rta.track_id
+              JOIN {self.schema}.artist artist
+                ON rta.artist_id = artist.artist_id
+          GROUP BY album.album_id
+                 , album.name
+                 , album.type
+                 , album.release_date
+                 , track.track_id
+                 , track.name
+                 , track.track_number
+          ORDER BY album_sort_order
+                 , release_date
+                 , album_id
+                 , track_number
+                 , track_name
+        """]
+
+    def get_index_names(self):
+        return [
+            (f"{self.name}_metadata_index_idx_combined_lookup_all", "combined_lookup_all", False),
+            (f"{self.name}_metadata_index_idx_combined_lookup_without_album", "combined_lookup_without_album", False),
+        ]
+
+    def process_row(self, row):
+        """ Calculate lookup for each track and assign a score based on ordering """
+        artist_names = " ".join([a[0] for a in row["artists"]])
+        artist_ids = [a[1] for a in row["artists"]]
+        self.row_id += 1
+
+        combined_lookup_all = unidecode(re.sub(r'[^\w]+', '', artist_names + row["album_name"] + row["track_name"]).lower())
+        combined_lookup_without_album = unidecode(re.sub(r'[^\w]+', '', artist_names + row["track_name"]).lower())
+
+        return {f"mapping.{self.name}_metadata_index": [
+            (
+                artist_ids,
+                row["album_id"],
+                row["track_id"],
+                combined_lookup_all,
+                combined_lookup_without_album,
+                -self.row_id
+            )
+        ]}

--- a/mbid_mapping/mapping/apple_metadata_index.py
+++ b/mbid_mapping/mapping/apple_metadata_index.py
@@ -1,106 +1,14 @@
-import re
-
 import psycopg2
-from unidecode import unidecode
 
+from mapping.album_metadata_index import AlbumMetadataIndex
 from mapping.utils import log
-from mapping.bulk_table import BulkInsertTable
 import config
-
-TEST_ARTIST_IDS = [1160983, 49627, 65, 21238]  # Gun'n'roses, beyoncé, portishead, Erik Satie
-
-
-class AppleMusicMetadataIndex(BulkInsertTable):
-    """
-        This class creates the Apple Music metadata index using the reverse painters algorithm.
-    """
-
-    def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
-        super().__init__("mapping.apple_metadata_index", select_conn, insert_conn, batch_size, unlogged)
-        self.row_id = 0
-
-    def get_create_table_columns(self):
-        return [("id",                               "SERIAL"),
-                ("artist_ids",                       "TEXT NOT NULL"),
-                ("album_id",                         "TEXT NOT NULL"),
-                ("track_id",                         "TEXT NOT NULL"),
-                ("combined_lookup_all",              "TEXT NOT NULL"),
-                ("combined_lookup_without_album",    "TEXT NOT NULL"),
-                ("score",                            "INTEGER NOT NULL")]
-
-    def get_insert_queries(self):
-        """ Retrieve the album name, track name, artist name for all tracks in apple music cache in a specific order.
-        These name fields will be used to calculate a lookup for each track which will then be used for matching
-        purposes. The order by determines the tie-breaking score in case of multiple rows have the same lookup.
-        """
-        return ["""
-            SELECT album.album_id AS album_id
-                 , album.name AS album_name
-                 , album.type AS album_type
-                 , album.release_date AS release_date
-                 , track.track_id AS track_id
-                 , track.name AS track_name
-                 , track.track_number AS track_number
-                 -- retrieve track artists in same order as they appear on the spotify track
-                 , array_agg(ARRAY[artist.name, artist.artist_id] ORDER BY rta.position) AS artists
-                 -- prefer albums over single over compilations.
-                 , CASE
-                    WHEN album.type = 'album' THEN 1
-                    WHEN album.type = 'single' THEN 2
-                    WHEN album.type = 'compilation' THEN 3
-                    ELSE 4 END
-                    AS album_sort_order
-              FROM apple_cache.album album
-              JOIN apple_cache.track track
-                ON album.album_id = track.album_id
-              JOIN apple_cache.rel_track_artist rta
-                ON track.track_id = rta.track_id
-              JOIN apple_cache.artist artist
-                ON rta.artist_id = artist.artist_id
-          GROUP BY album.album_id
-                 , album.name
-                 , album.type
-                 , album.release_date
-                 , track.track_id
-                 , track.name
-                 , track.track_number
-          ORDER BY album_sort_order
-                 , release_date
-                 , album_id
-                 , track_number
-                 , track_name
-        """]
-
-    def get_index_names(self):
-        return [
-            ("apple_metadata_index_idx_combined_lookup_all", "combined_lookup_all", False),
-            ("apple_metadata_index_idx_combined_lookup_without_album", "combined_lookup_without_album", False),
-        ]
-
-    def process_row(self, row):
-        """ Calculate lookup for each track and assign a score based on ordering """
-        artist_names = " ".join([a[0] for a in row["artists"]])
-        artist_ids = [a[1] for a in row["artists"]]
-        self.row_id += 1
-
-        combined_lookup_all = unidecode(re.sub(r'[^\w]+', '', artist_names + row["album_name"] + row["track_name"]).lower())
-        combined_lookup_without_album = unidecode(re.sub(r'[^\w]+', '', artist_names + row["track_name"]).lower())
-
-        return {"mapping.apple_metadata_index": [
-            (
-                artist_ids,
-                row["album_id"],
-                row["track_id"],
-                combined_lookup_all,
-                combined_lookup_without_album,
-                -self.row_id
-            )
-        ]}
 
 
 def create_apple_metadata_index(use_lb_conn: bool):
     """
-        Main function for creating the apple music metadata index
+        Main function for creating the apple metadata index
+
         Arguments:
             use_lb_conn: whether to use LB conn or not
     """
@@ -110,7 +18,7 @@ def create_apple_metadata_index(use_lb_conn: bool):
         lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
     log("apple_metadata_index: start!")
 
-    ndx = AppleMusicMetadataIndex(lb_conn)
+    ndx = AlbumMetadataIndex("apple", "apple_cache", lb_conn)
     ndx.run()
 
     log("apple_metadata_index: done!")

--- a/mbid_mapping/mapping/apple_metadata_index.py
+++ b/mbid_mapping/mapping/apple_metadata_index.py
@@ -1,0 +1,116 @@
+import re
+
+import psycopg2
+from unidecode import unidecode
+
+from mapping.utils import log
+from mapping.bulk_table import BulkInsertTable
+import config
+
+TEST_ARTIST_IDS = [1160983, 49627, 65, 21238]  # Gun'n'roses, beyoncé, portishead, Erik Satie
+
+
+class AppleMusicMetadataIndex(BulkInsertTable):
+    """
+        This class creates the Apple Music metadata index using the reverse painters algorithm.
+    """
+
+    def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
+        super().__init__("mapping.apple_metadata_index", select_conn, insert_conn, batch_size, unlogged)
+        self.row_id = 0 
+
+    def get_create_table_columns(self):
+        return [("id",                               "SERIAL"),
+                ("artist_ids",                       "TEXT NOT NULL"),
+                ("album_id",                         "TEXT NOT NULL"),
+                ("track_id",                         "TEXT NOT NULL"),
+                ("combined_lookup_all",              "TEXT NOT NULL"),
+                ("combined_lookup_without_album",    "TEXT NOT NULL"),
+                ("score",                            "INTEGER NOT NULL")]
+
+    def get_insert_queries(self):
+        """ Retrieve the album name, track name, artist name for all tracks in apple music cache in a specific order.
+        These name fields will be used to calculate a lookup for each track which will then be used for matching
+        purposes. The order by determines the tie-breaking score in case of multiple rows have the same lookup.
+        """
+        return ["""
+            SELECT album.album_id AS album_id
+                 , album.name AS album_name
+                 , album.type AS album_type
+                 , album.release_date AS release_date
+                 , track.track_id AS track_id
+                 , track.name AS track_name
+                 , track.track_number AS track_number
+                 -- retrieve track artists in same order as they appear on the spotify track
+                 , array_agg(ARRAY[artist.name, artist.artist_id] ORDER BY rta.position) AS artists
+                 -- prefer albums over single over compilations.
+                 , CASE 
+                    WHEN album.type = 'album' THEN 1
+                    WHEN album.type = 'single' THEN 2
+                    WHEN album.type = 'compilation' THEN 3
+                    ELSE 4 END
+                    AS album_sort_order
+              FROM apple_cache.album album
+              JOIN apple_cache.track track
+                ON album.album_id = track.album_id
+              JOIN apple_cache.rel_track_artist rta
+                ON track.track_id = rta.track_id
+              JOIN apple_cache.artist artist
+                ON rta.artist_id = artist.artist_id
+          GROUP BY album.album_id
+                 , album.name
+                 , album.type
+                 , album.release_date
+                 , track.track_id
+                 , track.name
+                 , track.track_number
+          ORDER BY album_sort_order
+                 , release_date
+                 , album_id
+                 , track_number
+                 , track_name
+        """]
+
+    def get_index_names(self):
+        return [
+            ("apple_metadata_index_idx_combined_lookup_all", "combined_lookup_all", False),
+            ("apple_metadata_index_idx_combined_lookup_without_album", "combined_lookup_without_album", False),
+        ]
+
+    def process_row(self, row):
+        """ Calculate lookup for each track and assign a score based on ordering """
+        artist_names = " ".join([a[0] for a in row["artists"]])
+        artist_ids = [a[1] for a in row["artists"]]
+        self.row_id += 1
+
+        combined_lookup_all = unidecode(re.sub(r'[^\w]+', '', artist_names + row["album_name"] + row["track_name"]).lower())
+        combined_lookup_without_album = unidecode(re.sub(r'[^\w]+', '', artist_names + row["track_name"]).lower())
+
+        return {"mapping.apple_metadata_index": [
+            (
+                artist_ids,
+                row["album_id"],
+                row["track_id"],
+                combined_lookup_all,
+                combined_lookup_without_album,
+                -self.row_id 
+            )
+        ]}
+
+
+def create_apple_metadata_index(use_lb_conn: bool):
+    """
+        Main function for creating the apple music metadata index
+        Arguments:
+            use_lb_conn: whether to use LB conn or not
+    """
+
+    lb_conn = None
+    if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
+        lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
+    log("apple_metadata_index: start!")
+
+    ndx = AppleMusicMetadataIndex(lb_conn)
+    ndx.run()
+
+    log("apple_metadata_index: done!")

--- a/mbid_mapping/mapping/apple_metadata_index.py
+++ b/mbid_mapping/mapping/apple_metadata_index.py
@@ -17,7 +17,7 @@ class AppleMusicMetadataIndex(BulkInsertTable):
 
     def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
         super().__init__("mapping.apple_metadata_index", select_conn, insert_conn, batch_size, unlogged)
-        self.row_id = 0 
+        self.row_id = 0
 
     def get_create_table_columns(self):
         return [("id",                               "SERIAL"),
@@ -44,7 +44,7 @@ class AppleMusicMetadataIndex(BulkInsertTable):
                  -- retrieve track artists in same order as they appear on the spotify track
                  , array_agg(ARRAY[artist.name, artist.artist_id] ORDER BY rta.position) AS artists
                  -- prefer albums over single over compilations.
-                 , CASE 
+                 , CASE
                     WHEN album.type = 'album' THEN 1
                     WHEN album.type = 'single' THEN 2
                     WHEN album.type = 'compilation' THEN 3
@@ -93,7 +93,7 @@ class AppleMusicMetadataIndex(BulkInsertTable):
                 row["track_id"],
                 combined_lookup_all,
                 combined_lookup_without_album,
-                -self.row_id 
+                -self.row_id
             )
         ]}
 

--- a/mbid_mapping/mapping/spotify_metadata_index.py
+++ b/mbid_mapping/mapping/spotify_metadata_index.py
@@ -1,101 +1,8 @@
-import re
-
 import psycopg2
-from unidecode import unidecode
 
+from mapping.album_metadata_index import AlbumMetadataIndex
 from mapping.utils import log
-from mapping.bulk_table import BulkInsertTable
 import config
-
-TEST_ARTIST_IDS = [1160983, 49627, 65, 21238]  # Gun'n'roses, beyoncé, portishead, Erik Satie
-
-
-class SpotifyMetadataIndex(BulkInsertTable):
-    """
-        This class creates the spotify metadata index using the reverse painters algorithm.
-    """
-
-    def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
-        super().__init__("mapping.spotify_metadata_index", select_conn, insert_conn, batch_size, unlogged)
-        self.row_id = 0 
-
-    def get_create_table_columns(self):
-        return [("id",                               "SERIAL"),
-                ("artist_ids",                       "TEXT NOT NULL"),
-                ("album_id",                         "TEXT NOT NULL"),
-                ("track_id",                         "TEXT NOT NULL"),
-                ("combined_lookup_all",              "TEXT NOT NULL"),
-                ("combined_lookup_without_album",    "TEXT NOT NULL"),
-                ("score",                            "INTEGER NOT NULL")]
-
-    def get_insert_queries(self):
-        """ Retrieve the album name, track name, artist name for all tracks in spotify cache in a specific order.
-        These name fields will be used to calculate a lookup for each track which will then be used for matching
-        purposes. The order by determines the tie-breaking score in case of multiple rows have the same lookup.
-        """
-        return ["""
-            SELECT album.album_id AS album_id
-                 , album.name AS album_name
-                 , album.type AS album_type
-                 , album.release_date AS release_date
-                 , track.track_id AS track_id
-                 , track.name AS track_name
-                 , track.track_number AS track_number
-                 -- retrieve track artists in same order as they appear on the spotify track
-                 , array_agg(ARRAY[artist.name, artist.artist_id] ORDER BY rta.position) AS artists
-                 -- prefer albums over single over compilations.
-                 , CASE 
-                    WHEN album.type = 'album' THEN 1
-                    WHEN album.type = 'single' THEN 2
-                    WHEN album.type = 'compilation' THEN 3
-                    ELSE 4 END
-                    AS album_sort_order
-              FROM spotify_cache.album album
-              JOIN spotify_cache.track track
-                ON album.album_id = track.album_id
-              JOIN spotify_cache.rel_track_artist rta
-                ON track.track_id = rta.track_id
-              JOIN spotify_cache.artist artist
-                ON rta.artist_id = artist.artist_id
-          GROUP BY album.album_id
-                 , album.name
-                 , album.type
-                 , album.release_date
-                 , track.track_id
-                 , track.name
-                 , track.track_number
-          ORDER BY album_sort_order
-                 , release_date
-                 , album_id
-                 , track_number
-                 , track_name
-        """]
-
-    def get_index_names(self):
-        return [
-            ("spotify_metadata_index_idx_combined_lookup_all", "combined_lookup_all", False),
-            ("spotify_metadata_index_idx_combined_lookup_without_album", "combined_lookup_without_album", False),
-        ]
-
-    def process_row(self, row):
-        """ Calculate lookup for each track and assign a score based on ordering """
-        artist_names = " ".join([a[0] for a in row["artists"]])
-        artist_ids = [a[1] for a in row["artists"]]
-        self.row_id += 1
-
-        combined_lookup_all = unidecode(re.sub(r'[^\w]+', '', artist_names + row["album_name"] + row["track_name"]).lower())
-        combined_lookup_without_album = unidecode(re.sub(r'[^\w]+', '', artist_names + row["track_name"]).lower())
-
-        return {"mapping.spotify_metadata_index": [
-            (
-                artist_ids,
-                row["album_id"],
-                row["track_id"],
-                combined_lookup_all,
-                combined_lookup_without_album,
-                -self.row_id 
-            )
-        ]}
 
 
 def create_spotify_metadata_index(use_lb_conn: bool):
@@ -109,9 +16,9 @@ def create_spotify_metadata_index(use_lb_conn: bool):
     lb_conn = None
     if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
         lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
-    log("spotify_metdata_index: start!")
+    log("spotify_metadata_index: start!")
 
-    ndx = SpotifyMetadataIndex(lb_conn)
+    ndx = AlbumMetadataIndex("spotify", "spotify_cache", lb_conn)
     ndx.run()
 
-    log("spotify_metdata_index: done!")
+    log("spotify_metadata_index: done!")


### PR DESCRIPTION
So far **added new endpoints for an Apple Music track lookup**, that would be used for exporting Listenbrainz tracks to Apple Music.

- Added new endpoints for labs_api `apple_id_from_mbid` and `apple_id_from_metadata`.

- Added new function for creating a table `apple_metadata_index`. It's necessary for track lookup in labs_api. Also updated docker && crontab file to automatically generate this table. Tested in wolf, works fine!

- tested both `apple_id_from_mbid` and `apple_id_from_metadata` function on wolf db, works perfectly

p.s This is the second PR, since I messed up with the [first one](https://github.com/metabrainz/listenbrainz-server/pull/2924) and closed it.