### PR TITLE
Fix search page bar input height

### DIFF
--- a/frontend/css/search.less
+++ b/frontend/css/search.less
@@ -15,6 +15,7 @@
   }
   input {
     border-radius: 33px 0 0 33px;
+    height: auto;
     &:focus {
       box-shadow: inset 3px 2px 4px darkgrey;
       & ~ button {


### PR DESCRIPTION
Mismatch between the input and the icon button next to it
Before:
![image](https://github.com/user-attachments/assets/f996e809-1ee8-4882-a97e-2625c7e25f1d)

After:
![image](https://github.com/user-attachments/assets/921a1d36-d8f9-45cf-816a-78ba547d33fa)
