### PR TITLE
Manual submission modal improvements and bug fixes

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -206,7 +206,7 @@ The following optional elements may also be included in the ``additional_info`` 
      - array of strings
      - A list of MusicBrainz Work IDs that may be associated with this recording.
    * - ``tracknumber``
-     - integer
+     - string
      - The tracknumber of the recording. This first recording on a release is tracknumber 1.
    * - ``isrc``
      - string

--- a/frontend/css/add-listen-modal.less
+++ b/frontend/css/add-listen-modal.less
@@ -160,6 +160,7 @@
   .add-album-track {
     display: flex;
     gap: 1em;
+    position: relative;
     .track-number {
       align-self: end;
     }
@@ -175,10 +176,14 @@
     grid-template-columns: repeat(auto-fit, minmax(150px, max-content));
   }
   .default-duration {
+    &.heading {
+      right: 1.7em;
+      z-index: 1;
+    }
     margin: 0;
     position: absolute;
     width: initial;
-    right: 1.4em;
+    right: 0;
     background-color: oldlace;
   }
   // Chevron indicator

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -38,9 +38,7 @@ function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
         }}
         checked={isChecked}
       />
-      <strong className="small track-number">
-        {padStart(track.position.toString(), 2, "0")}
-      </strong>
+      <strong className="small track-number">{track.number}</strong>
       <span>{track.title}</span>
       <span className={`duration ${!track.length ? "default-duration" : ""}`}>
         {millisecondsToStr(track.length ?? DEFAULT_TRACK_LENGTH_SECONDS * 1000)}

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -213,7 +213,7 @@ export default function AddAlbumListens({
   );
 
   const allDurations = selectedAlbum?.media.flatMap((medium) =>
-    medium.tracks.map((track) => track.length)
+    medium.tracks.map((track) => track.length ?? track.recording.length)
   );
   const showDefaultDuration = !allDurations?.every(Boolean);
 
@@ -272,7 +272,9 @@ export default function AddAlbumListens({
                     const mediumTime = medium.tracks
                       .map(
                         (track) =>
-                          track.length ?? DEFAULT_TRACK_LENGTH_SECONDS * 1000
+                          track.length ??
+                          track.recording.length ??
+                          DEFAULT_TRACK_LENGTH_SECONDS * 1000
                       )
                       ?.reduce((total, duration) => total + duration, 0);
 

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -174,7 +174,7 @@ export default function AddAlbumListens({
             </div>
             {showDefaultDuration && (
               <div
-                className="default-duration small"
+                className="default-duration heading small"
                 title={`When no duration is available a default of ${defaultDuration} will be used`}
               >
                 default {defaultDuration}

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -68,6 +68,7 @@ type TrackRowProps = {
 };
 
 function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
+  const trackDuration = track.length ?? track.recording.length;
   return (
     <div className="add-album-track">
       <input
@@ -83,8 +84,10 @@ function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
           : track.number}
       </strong>
       <span>{track.title}</span>
-      <span className={`duration ${!track.length ? "default-duration" : ""}`}>
-        {millisecondsToStr(track.length ?? DEFAULT_TRACK_LENGTH_SECONDS * 1000)}
+      <span className={`duration ${!trackDuration ? "default-duration" : ""}`}>
+        {millisecondsToStr(
+          trackDuration ?? DEFAULT_TRACK_LENGTH_SECONDS * 1000
+        )}
       </span>
     </div>
   );

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -1,6 +1,21 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, {
+  ChangeEvent,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "react-toastify";
-import { differenceBy, padStart, sortBy, uniqBy, without } from "lodash";
+import {
+  differenceBy,
+  identity,
+  padStart,
+  sortBy,
+  uniq,
+  uniqBy,
+  without,
+} from "lodash";
 import { formatDuration } from "date-fns";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
@@ -22,10 +37,33 @@ type MBReleaseWithMetadata = MusicBrainzRelease &
   WithArtistCredits &
   WithReleaseGroup;
 
+/* Allows sorting a selection of tracks based on the original order of that track in the multiple media
+  We cannot just order by the position attribute because it is repeated for each medium (each medium will have a track 1).
+  Courtesy of Shl for this elegant solution: https://stackoverflow.com/a/62298591/4904467
+*/
+function sortByArray<T, U>({
+  source,
+  by,
+  sourceTransformer = identity,
+}: {
+  source: T[];
+  by: U[];
+  sourceTransformer?: (item: T) => U;
+}) {
+  const indexesByElements = new Map(by.map((item, idx) => [item, idx]));
+  const orderedResult = sortBy(source, (p) =>
+    indexesByElements.get(sourceTransformer(p))
+  );
+  return orderedResult;
+}
+
 type TrackRowProps = {
   track: MBTrackWithAC;
   isChecked: boolean;
-  onClickCheckbox: (track: MBTrackWithAC, checked: boolean) => void;
+  onClickCheckbox: (
+    track: MBTrackWithAC,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => void;
 };
 
 function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
@@ -33,8 +71,8 @@ function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
     <div className="add-album-track">
       <input
         type="checkbox"
-        onChange={(e) => {
-          onClickCheckbox(track, e.target.checked);
+        onChange={(event) => {
+          onClickCheckbox(track, event);
         }}
         checked={isChecked}
       />
@@ -56,6 +94,14 @@ export default function AddAlbumListens({
   const [selectedAlbum, setSelectedAlbum] = useState<MBReleaseWithMetadata>();
   const [selectedTracks, setSelectedTracks] = useState<Array<MBTrackWithAC>>(
     []
+  );
+
+  // No need to store that one in the state
+  const lastChecked = useRef<MBTrackWithAC>();
+  const allTracks: MBTrackWithAC[] = useMemo(
+    () =>
+      selectedAlbum?.media.map((m) => m.tracks as MBTrackWithAC[]).flat() ?? [],
+    [selectedAlbum]
   );
 
   useEffect(() => {
@@ -97,18 +143,46 @@ export default function AddAlbumListens({
   }, [selectedAlbumMBID, lookupMBRelease]);
 
   const onTrackSelectionChange = React.useCallback(
-    (track: MBTrackWithAC, isChecked: boolean) => {
+    (track: MBTrackWithAC, event: ChangeEvent<HTMLInputElement>) => {
       setSelectedTracks((prevSelectedTracks) => {
-        let newSelection: MBTrackWithAC[];
-        if (isChecked) {
-          newSelection = sortBy([...prevSelectedTracks, track], "position");
+        let newSelection: MBTrackWithAC[] = [];
+        const isChecked = event.target.checked;
+        // @ts-ignore nativeEvent.shiftKey exists for there input events,
+        // but the react types define a very basic Event type which does not have shiftKey
+        const shiftKey = Boolean(event.nativeEvent.shiftKey!);
+        if (shiftKey && lastChecked?.current !== track) {
+          const lastIndex = allTracks!.findIndex(
+            (t) => t === lastChecked.current
+          );
+          const thisIndex = allTracks!.findIndex((t) => t === track);
+
+          if (lastIndex > thisIndex) {
+            const trackRange = allTracks!.slice(thisIndex, lastIndex + 1);
+            newSelection = isChecked
+              ? uniq([...trackRange, ...prevSelectedTracks])
+              : without(prevSelectedTracks, ...trackRange);
+          } else if (thisIndex > lastIndex) {
+            const trackRange = allTracks!.slice(lastIndex, thisIndex + 1);
+            newSelection = isChecked
+              ? uniq([...prevSelectedTracks, ...trackRange])
+              : without(prevSelectedTracks, ...trackRange);
+          }
+        } else if (isChecked) {
+          newSelection = [...prevSelectedTracks, track];
         } else {
           newSelection = without(prevSelectedTracks, track);
         }
-        return newSelection;
+        lastChecked.current = track;
+        // return sortBy(newSelection, mediumPosition, "position");
+        // Sort according to the original order of the track, fix for multiple medium
+        return sortByArray({
+          source: newSelection,
+          by: allTracks.map((t) => t.id),
+          sourceTransformer: (t) => t.id,
+        });
       });
     },
-    []
+    [allTracks]
   );
 
   const toggleSelectionAllMediumTracks = React.useCallback(

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -10,6 +10,7 @@ import { toast } from "react-toastify";
 import {
   differenceBy,
   identity,
+  isFinite,
   padStart,
   sortBy,
   uniq,
@@ -76,7 +77,11 @@ function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
         }}
         checked={isChecked}
       />
-      <strong className="small track-number">{track.number}</strong>
+      <strong className="small track-number">
+        {isFinite(Number(track.number))
+          ? padStart(track.position.toString(), 2, "0")
+          : track.number}
+      </strong>
       <span>{track.title}</span>
       <span className={`duration ${!track.length ? "default-duration" : ""}`}>
         {millisecondsToStr(track.length ?? DEFAULT_TRACK_LENGTH_SECONDS * 1000)}

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -326,7 +326,8 @@ export default NiceModal.create(() => {
                     }
                     maxDate={new Date()}
                     clearIcon={null}
-                    format="yyyy-MM-dd h:mm:ss a"
+                    format="yyyy-MM-dd hh:mm:ss"
+                    maxDetail="second"
                     disabled={!customTimestamp}
                   />
                 </div>

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -211,6 +211,10 @@ export default NiceModal.create(() => {
     handleError,
   ]);
 
+  const userLocale = navigator.languages?.length
+    ? navigator.languages[0]
+    : navigator.language;
+
   return (
     <div
       className={`modal fade ${modal.visible ? "in" : ""}`}
@@ -326,7 +330,8 @@ export default NiceModal.create(() => {
                     }
                     maxDate={new Date()}
                     clearIcon={null}
-                    format="yyyy-MM-dd hh:mm:ss"
+                    format={userLocale ? undefined : "yyyy-MM-dd hh:mm:ss"}
+                    locale={userLocale}
                     maxDetail="second"
                     disabled={!customTimestamp}
                   />

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -69,7 +69,7 @@ export const getListenFromTrack = (
         recording_mbid: track.recording.id,
         submission_client: "listenbrainz web",
         track_mbid: track.id,
-        tracknumber: parseInt(track.number, 10),
+        tracknumber: track.number,
         artist_mbids: track["artist-credit"].map((ac) => ac.artist.id),
       },
     },

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -41,11 +41,14 @@ export function getListenFromRecording(
         release_group_mbid: releaseOrCanonical["release-group"].id,
         recording_mbid: recording.id,
         submission_client: "listenbrainz web",
-        duration_ms: recording.length,
         artist_mbids: recording["artist-credit"].map((ac) => ac.artist.id),
       },
     },
   };
+  if (recording.length) {
+    // Cannot send a `null` duration
+    listen.track_metadata.additional_info!.duration_ms = recording.length;
+  }
   return listen;
 }
 
@@ -65,13 +68,16 @@ export const getListenFromTrack = (
       additional_info: {
         recording_mbid: track.recording.id,
         submission_client: "listenbrainz web",
-        duration_ms: track.length,
         track_mbid: track.id,
         tracknumber: parseInt(track.number, 10),
         artist_mbids: track["artist-credit"].map((ac) => ac.artist.id),
       },
     },
   };
+  if (track.length) {
+    // Cannot send a `null` duration
+    listen.track_metadata.additional_info!.duration_ms = track.length;
+  }
   if (release) {
     listen.track_metadata.release_mbid = release.id;
     listen.track_metadata.release_name = release.title;

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -82,7 +82,7 @@ export const getListenFromTrack = (
     listen.track_metadata.additional_info!.duration_ms = track.recording.length;
   }
   if (release) {
-    listen.track_metadata.release_mbid = release.id;
+    listen.track_metadata.additional_info!.release_mbid = release.id;
     listen.track_metadata.release_name = release.title;
   }
   return listen;

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -77,6 +77,9 @@ export const getListenFromTrack = (
   if (track.length) {
     // Cannot send a `null` duration
     listen.track_metadata.additional_info!.duration_ms = track.length;
+  } else if (track.recording.length) {
+    // Cannot send a `null` duration
+    listen.track_metadata.additional_info!.duration_ms = track.recording.length;
   }
   if (release) {
     listen.track_metadata.release_mbid = release.id;

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -33,7 +33,7 @@ interface AdditionalInfo {
   origin_url?: string | null;
   tags?: Array<string> | null;
   track_mbid?: string | null;
-  tracknumber?: number | null;
+  tracknumber?: string | number | null;
   work_mbids?: Array<string> | null;
 }
 


### PR DESCRIPTION
- Sending a `null` or non-integer value for duration_ms in the listen payload results in an error and the listens not submitted.
Reported in the forums https://community.metabrainz.org/t/add-manual-album-listens-offline/696894/19
Thanks Nicknickcdf!
- default durations were not scrolling with the rest of the medium content because of position:absolute without position:relative on their parent element.
- send tracknumber string instead of forcing to integer; the API docs say they expect an integer but track.number in MB is a string and the DB model also expects optional string
- if track duration is not available, use associated recording's duration.
- set the release MBID correclty in `track_metadata.additional_info.release_mbid` instead of `track_metadata.release_mbid`
- display MB `track.number` string instead of `track.position` integer, better for some mediums (cassettes, etc.)
- while doing that, fixed the API docs for `tracknumber` which expected an optional integer, to an optional string as the DB model expects

All of this feedback has been reported on https://tickets.metabrainz.org/browse/LB-1401 or in the forums.
