### PR TITLE
fix: BrainzPlayer Queue Bugs, LB-1623, LB-1624

### DIFF
--- a/frontend/js/src/album/AlbumPage.tsx
+++ b/frontend/js/src/album/AlbumPage.tsx
@@ -345,6 +345,7 @@ export default function AlbumPage(): JSX.Element {
                     window.postMessage(
                       {
                         brainzplayer_event: "play-ambient-queue",
+                        payload: listensFromAlbumsRecordingsFlattened,
                       },
                       window.location.origin
                     );

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -295,6 +295,7 @@ export default function ArtistPage(): JSX.Element {
                     window.postMessage(
                       {
                         brainzplayer_event: "play-ambient-queue",
+                        payload: listensFromPopularRecordings,
                       },
                       window.location.origin
                     );

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -871,15 +871,20 @@ export default function BrainzPlayer() {
     );
   };
 
-  const playAmbientQueue = (): void => {
+  const playAmbientQueue = (tracks: BrainzPlayerQueue): void => {
     // 1. Clear the items in the queue after the current playing track
     const currentPlayingListenIndex = currentListenIndexRef.current;
     dispatch(
       {
-        type: "CLEAR_QUEUE_AFTER_CURRENT",
+        type: "CLEAR_QUEUE_AFTER_CURRENT_AND_SET_AMBIENT_QUEUE",
+        data: tracks,
+        isActivated: true,
       },
       async () => {
-        while (queueRef.current.length !== currentPlayingListenIndex + 1) {
+        while (
+          queueRef.current.length !== currentPlayingListenIndex + 1 &&
+          isActivatedRef.current
+        ) {
           // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
@@ -933,7 +938,7 @@ export default function BrainzPlayer() {
         togglePlay();
         break;
       case "play-ambient-queue":
-        playAmbientQueue();
+        playAmbientQueue(payload);
         break;
       default:
       // do nothing

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -244,6 +244,8 @@ export default function BrainzPlayer() {
   currentListenIndexRef.current = currentListenIndex;
   const playerPausedRef = React.useRef(playerPaused);
   playerPausedRef.current = playerPaused;
+  const continuousPlaybackTimeRef = React.useRef(continuousPlaybackTime);
+  continuousPlaybackTimeRef.current = continuousPlaybackTime;
 
   // Functions
   const alertBeforeClosingPage = (event: BeforeUnloadEvent) => {
@@ -463,7 +465,7 @@ export default function BrainzPlayer() {
         durationMs - SUBMIT_LISTEN_UPDATE_INTERVAL
       );
     }
-    if (continuousPlaybackTime >= playbackTimeRequired) {
+    if (continuousPlaybackTimeRef.current >= playbackTimeRequired) {
       const listen = getListenMetadataToSubmit();
       dispatch({ listenSubmitted: true });
       await submitListenToListenBrainz("single", listen);

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -242,10 +242,12 @@ export default function BrainzPlayer() {
   listenSubmittedRef.current = listenSubmitted;
   const currentListenIndexRef = React.useRef(currentListenIndex);
   currentListenIndexRef.current = currentListenIndex;
+  const playerPausedRef = React.useRef(playerPaused);
+  playerPausedRef.current = playerPaused;
 
   // Functions
   const alertBeforeClosingPage = (event: BeforeUnloadEvent) => {
-    if (!playerPaused) {
+    if (!playerPausedRef.current) {
       // Some old browsers may allow to set a custom message, but this is deprecated.
       event.preventDefault();
       // eslint-disable-next-line no-param-reassign
@@ -793,12 +795,12 @@ export default function BrainzPlayer() {
       },
       () => {
         updateWindowTitleWithTrackName();
-        if (!playerPaused) {
+        if (!playerPausedRef.current) {
           submitNowPlayingToListenBrainz();
         }
       }
     );
-    if (playerPaused) {
+    if (playerPausedRef.current) {
       // Don't send notifications or any of that if the player is not playing
       // (Avoids getting notifications upon pausing a track)
       return;

--- a/frontend/js/src/common/brainzplayer/BrainzPlayerContext.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayerContext.tsx
@@ -73,7 +73,7 @@ export type BrainzPlayerActionType = Partial<BrainzPlayerContextT> & {
     | "SET_PLAYBACK_TIMER"
     | "TOGGLE_REPEAT_MODE"
     | "MOVE_QUEUE_ITEM"
-    | "CLEAR_QUEUE_AFTER_CURRENT"
+    | "CLEAR_QUEUE_AFTER_CURRENT_AND_SET_AMBIENT_QUEUE"
     | "MOVE_AMBIENT_QUEUE_ITEM"
     | "MOVE_AMBIENT_QUEUE_ITEMS_TO_QUEUE"
     | "REMOVE_TRACK_FROM_QUEUE"
@@ -99,7 +99,7 @@ function valueReducer(
         return { ...state, ...action };
       }
       const data = action.data as BrainzPlayerQueue;
-      const { type, data: _, ...restActions } = action;
+      const { data: _, ...restActions } = action;
       const newQueue = [...data].map(listenOrJSPFTrackToQueueItem);
       if (data.length !== 0) {
         return {
@@ -286,12 +286,17 @@ function valueReducer(
         ambientQueue: [...ambientQueue, trackToAdd],
       };
     }
-    case "CLEAR_QUEUE_AFTER_CURRENT": {
+    case "CLEAR_QUEUE_AFTER_CURRENT_AND_SET_AMBIENT_QUEUE": {
       const { currentListenIndex, queue } = state;
       const updatedQueue = queue.slice(0, currentListenIndex + 1);
+      const data = action.data as BrainzPlayerQueue;
+      const { data: _, ...restActions } = action;
+      const newAmbientQueue = [...data].map(listenOrJSPFTrackToQueueItem);
       return {
         ...state,
+        ...restActions,
         queue: updatedQueue,
+        ambientQueue: newAmbientQueue,
       };
     }
     case "MOVE_AMBIENT_QUEUE_ITEMS_TO_QUEUE": {

--- a/frontend/js/src/common/brainzplayer/Queue.tsx
+++ b/frontend/js/src/common/brainzplayer/Queue.tsx
@@ -160,7 +160,12 @@ function Queue(props: BrainzPlayerQueueProps) {
                     track={queueItem}
                     removeTrackFromQueue={(
                       trackToDelete: BrainzPlayerQueueItem
-                    ) => removeTrackFromQueue(trackToDelete, index)}
+                    ) =>
+                      removeTrackFromQueue(
+                        trackToDelete,
+                        index + currentListenIndex + 1
+                      )
+                    }
                   />
                 );
               }


### PR DESCRIPTION
This PR Fixes two issues:
1. LB-1623: Listening to tracks not submitting listens
2. Track not getting deleted from queue
3. LB-1624: "Play Album" button doesn't work on album pages