### PR TITLE
LB-1317, LB-1318: Export to music service options on "Created for you" page

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -379,7 +379,7 @@ pre code.hljs {
   text-align: center;
   display: inline-block;
 
-  & + .btn-icon {
+  & + * {
     margin-left: 0.4em;
   }
 

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -127,7 +127,7 @@ export default class RecommendationsPage extends React.Component<
     }
   }
 
-  fetchPlaylist = async (playlistId: string) => {
+  fetchPlaylist = async (playlistId: string, reloadOnError = false) => {
     const { APIService, currentUser } = this.context;
     try {
       const response = await APIService.getPlaylist(
@@ -145,6 +145,9 @@ export default class RecommendationsPage extends React.Component<
       });
     } catch (error) {
       toast.error(error.message);
+      if (reloadOnError) {
+        window.location.reload();
+      }
     }
   };
 
@@ -166,7 +169,7 @@ export default class RecommendationsPage extends React.Component<
       toast.error("No playlist to select");
       return;
     }
-    await this.fetchPlaylist(playlistId);
+    await this.fetchPlaylist(playlistId, true);
   };
 
   copyPlaylist: React.ReactEventHandler<HTMLElement> = async (event) => {

--- a/frontend/js/src/user/recommendations/components/RecommendationPlaylistSettings.tsx
+++ b/frontend/js/src/user/recommendations/components/RecommendationPlaylistSettings.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-toastify";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCode,
+  faCog,
   faPlayCircle,
   faSave,
 } from "@fortawesome/free-solid-svg-icons";
@@ -13,6 +14,7 @@ import { getPlaylistExtension, getPlaylistId } from "../../../playlists/utils";
 import { preciseTimestamp } from "../../../utils/utils";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import ListenPayloadModal from "../../../common/listens/ListenPayloadModal";
+import PlaylistMenu from "../../../playlists/components/PlaylistMenu";
 
 export type RecommendationPlaylistSettingsProps = {
   playlist: JSPFPlaylist;
@@ -102,6 +104,20 @@ export default function RecommendationPlaylistSettings({
           >
             <FontAwesomeIcon icon={faCode} title="Inspect playlist" />
           </button>
+          <div className="dropdown playlist-card-action-dropdown">
+            <button
+              className="dropdown-toggle playlist-card-action-button"
+              type="button"
+              id="playlistOptionsDropdown"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="true"
+            >
+              <FontAwesomeIcon icon={faCog} title="More options" />
+              &nbsp;Options
+            </button>
+            <PlaylistMenu playlist={playlist} />
+          </div>
         </div>
         <div>
           {extension?.public ? "Public" : "Private"} playlist by&nbsp;

--- a/frontend/js/src/user/recommendations/components/RecommendationPlaylistSettings.tsx
+++ b/frontend/js/src/user/recommendations/components/RecommendationPlaylistSettings.tsx
@@ -104,9 +104,9 @@ export default function RecommendationPlaylistSettings({
           >
             <FontAwesomeIcon icon={faCode} title="Inspect playlist" />
           </button>
-          <div className="dropdown playlist-card-action-dropdown">
+          <span className="dropdown">
             <button
-              className="dropdown-toggle playlist-card-action-button"
+              className="dropdown-toggle btn btn-icon btn-info"
               type="button"
               id="playlistOptionsDropdown"
               data-toggle="dropdown"
@@ -114,10 +114,9 @@ export default function RecommendationPlaylistSettings({
               aria-expanded="true"
             >
               <FontAwesomeIcon icon={faCog} title="More options" />
-              &nbsp;Options
             </button>
             <PlaylistMenu playlist={playlist} />
-          </div>
+          </span>
         </div>
         <div>
           {extension?.public ? "Public" : "Private"} playlist by&nbsp;


### PR DESCRIPTION
We add the playlist actions menu component that is already used in other playlist pages, allowing users quick access to export those playlists:

![image](https://github.com/metabrainz/listenbrainz-server/assets/6179856/3dbcdc11-b932-4f2a-9080-54d0d33070bf)|


Also fixes LB-1318 , refreshing the page if fetching a playlist (i.e. when the user clicks it) fails. This means the user has stale data and we should refresh the page.
Once we use React Query for this component, we can force-refetch the data instead of refreshing the page,