### PR TITLE
Lazy load cover art

### DIFF
--- a/frontend/js/src/common/listens/CoverArtWithFallback.tsx
+++ b/frontend/js/src/common/listens/CoverArtWithFallback.tsx
@@ -33,6 +33,7 @@ export default function CoverArtWithFallback({
       onError={(err) => {
         setError(true);
       }}
+      loading="lazy"
     />
   );
 }


### PR DESCRIPTION
Pretty simple really. Saves some resources for the user.
Should only load images if the component is visible on screen.