### PR TITLE
LB-568: Add contributor's OpenAPI 3 specification to API docs

### DIFF
--- a/docs/users/api/index.rst
+++ b/docs/users/api/index.rst
@@ -82,6 +82,14 @@ Reference
    misc
 
 
+OpenAPI specification
+-------------
+
+Contributor `rain0r <https://github.com/rain0r>`_ went through the trouble of making
+an OpenAPI 3 specification for the ListenBrainz API. Many thanks! Check it out here:
+`<https://github.com/rain0r/listenbrainz-openapi>`_
+
+
 Rate limiting
 -------------
 


### PR DESCRIPTION
Thanks goes to @rain0r for their efforts!
https://github.com/rain0r/listenbrainz-openapi
