### PR TITLE
Album art util: Return early if there is no listen

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -844,6 +844,9 @@ const getAlbumArtFromListenMetadata = async (
   spotifyUser?: SpotifyUser,
   APIService?: APIServiceClass
 ): Promise<string | undefined> => {
+  if (!listen) {
+    return undefined;
+  }
   // if spotifyListen
   if (
     SpotifyPlayer.isListenFromThisService(listen) &&


### PR DESCRIPTION
When clearing the BrainzPlayer queue, the `getAlbumArtFromListenMetadata` async function may be called with an undefined listen, possibly as the async function is run during the component cleanup lifecycle, and as a consequence the expected `listen` argument may be undefined, resulting in an error crashing the page as described in LB-1620 :
> TypeError: Cannot read properties of undefined (reading 'track_metadata')

at https://github.com/metabrainz/listenbrainz-server/blob/38287bb442dd8cae9941826d0b1a44f1f5287fb9/frontend/js/src/utils/utils.tsx#L863-L865

Simple PR to return early with the acceptable value `undefined`  if `listen` is falsy