### PR TITLE
Fix statistics dump

### DIFF
--- a/listenbrainz/db/couchdb.py
+++ b/listenbrainz/db/couchdb.py
@@ -262,7 +262,9 @@ def dump_database(prefix: str, fp: BinaryIO):
     # get the older database for this stat type because it will likely be the complete one
     # the newer one is probably incomplete and that's why the old one has not been cleaned up yet.
     database = databases[-1]
-    lock_database(database)
+    # check if the database is already locked from a previous failed dump attempt
+    if not check_database_lock(database):
+        lock_database(database)
 
     try:
         with _get_requests_session() as http:

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -362,9 +362,13 @@ def dump_statistics(location: str):
     ]
     full_path = os.path.join(location, "statistics")
     for stat in stats:
-        os.makedirs(full_path, exist_ok=True)
-        with open(os.path.join(full_path, f"{stat}.jsonl"), "wb+") as fp:
-            couchdb.dump_database(stat, fp)
+        try:
+            current_app.logger.info(f"Dumping statistics for {stat}...")
+            os.makedirs(full_path, exist_ok=True)
+            with open(os.path.join(full_path, f"{stat}.jsonl"), "wb+") as fp:
+                couchdb.dump_database(stat, fp)
+        except Exception:
+            current_app.logger.info(f"Failed to create dump for {stat}:", exc_info=True)
 
 
 def _create_dump(location: str, db_engine: Optional[sqlalchemy.engine.Engine], dump_type: str, tables: Optional[dict],

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -76,7 +76,8 @@ class DumpTestCase(DatabaseTestCase):
         data[1]["to_ts"] = to_ts1
 
         time_now = datetime.today()
-        dump_location = db_dump.create_statistics_dump(self.tempdir, time_now)
+        with self.app.app_context():
+            dump_location = db_dump.create_statistics_dump(self.tempdir, time_now)
         self.assertTrue(os.path.isfile(dump_location))
 
         found = set()


### PR DESCRIPTION
Do not fail entire dump and as a result all other selected dumps (timescale/db/listen) if exporting one stat fails.
