### PR TITLE
Make release_name optional

### DIFF
--- a/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
+++ b/listenbrainz/labs_api/labs/api/explain_mbid_mapping.py
@@ -9,7 +9,7 @@ from listenbrainz.mbid_mapping_writer.mbid_mapper import MBIDMapper
 
 class ExplainMBIDMappingInput(BaseModel):
     artist_credit_name: str
-    recording_name: str
+    recording_name: Optional[str]
     release_name: str
 
 


### PR DESCRIPTION
the mapping explain function 500s since the release name is required in the model. Marking it as optional should fix the issue.