### PR TITLE
Minor text updates

### DIFF
--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -81,7 +81,7 @@ export default function DeleteListens() {
         <title>Delete Listens</title>
       </Helmet>
       <h3 className="page-title">Delete listens: {name}</h3>
-            <p>
+      <p>
         <b>Deleted listens are not recoverable.</b> Consider exporting your
         ListenBrainz data before deleting your account.
       </p>
@@ -101,7 +101,7 @@ export default function DeleteListens() {
         <Link to="/settings/music-services/details/">Disconnect</Link> Spotify
         before deleting.
       </p>
-      
+
       <button
         id="btn-delete-listens"
         className="btn btn-danger btn-lg"

--- a/frontend/js/src/settings/delete-listens/DeleteListens.tsx
+++ b/frontend/js/src/settings/delete-listens/DeleteListens.tsx
@@ -81,6 +81,14 @@ export default function DeleteListens() {
         <title>Delete Listens</title>
       </Helmet>
       <h3 className="page-title">Delete listens: {name}</h3>
+            <p>
+        <b>Deleted listens are not recoverable.</b> Consider exporting your
+        ListenBrainz data before deleting your account.
+      </p>
+
+      <ExportButtons feedback={false} />
+      <br />
+
       <p>
         <b>
           This will permanently delete all ListenBrainz listens for user {name}.
@@ -93,15 +101,7 @@ export default function DeleteListens() {
         <Link to="/settings/music-services/details/">Disconnect</Link> Spotify
         before deleting.
       </p>
-
-      <p>
-        The listens will not be recoverable. Please consider exporting your
-        ListenBrainz data before deleting your account.
-      </p>
-
-      <ExportButtons feedback={false} />
-      <br />
-
+      
       <button
         id="btn-delete-listens"
         className="btn btn-danger btn-lg"

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -78,7 +78,7 @@ export default function DeleteAccount() {
           This will permanently delete all ListenBrainz data for user {name}.
         </b>
       </p>
-      
+
       <button
         id="btn-delete-user"
         className="btn btn-danger btn-lg"

--- a/frontend/js/src/settings/delete/DeleteAccount.tsx
+++ b/frontend/js/src/settings/delete/DeleteAccount.tsx
@@ -66,19 +66,19 @@ export default function DeleteAccount() {
       </Helmet>
       <h3 className="page-title">Delete account: {name}</h3>
       <p>
-        <b>
-          This will permanently delete all ListenBrainz data for user {name}.
-        </b>
-      </p>
-
-      <p>
-        <b>The data will not be recoverable.</b> Please consider exporting your
+        <b>Deleted data is not recoverable.</b> Consider exporting your
         ListenBrainz data before deleting your account.
       </p>
 
       <ExportButtons />
       <br />
       <p className="text-brand text-danger">This cannot be undone!</p>
+      <p>
+        <b>
+          This will permanently delete all ListenBrainz data for user {name}.
+        </b>
+      </p>
+      
       <button
         id="btn-delete-user"
         className="btn btn-danger btn-lg"

--- a/frontend/js/src/settings/import/ImportListens.tsx
+++ b/frontend/js/src/settings/import/ImportListens.tsx
@@ -4,6 +4,7 @@ import { Link, useLoaderData } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import LastFmImporter from "../../lastfm/LastFMImporter";
 import GlobalAppContext from "../../utils/GlobalAppContext";
+import ReactTooltip from "react-tooltip";
 
 type ImportLoaderData = {
   user_has_email: boolean;
@@ -47,17 +48,20 @@ export default function Import() {
         </div>
       )}
       <p>
-        Import your existing listen history from other databases. To submit{" "}
-        <em>new</em> listens, please visit the{" "}
-        <a href="https://listenbrainz.org/add-data/">Connect services</a> and{" "}
-        <a href="https://listenbrainz.org/settings/music-services/details/">
-          Submitting data
-        </a>{" "}
-        pages.
-        <br />
+        Import your existing listen history from other databases.{" "}
+      <ReactTooltip id="info-tooltip" place="top">
         Fun Fact: The term <strong>scrobble</strong> is a trademarked term by
         Last.fm, and we cannot use it. Instead, we use the term{" "}
         <strong>listen</strong> for our data.
+      </ReactTooltip>
+        <br />
+        To submit{" "}
+        <em>new</em> listens, please visit the{" "}
+        <a href="https://listenbrainz.org/settings/music-services/details/">Connect services</a> and{" "}
+        <a href="https://listenbrainz.org/add-data/">
+          Submitting data
+        </a>{" "}
+        pages.
       </p>
 
       <h3>Import from Last.fm and Libre.fm</h3>

--- a/frontend/js/src/settings/import/ImportListens.tsx
+++ b/frontend/js/src/settings/import/ImportListens.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 
 import { Link, useLoaderData } from "react-router-dom";
 import { Helmet } from "react-helmet";
+import ReactTooltip from "react-tooltip";
 import LastFmImporter from "../../lastfm/LastFMImporter";
 import GlobalAppContext from "../../utils/GlobalAppContext";
-import ReactTooltip from "react-tooltip";
 
 type ImportLoaderData = {
   user_has_email: boolean;
@@ -48,19 +48,23 @@ export default function Import() {
         </div>
       )}
       <p>
-        Import your existing listen history from other databases.{" "}
-      <ReactTooltip id="info-tooltip" place="top">
-        Fun Fact: The term <strong>scrobble</strong> is a trademarked term by
-        Last.fm, and we cannot use it. Instead, we use the term{" "}
-        <strong>listen</strong> for our data.
-      </ReactTooltip>
+        Import your existing{" "}
+        <span className="strong" data-tip data-for="info-tooltip">
+          listen
+        </span>{" "}
+        history from other databases.{" "}
+        <ReactTooltip id="info-tooltip" place="top">
+          Fun Fact: The term <strong>scrobble</strong> is a trademarked term by
+          Last.fm, and we cannot use it.
+          <br />
+          Instead, we use the term <strong>listen</strong> for our data.
+        </ReactTooltip>
         <br />
-        To submit{" "}
-        <em>new</em> listens, please visit the{" "}
-        <a href="https://listenbrainz.org/settings/music-services/details/">Connect services</a> and{" "}
-        <a href="https://listenbrainz.org/add-data/">
-          Submitting data
+        To submit <em>new</em> listens, please visit the{" "}
+        <a href="https://listenbrainz.org/settings/music-services/details/">
+          Connect services
         </a>{" "}
+        and <a href="https://listenbrainz.org/add-data/">Submitting data</a>{" "}
         pages.
       </p>
 


### PR DESCRIPTION
**Import listens page:**
Swapped around the target url's for 'connect services' and 'submitting data'
Moved the Fun fact into a tool tip.

**Delete listens page:**
Separate 'download listens' and 'delete listens' more, by moving relevant text to the corresponding button.

**Delete account page:**
Separate 'download listens/feedback' and 'delete account' more, by moving relevant text to the corresponding button.