### PR TITLE
LB-1600: Require login for /listening-now page

### DIFF
--- a/listenbrainz/webserver/views/metadata_viewer.py
+++ b/listenbrainz/webserver/views/metadata_viewer.py
@@ -9,6 +9,7 @@ metadata_viewer_bp = Blueprint("metadata_viewer", __name__)
 
 @metadata_viewer_bp.route("/",  defaults={'path': ''})
 @metadata_viewer_bp.route('/<path:path>/')
+@login_required
 def playing_now_metadata_page(path):
     return render_template("index.html")
 


### PR DESCRIPTION
This page and associated POST endpoint (to get data for the front-end) require a logged-in user. Otherwise the POST request returns a redirect response to the login page, and the RouteLoader in the front-end throws an error trying to JSON parse an HTML body.
