### PR TITLE
fix: Encoded Apple musicUserToken getting saved in the database

### DIFF
--- a/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
@@ -310,7 +310,7 @@ export default class AppleMusicPlayer
     if (!this.appleMusicPlayer) {
       return;
     }
-    this.appleMusicPlayer?.removeEventListener(
+    this.appleMusicPlayer.removeEventListener(
       "playbackStateDidChange",
       this.onPlaybackStateChange.bind(this)
     );
@@ -360,6 +360,10 @@ export default class AppleMusicPlayer
     } catch (error) {
       console.debug(error);
       this.handleAccountError();
+    }
+
+    if (!this.appleMusicPlayer) {
+      return;
     }
 
     this.appleMusicPlayer.addEventListener(

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -1005,7 +1005,6 @@ export default class BrainzPlayer extends React.Component<
                 this.dataSources[currentDataSourceIndex]?.current instanceof
                   AppleMusicPlayer
               }
-              appleMusicUser={appleAuth}
               onInvalidateDataSource={this.invalidateDataSource}
               ref={this.appleMusicPlayer}
               playerPaused={playerPaused}

--- a/frontend/js/src/utils/musickit.d.ts
+++ b/frontend/js/src/utils/musickit.d.ts
@@ -185,6 +185,8 @@ declare namespace MusicKit {
      */
     readonly storefrontId: string;
     readonly playbackState: PlaybackStates;
+
+    restrictedEnabled: boolean;
     /**
      * Add an event listener for a MusicKit instance by name.
      *

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -372,9 +372,9 @@ def music_services_set_token(service_name: str):
     if service_name != 'apple':
         raise APIInternalServerError("The set-token method not implemented for this service")
 
-    music_user_token = request.data
+    music_user_token = request.data.decode('UTF-8')
 
-    if music_user_token is None:
+    if not music_user_token:
         raise BadRequest('Missing user token in request body')
 
     apple_service = AppleService()


### PR DESCRIPTION
This PR fixes three things
1. Decodes the request data before saving it in the database.
2. Sets the `music_user_token` in the global context.
3. Checks if the user has an active subscription while mounting