### PR TITLE
LB-1399: Choose specific release in manual MBID mapping

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -81,7 +81,7 @@ CREATE UNIQUE INDEX similar_artist_credit_mbids_reverse_uniq_idx ON similarity.a
 
 CREATE INDEX similarity_overhyped_artists_artist_mbid_idx ON similarity.overhyped_artists(artist_mbid) INCLUDE (factor);
 
-CREATE INDEX mbid_manual_mapping_top_idx ON mbid_manual_mapping_top (recording_msid) INCLUDE (recording_mbid);
+CREATE INDEX mbid_manual_mapping_top_idx ON mbid_manual_mapping_top (recording_msid) INCLUDE (recording_mbid, release_mbid);
 
 CREATE INDEX popularity_recording_listen_count_idx ON popularity.recording (total_listen_count) INCLUDE (recording_mbid);
 CREATE INDEX popularity_recording_user_count_idx ON popularity.recording (total_user_count) INCLUDE (recording_mbid);

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -62,6 +62,7 @@ CREATE TABLE mbid_manual_mapping(
     id             INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
     recording_msid UUID NOT NULL,
     recording_mbid UUID NOT NULL,
+    release_mbid UUID NOT NULL,
     user_id        INTEGER NOT NULL,
     created        TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
 );

--- a/admin/timescale/updates/2024-07-04-add-release-in-mbid-mapping.sql
+++ b/admin/timescale/updates/2024-07-04-add-release-in-mbid-mapping.sql
@@ -1,5 +1,11 @@
 BEGIN;
 
+ALTER TABLE mbid_manual_mapping ADD COLUMN release_mbid UUID NOT NULL;
+
+
+
+DROP MATERIALIZED VIEW mbid_manual_mapping_top;
+
 -- create a materialized view of the top mappings of a recording msid. top mappings are chosen
 -- by the highest number of users that have added it. if multiple mappings have same count, break
 -- ties by preferring the mapping that was created most recently. to avoid abuse, mappings are only
@@ -18,5 +24,6 @@ CREATE MATERIALIZED VIEW mbid_manual_mapping_top AS (
          , count(*) DESC
          , max(created) DESC
 );
+
 
 COMMIT;

--- a/frontend/css/search-track.less
+++ b/frontend/css/search-track.less
@@ -18,21 +18,22 @@
   // Options within the dropdown menu
   > option, > button {
     .track-search-dropdown>a,.track-search-dropdown>button {
-    display: block;
-    width: 100%;
-    outline: inherit;
-    padding: 5px 20px;
-    font: inherit;
-    text-align: left;
-    background: none;
-    color: inherit;
-    border: none;
-    cursor: pointer;
+      display: block;
+      width: 100%;
+      outline: inherit;
+      padding: 5px 20px;
+      font: inherit;
+      text-align: left;
+      background: none;
+      color: inherit;
+      border: none;
+      cursor: pointer;
 
-    &:hover,
-    &:focus {
-      color: #fff;
-      background-color: #353070;
+      &:hover,
+      &:focus {
+        color: #fff;
+        background-color: #353070;
+      }
     }
   }
 }

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1049,19 +1049,26 @@ export default class APIService {
   submitMBIDMapping = async (
     userToken: string,
     recordingMSID: string,
-    recordingMBID: string
+    recordingMBID: string,
+    releaseMBID?: string
   ): Promise<{ status: string }> => {
     const url = `${this.APIBaseURI}/metadata/submit_manual_mapping/`;
+    const optional: { release_mbid?: string } = {};
+    if (releaseMBID) {
+      optional.release_mbid = releaseMBID;
+    }
+    const body = {
+      recording_msid: recordingMSID,
+      recording_mbid: recordingMBID,
+      ...optional,
+    };
     const response = await fetch(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
         "Content-Type": "application/json;charset=UTF-8",
       },
-      body: JSON.stringify({
-        recording_msid: recordingMSID,
-        recording_mbid: recordingMBID,
-      }),
+      body: JSON.stringify(body),
     });
     await this.checkStatus(response);
     return response.json();

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -113,6 +113,7 @@ PUBLIC_TABLES_TIMESCALE_DUMP = {
         'id',
         'recording_msid',
         'recording_mbid',
+        'release_mbid',
         'user_id',
         'created',
     ),

--- a/listenbrainz/db/mbid_manual_mapping.py
+++ b/listenbrainz/db/mbid_manual_mapping.py
@@ -11,16 +11,18 @@ from listenbrainz.db.model.mbid_manual_mapping import MbidManualMapping
 def create_mbid_manual_mapping(ts_conn, mapping: MbidManualMapping):
     """Save a user mapping to the database. """
     query = """
-        INSERT INTO mbid_manual_mapping(recording_msid, recording_mbid, user_id)
-             VALUES (:recording_msid, :recording_mbid, :user_id)
+        INSERT INTO mbid_manual_mapping(recording_msid, recording_mbid, release_mbid, user_id)
+             VALUES (:recording_msid, :recording_mbid, :release_mbid, :user_id)
         ON CONFLICT (user_id, recording_msid)
       DO UPDATE SET recording_mbid = EXCLUDED.recording_mbid
+                SET release_mbid = EXCLUDED.release_mbid
     """
     ts_conn.execute(
         text(query),
         {
             "recording_msid": mapping.recording_msid,
             "recording_mbid": mapping.recording_mbid,
+            "release_mbid": mapping.release_mbid,
             "user_id": mapping.user_id
         }
     )
@@ -41,6 +43,7 @@ def get_mbid_manual_mapping(ts_conn, recording_msid: uuid.UUID, user_id: int) ->
     query = """
         SELECT recording_msid::text
              , recording_mbid::text
+             , release_mbid::text
              , user_id
              , created
           FROM mbid_manual_mapping
@@ -59,6 +62,7 @@ def get_mbid_manual_mapping(ts_conn, recording_msid: uuid.UUID, user_id: int) ->
         return MbidManualMapping(
             recording_msid=row.recording_msid,
             recording_mbid=row.recording_mbid,
+            release_mbid=row.release_mbid,
             user_id=row.user_id,
             created=row.created
         )
@@ -79,6 +83,7 @@ def get_mbid_manual_mappings(ts_conn, recording_msid: uuid.UUID) -> List[MbidMan
     query = """
         SELECT recording_msid::text
              , recording_mbid::text
+             , release_mbid::text
              , user_id
              , created
           FROM mbid_manual_mapping

--- a/listenbrainz/db/model/mbid_manual_mapping.py
+++ b/listenbrainz/db/model/mbid_manual_mapping.py
@@ -8,6 +8,7 @@ class MbidManualMapping(BaseModel):
     """An instance of a msid-mbid mapping manually created by a user"""
     recording_msid: str
     recording_mbid: str
+    release_mbid: Optional[str]
     user_id: int
     created: Optional[datetime.datetime]
 
@@ -15,6 +16,7 @@ class MbidManualMapping(BaseModel):
         return {
             "recording_msid": self.recording_msid,
             "recording_mbid": self.recording_mbid,
+            "recording_mbid": self.release_mbid,
             "user_id": self.user_id,
             "created": self.created
         }

--- a/listenbrainz/db/tests/test_mbid_manual_mapping.py
+++ b/listenbrainz/db/tests/test_mbid_manual_mapping.py
@@ -22,6 +22,22 @@ class MbidManualMappingDatabaseTestCase(TimescaleTestCase):
         assert new_mapping.recording_msid == mapping.recording_msid
         assert new_mapping.user_id == mapping.user_id
 
+    def test_optional_release_mbid(self):
+        """Add and get a mapping with release_mbid"""
+        msid = "597fa2f2-8cf4-4566-a307-dbfb5aa35ec4"
+        mbid = "c8d63620-ced3-4abf-84f8-85457ce798c6"
+        release_mbid = "cb24f4bb-3ecf-44c7-bba9-5241faac3cef"
+        user_id = 1
+
+        mapping = MbidManualMapping(recording_msid=msid, recording_mbid=mbid, release_mbid=release_mbid, user_id=user_id)
+        db_mbid_manual_mapping.create_mbid_manual_mapping(self.ts_conn, mapping)
+        
+        new_mapping = db_mbid_manual_mapping.get_mbid_manual_mapping(self.ts_conn, msid, user_id)
+        assert new_mapping.recording_mbid == mapping.recording_mbid
+        assert new_mapping.recording_msid == mapping.recording_msid
+        assert new_mapping.release_mbid == mapping.release_mbid
+        assert new_mapping.user_id == mapping.user_id
+
     def test_cant_add_same_mapping_twice(self):
         """Try and add the same mapping by the same user twice, it gets updated"""
         msid = "597fa2f2-8cf4-4566-a307-dbfb5aa35ec4"

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -464,6 +464,7 @@ def submit_manual_mapping():
 
     recording_msid = request.json.get("recording_msid")
     recording_mbid = request.json.get("recording_mbid")
+    release_mbid = request.json.get("release_mbid")
     if not recording_msid or not is_valid_uuid(recording_msid):
         raise APIBadRequest("recording_msid is invalid or not present in arguments")
     if not recording_mbid or not is_valid_uuid(recording_mbid):
@@ -472,6 +473,7 @@ def submit_manual_mapping():
     mapping = MbidManualMapping(
         recording_msid=recording_msid,
         recording_mbid=recording_mbid,
+        release_mbid=release_mbid,
         user_id=user["id"]
     )
 


### PR DESCRIPTION
Allows users to select a specific release when they link an unmatched listen, as well as allowing users to correct failures of the automatic MBID mapper which sometimes maps to a recording and a release that don't match (the recording is not on that release).