### PR TITLE
LB-817: Disable BrainzPlayer if all sources disabled

### DIFF
--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -276,21 +276,7 @@ export default class BrainzPlayer extends React.Component<
         userPreferences?.brainzplayer?.soundcloudEnabled === false &&
         userPreferences?.brainzplayer?.appleMusicEnabled === false;
       if (brainzPlayerDisabled) {
-        toast.info(
-          <ToastMsg
-            title="BrainzPlayer disabled"
-            message={
-              <>
-                You have disabled all music services for playback on
-                ListenBrainz. To enable them again, please go to the{" "}
-                <Link to="/settings/brainzplayer/">
-                  music player preferences
-                </Link>{" "}
-                page
-              </>
-            }
-          />
-        );
+        this.infoBPDeactivated();
         return;
       }
     }
@@ -356,7 +342,7 @@ export default class BrainzPlayer extends React.Component<
     const { listens } = this.props;
     const { isActivated } = this.state;
 
-    if (!isActivated) {
+    if (!isActivated || !this.dataSources.length) {
       // Player has not been activated by the user, do nothing.
       return;
     }
@@ -447,6 +433,9 @@ export default class BrainzPlayer extends React.Component<
   };
 
   activatePlayerAndPlay = (): void => {
+    if (!this.dataSources.length) {
+      return;
+    }
     overwriteMediaSession(this.mediaSessionHandlers);
     this.setState({ isActivated: true }, this.playNextTrack);
   };
@@ -455,6 +444,10 @@ export default class BrainzPlayer extends React.Component<
     listen: Listen | JSPFTrack,
     datasourceIndex: number = 0
   ): void => {
+    if (!this.dataSources.length) {
+      this.handleInfoMessage(<> </>, "BrainzPlayer is deactivated");
+      return;
+    }
     this.setState({
       isActivated: true,
       currentListen: listen,
@@ -874,6 +867,23 @@ export default class BrainzPlayer extends React.Component<
     this.playerStateTimerID = undefined;
   };
 
+  private infoBPDeactivated() {
+    toast.info(
+      <ToastMsg
+        title="BrainzPlayer disabled"
+        message={
+          <>
+            You have disabled all music services for playback on ListenBrainz.
+            To enable them again, please go to the{" "}
+            <Link to="/settings/brainzplayer/">music player preferences</Link>{" "}
+            page
+          </>
+        }
+      />,
+      { toastId: "brainzplayer-deactivated" }
+    );
+  }
+
   render() {
     const {
       currentDataSourceIndex,
@@ -907,7 +917,7 @@ export default class BrainzPlayer extends React.Component<
     return (
       <div>
         <BrainzPlayerUI
-          disabled={brainzPlayerDisabled}
+          disabled={brainzPlayerDisabled || !this.dataSources.length}
           playPreviousTrack={this.playPreviousTrack}
           playNextTrack={this.playNextTrack}
           togglePlay={


### PR DESCRIPTION
When all music sources are disabled, disable BrainzPlayer entirely. Show a message if users then try to play a track.
Show a message if users then try to play a track.

![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/ec778b3e-5265-4119-9eb3-3cb429dbc3ea)

We already had this in place:
![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/bfdf7335-24e5-4c83-b592-0e2d73a99af8)


