### PR TITLE
Autofocus on search input in MBIDMapping modal

### DIFF
--- a/frontend/js/src/common/listens/MBIDMappingModal.tsx
+++ b/frontend/js/src/common/listens/MBIDMappingModal.tsx
@@ -48,6 +48,8 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
     TrackMetadata
   >();
 
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   const closeModal = React.useCallback(() => {
     modal.hide();
     document?.body?.classList?.remove("modal-open");
@@ -141,6 +143,8 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
     setDefaultValue(
       `${getTrackName(listenToMap)} - ${getArtistName(listenToMap)}`
     );
+    // Autofocus on the search input in order to automatically show list of results
+    searchInputRef?.current?.focus();
   }, [listenToMap]);
 
   const listenFromSelectedRecording = getListenFromSelectedRecording(
@@ -270,6 +274,7 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
               ) : (
                 <div className="card listen-card">
                   <SearchTrackOrMBID
+                    ref={searchInputRef}
                     expectedPayload="trackmetadata"
                     key={`${defaultValue}-${copyTextClickCounter}`}
                     onSelectRecording={(trackMetadata) => {

--- a/frontend/js/src/user/components/AddSingleListen.tsx
+++ b/frontend/js/src/user/components/AddSingleListen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   faChevronDown,
   faTimesCircle,
@@ -25,6 +25,8 @@ export default function AddSingleListen({
       | (MusicBrainzRelease & WithReleaseGroup)
       | undefined;
   }>({});
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const removeRecording = (recordingMBID: string) => {
     setSelectedRecordings((prevRecordings) =>
@@ -72,6 +74,7 @@ export default function AddSingleListen({
   return (
     <div>
       <SearchTrackOrMBID
+        ref={searchInputRef}
         expectedPayload="recording"
         onSelectRecording={selectRecording}
       />
@@ -101,6 +104,7 @@ export default function AddSingleListen({
                       iconSize="lg"
                       action={() => {
                         removeRecording(recording.id);
+                        searchInputRef?.current?.focus();
                       }}
                     />
                   }

--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -31,6 +31,7 @@ export default function SearchAlbumOrMBID({
   const { APIService } = useContext(GlobalAppContext);
   const { lookupMBReleaseGroup, searchMBRelease } = APIService;
   const dropdownRef = DropdownRef();
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState(defaultValue ?? "");
   const [searchResults, setSearchResults] = useState<
     Array<MusicBrainzRelease & Partial<WithMedia> & WithArtistCredits>
@@ -122,6 +123,7 @@ export default function SearchAlbumOrMBID({
     setInputValue("");
     setSearchResults([]);
     onSelectAlbum();
+    searchInputRef?.current?.focus();
   };
 
   useEffect(() => {
@@ -143,6 +145,7 @@ export default function SearchAlbumOrMBID({
     <div>
       <div className="input-group dropdown-search" ref={dropdownRef}>
         <input
+          ref={searchInputRef}
           type="search"
           value={inputValue}
           className="form-control"


### PR DESCRIPTION
In MBIDMapping modal when clicking the button to copy text, the search text input should have focus, otherwise it looks like there are no results as the search results are shown on text input focus.

Apply same mechanism for "add listens" modal components where applicable (mostly reset buttons)