### PR TITLE
Add a donation page with support tiers

### DIFF
--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -1,24 +1,71 @@
 #donations-page {
     background: @homepage-background;
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-bottom: -20px;
+    padding: 3em 2em;
+    position: relative;
+    .donations-page-header {
+        text-align: center;
+        margin-bottom: 2em;
+    }
+    .donations-page-header,.donations-page-header > h1{
+        color: @white
+    }
+    .donations-page-footer {
+        z-index: 1;
+        position: relative;
+    }
+    .grey-wedge {
+        height: 530px;
+        bottom: 0;
+        clip-path: polygon(100% 100%, 100% 18%,0px 0%, 0% 100%);
+        background: #e9e9e9;
+        position: absolute;
+        left: 0;
+        width: 100%;
+    }
+    .blob {
+        position: absolute;
+        top: 25%;
+        opacity: 70%;
+    }
 }
 
 #donations-tiers {
     position: relative;
+    width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 3em;
     z-index: 1;
     display: flex;
-    gap: 1em;
-    align-items: center;
+    flex-wrap: wrap;
+    gap: 1.5em;
+    align-items: stretch;
+    // height:70vh;
     .tier {
         padding: 1em;
         flex: 1;
-        height: 68vh;
+        flex-basis: 250px;
         scale:1;
+        height: auto;
         &:hover{
-            height:70vh;
             scale: 1.1;
         }
-        background: fadeout(white,20%);
-        transition: scale 0.4s ease-out;
+        background: fadeout(white,30%);
+        transition: scale 0.2s ease-in-out;
+        // blurred glass effect
+        // background: rgba(255, 255, 255, 0.2);
+        border-radius: 16px;
+        box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+        backdrop-filter: blur(5px);
+        -webkit-backdrop-filter: blur(5px);
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        &:first-child {
+            flex-basis: 100%;
+            height: auto;
+        }
     }
     .tier-heading {
         text-align: center;
@@ -26,5 +73,8 @@
         margin-bottom: 1em;
         padding-bottom: 1em;
         border-bottom: 1px solid @gray;
+    }
+    .perk {
+        margin-bottom: 0.5em;
     }
 }

--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -1,80 +1,81 @@
 #donations-page {
-    background: @homepage-background;
-    margin-left: -15px;
-    margin-right: -15px;
-    margin-bottom: -20px;
-    padding: 3em 2em;
+  background: @homepage-background;
+  margin-left: -15px;
+  margin-right: -15px;
+  margin-bottom: -20px;
+  padding: 3em 2em;
+  position: relative;
+  .donations-page-header {
+    text-align: center;
+    margin-bottom: 2em;
+  }
+  .donations-page-header,
+  .donations-page-header > h1 {
+    color: @white;
+  }
+  .donations-page-footer {
+    z-index: 1;
     position: relative;
-    .donations-page-header {
-        text-align: center;
-        margin-bottom: 2em;
-    }
-    .donations-page-header,.donations-page-header > h1{
-        color: @white
-    }
-    .donations-page-footer {
-        z-index: 1;
-        position: relative;
-    }
-    .grey-wedge {
-        height: 530px;
-        bottom: 0;
-        clip-path: polygon(100% 100%, 100% 18%,0px 0%, 0% 100%);
-        background: #e9e9e9;
-        position: absolute;
-        left: 0;
-        width: 100%;
-    }
-    .blob {
-        position: absolute;
-        top: 25%;
-        opacity: 70%;
-    }
+  }
+  .grey-wedge {
+    height: 530px;
+    bottom: 0;
+    clip-path: polygon(100% 100%, 100% 18%, 0px 0%, 0% 100%);
+    background: #e9e9e9;
+    position: absolute;
+    left: 0;
+    width: 100%;
+  }
+  .blob {
+    position: absolute;
+    top: 25%;
+    opacity: 70%;
+  }
 }
 
 #donations-tiers {
-    position: relative;
-    width: 90%;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 3em;
-    z-index: 1;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5em;
-    align-items: stretch;
-    // height:70vh;
-    .tier {
-        padding: 1em;
-        flex: 1;
-        flex-basis: 250px;
-        scale:1;
-        height: auto;
-        &:hover{
-            scale: 1.1;
-        }
-        background: fadeout(white,30%);
-        transition: scale 0.2s ease-in-out;
-        // blurred glass effect
-        // background: rgba(255, 255, 255, 0.2);
-        border-radius: 16px;
-        box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-        backdrop-filter: blur(5px);
-        -webkit-backdrop-filter: blur(5px);
-        border: 1px solid rgba(255, 255, 255, 0.3);
-        &:first-child {
-            flex-basis: 100%;
-            height: auto;
-        }
+  position: relative;
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 3em;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5em;
+  align-items: stretch;
+  // height:70vh;
+  .tier {
+    padding: 1em;
+    flex: 1;
+    flex-basis: 250px;
+    scale: 1;
+    height: auto;
+    &:hover {
+      scale: 1.1;
     }
-    .tier-heading {
-        text-align: center;
-        min-height: 150px;
-        margin-bottom: 1em;
-        padding-bottom: 1em;
-        border-bottom: 1px solid @gray;
+    background: fadeout(white, 30%);
+    transition: scale 0.2s ease-in-out;
+    // blurred glass effect
+    // background: rgba(255, 255, 255, 0.2);
+    border-radius: 16px;
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    &:first-child {
+      flex-basis: 100%;
+      height: auto;
     }
-    .perk {
-        margin-bottom: 0.5em;
-    }
+  }
+  .tier-heading {
+    text-align: center;
+    min-height: 150px;
+    margin-bottom: 1em;
+    padding-bottom: 1em;
+    border-bottom: 1px solid @gray;
+  }
+  .perk {
+    margin-bottom: 0.5em;
+  }
 }

--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -44,7 +44,9 @@
   flex-wrap: wrap;
   gap: 1.5em;
   align-items: stretch;
-  // height:70vh;
+  ul {
+    margin-left: 1.5em;
+  }
   .tier {
     padding: 1em;
     flex: 1;

--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -70,10 +70,7 @@
   }
   .tier-heading {
     text-align: center;
-    min-height: 150px;
-    margin-bottom: 1em;
-    padding-bottom: 1em;
-    border-bottom: 1px solid @gray;
+    margin-bottom: 1.5em;
   }
   .perk {
     margin-bottom: 0.5em;

--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -8,8 +8,6 @@
   .donations-page-header {
     text-align: center;
     margin-bottom: 2em;
-  }
-  .donations-page-header{
     color: @white;
     font-size: 24px;
   }

--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -9,9 +9,9 @@
     text-align: center;
     margin-bottom: 2em;
   }
-  .donations-page-header,
-  .donations-page-header > h1 {
+  .donations-page-header{
     color: @white;
+    font-size: 24px;
   }
   .donations-page-footer {
     z-index: 1;

--- a/frontend/css/donations.less
+++ b/frontend/css/donations.less
@@ -1,0 +1,30 @@
+#donations-page {
+    background: @homepage-background;
+}
+
+#donations-tiers {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    gap: 1em;
+    align-items: center;
+    .tier {
+        padding: 1em;
+        flex: 1;
+        height: 68vh;
+        scale:1;
+        &:hover{
+            height:70vh;
+            scale: 1.1;
+        }
+        background: fadeout(white,20%);
+        transition: scale 0.4s ease-out;
+    }
+    .tier-heading {
+        text-align: center;
+        min-height: 150px;
+        margin-bottom: 1em;
+        padding-bottom: 1em;
+        border-bottom: 1px solid @gray;
+    }
+}

--- a/frontend/css/donors-page.less
+++ b/frontend/css/donors-page.less
@@ -91,7 +91,7 @@
       color: @black;
       font-weight: bold;
       margin-left: 2em;
-      &.btn{
+      &.btn {
         border-radius: @border-radius-base;
       }
     }
@@ -106,6 +106,31 @@
     canvas {
       position: absolute;
       opacity: 0.5;
+    }
+  }
+}
+
+.recent-donor-card {
+  gap: 1rem;
+  > div {
+    width: 150px;
+  }
+  .user-link {
+    word-wrap: break-word;
+  }
+  .donor-pinned-recording {
+    display: flex;
+    align-items: center;
+    background: #edf2f7;
+    gap: 0.5rem;
+    margin-left: auto;
+    border-radius: 10px;
+    .text {
+      color: #6b7280;
+      text-wrap: wrap;
+    }
+    svg {
+      color: #353070;
     }
   }
 }

--- a/frontend/css/donors-page.less
+++ b/frontend/css/donors-page.less
@@ -80,5 +80,32 @@
 }
 
 #donors {
-  margin-top: 1.5em;
+  margin-top: 15px;
+  .donations-page-header {
+    .donation-header-text {
+      position: relative;
+      color: @white;
+      font-size: 16px;
+    }
+    a {
+      color: @black;
+      font-weight: bold;
+      margin-left: 2em;
+      &.btn{
+        border-radius: @border-radius-base;
+      }
+    }
+    opacity: 0.85;
+    border-radius: @border-radius-large;
+    background: @homepage-background;
+    padding: 3em 2em;
+    position: relative;
+    text-align: center;
+    margin-bottom: 2em;
+    overflow: hidden;
+    canvas {
+      position: absolute;
+      opacity: 0.5;
+    }
+  }
 }

--- a/frontend/css/homepage.less
+++ b/frontend/css/homepage.less
@@ -1,10 +1,10 @@
 @dark-grey: #46433a;
 @even-darker-grey: #353070;
 @homepage-background: linear-gradient(
-      288deg,
-      @dark-grey 16.96%,
-      @even-darker-grey 98.91%
-    );
+  288deg,
+  @dark-grey 16.96%,
+  @even-darker-grey 98.91%
+);
 #homepage-container {
   overflow-y: auto;
   height: 100vh; // absolute fallback

--- a/frontend/css/homepage.less
+++ b/frontend/css/homepage.less
@@ -1,5 +1,10 @@
 @dark-grey: #46433a;
 @even-darker-grey: #353070;
+@homepage-background: linear-gradient(
+      288deg,
+      @dark-grey 16.96%,
+      @even-darker-grey 98.91%
+    );
 #homepage-container {
   overflow-y: auto;
   height: 100vh; // absolute fallback
@@ -16,11 +21,7 @@
   }
 
   .homepage-upper {
-    background: linear-gradient(
-      288deg,
-      @dark-grey 16.96%,
-      @even-darker-grey 98.91%
-    );
+    background: @homepage-background;
     height: 100%;
     position: relative;
     padding-left: 50px;
@@ -118,11 +119,7 @@
   }
 
   .homepage-lower {
-    background: linear-gradient(
-      288deg,
-      @dark-grey 16.96%,
-      @even-darker-grey 98.91%
-    );
+    background: @homepage-background;
     height: 100%;
     position: relative;
     padding-left: 50px;

--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -39,6 +39,7 @@
 @import "search.less";
 @import "accordion.less";
 @import "donors-page.less";
+@import "donations.less";
 
 @icon-font-path: "/static/fonts/";
 

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -38,9 +38,12 @@ export default function Data() {
                 <b>Free for everyone</b>
               </h2>
             </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>All website features, for free, forever</b>
+            <div>
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
+              <b style={{ marginLeft: "0.5em" }}>
+                All website features, for free, forever
+              </b>
+              <br />
             </div>
           </div>
           <div className="tier card">
@@ -61,23 +64,36 @@ export default function Data() {
                 Donate
               </button>
             </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>All website features, for free, forever</b>
-            </div>
-
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>User flair</b>
-              <br />
-              <small>
-                Add a special effect to your username on the website
-              </small>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>Our eternal gratitude</b>
-            </div>
+            <ul className="fa-ul">
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>All website features, for free, forever</b>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>User flair</b>
+                <br />
+                <small>
+                  Add a special effect to your username on the website
+                </small>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Our eternal gratitude</b>
+              </li>
+            </ul>
           </div>
           <div className="tier card">
             <div className="tier-heading">
@@ -97,28 +113,45 @@ export default function Data() {
                 Donate
               </button>
             </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>All website features, for free, forever</b>
-            </div>
+            <ul className="fa-ul">
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>All website features, for free, forever</b>
+              </li>
 
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>User flair</b>
-              <br />
-              <small>
-                Add a special effect to your username on the website
-              </small>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>Our eternal gratitude</b>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
-              &nbsp;
-              <b>Inner sense of peace and accomplishment</b>
-            </div>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>User flair</b>
+                <br />
+                <small>
+                  Add a special effect to your username on the website
+                </small>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Our eternal gratitude</b>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Inner sense of peace and accomplishment</b>
+              </li>
+            </ul>
           </div>
           <div className="tier card">
             <div className="tier-heading">
@@ -138,48 +171,71 @@ export default function Data() {
                 Donate
               </button>
             </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>All website features, for free, forever</b>
-            </div>
+            <ul className="fa-ul">
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>All website features, for free, forever</b>
+              </li>
 
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>User flair</b>
-              <br />
-              <small>
-                Add a special effect to your username on the website
-              </small>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
-              <b>Our eternal gratitude</b>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
-              &nbsp;
-              <b>Inner sense of peace and accomplishment</b>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
-              &nbsp;
-              <b>Make your momma proud</b>
-              <br />
-              <small>Or maybe show her you haven&apos;t changed</small>
-            </div>
-            <div className="perk">
-              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
-              &nbsp;
-              <b>Bragging rights</b>
-              <br />
-              <small>
-                When we have taken over the world, you can proudly say
-                <i>
-                  &ldquo;I helped our music recommendation overlords get to
-                  where they are today&rdquo;
-                </i>
-              </small>
-            </div>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>User flair</b>
+                <br />
+                <small>
+                  Add a special effect to your username on the website
+                </small>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Our eternal gratitude</b>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Inner sense of peace and accomplishment</b>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Make your momma proud</b>
+                <br />
+                <small>Or maybe show her you haven&apos;t changed</small>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>Bragging rights</b>
+                <br />
+                <small>
+                  When we have taken over the world, you can proudly say
+                  <i>
+                    &ldquo;I helped our music recommendation overlords get to
+                    where they are today&rdquo;
+                  </i>
+                </small>
+              </li>
+            </ul>
           </div>
         </div>
         <div className="donations-page-footer">

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -2,20 +2,41 @@ import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
 import { COLOR_LB_GREEN } from "../../utils/constants";
+import Blob from "../../home/Blob";
 
 export default function Data() {
   return (
     <div id="donations-page">
-      <div className="">
-        <h1>Money can’t buy happiness, but it can buy LISTENBRAINZ HOSTING</h1>
-        <p>
-          ListenBrainz is open-source and non-profit, and you can help us
-          survive and thrive with repeating or one-time donations.
-        </p>
+      <Blob width={250} height={250} randomness={1.5} className="blob" />
+      <Blob
+        width={250}
+        height={250}
+        randomness={1.1}
+        className="blob"
+        style={{ top: "45%", right: "15%" }}
+      />
+      <div>
+        <div className="donations-page-header">
+          <h1>
+            Money can&apos;t buy happiness, but it can buy
+            <br />
+            <span style={{ fontWeight: 600 }}>LISTENBRAINZ HOSTING</span>
+          </h1>
+          <p>
+            ListenBrainz is a free, open-source and non-profit project.
+            <br />
+            If you enjoy it, you can help us survive and thrive with your
+            donations.
+            <br />
+            At our scale, every contribution matters.
+          </p>
+        </div>
         <div id="donations-tiers">
-          <div className="tier card">
-            <div className="tier-heading">
-              <h3>Free</h3>
+          <div className="tier card text-center">
+            <div>
+              <h2>
+                <b>Free for everyone</b>
+              </h2>
             </div>
             <div className="perk">
               <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
@@ -24,9 +45,15 @@ export default function Data() {
           </div>
           <div className="tier card">
             <div className="tier-heading">
-              <h3>10$ donation</h3>
+              <h2>
+                <b>5$</b>
+                <br />
+                donation
+              </h2>
               <br />
-              <button type="button">Donate here</button>
+              <button type="button" className="btn btn-primary">
+                Donate
+              </button>
             </div>
             <div className="perk">
               <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
@@ -38,8 +65,37 @@ export default function Data() {
               <b>User flair</b>
               <br />
               <small>
-                Your username will appear with a special effect on the website
-                for everyone to see
+                Add a special effect to your username on the website
+              </small>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>Our eternal gratitude</b>
+            </div>
+          </div>
+          <div className="tier card">
+            <div className="tier-heading">
+              <h2>
+                <b>20$</b>
+                <br />
+                donation
+              </h2>
+              <br />
+              <button type="button" className="btn btn-primary">
+                Donate
+              </button>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>All website features, for free, forever</b>
+            </div>
+
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>User flair</b>
+              <br />
+              <small>
+                Add a special effect to your username on the website
               </small>
             </div>
             <div className="perk">
@@ -54,9 +110,15 @@ export default function Data() {
           </div>
           <div className="tier card">
             <div className="tier-heading">
-              <h3>50$ donation</h3>
+              <h2>
+                <b>50$</b>
+                <br />
+                donation
+              </h2>
               <br />
-              <button type="button">Donate here</button>
+              <button type="button" className="btn btn-primary">
+                Donate
+              </button>
             </div>
             <div className="perk">
               <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
@@ -68,8 +130,7 @@ export default function Data() {
               <b>User flair</b>
               <br />
               <small>
-                Your username will appear with a special effect on the website
-                for everyone to see
+                Add a special effect to your username on the website
               </small>
             </div>
             <div className="perk">
@@ -86,9 +147,7 @@ export default function Data() {
               &nbsp;
               <b>Make your momma proud</b>
               <br />
-              <small>
-                Or maybe show her you haven&apos;t changed, depending.
-              </small>
+              <small>Or maybe show her you haven&apos;t changed</small>
             </div>
             <div className="perk">
               <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
@@ -96,8 +155,7 @@ export default function Data() {
               <b>Bragging rights</b>
               <br />
               <small>
-                When we have taken over the world, you&apos;ll be able to
-                proudly say
+                When we have taken over the world, you can proudly say
                 <i>
                   &ldquo;I helped our music recommendation overlords get to
                   where they are today&rdquo;
@@ -106,42 +164,32 @@ export default function Data() {
             </div>
           </div>
         </div>
-        <hr />
-        <h3>Jokes aside</h3>
-        <p>
-          We believe in creating a free service for all where you do not pay
-          with your personal information and where <b>you</b> do not
-          become the product like so many other online services.
-          <br />
-          Similarly, we want all features to ba available to everyone, and steer
-          away from a pay-to-play, &quot;ListenBrainz Pro++&quot; model.
-        </p>
-        <p>
-          Of course, hosting and developing such a service costs money in the
-          real world, and we are not exempt from that reality. All the
-          information (listening history, popularity, etc.) is available
-          publicly and for free to anyone, but commercial entities are expected to support us
-          financially. That is not quite enough to pay for everything or to have
-          the resources we need to create the features you request.
-        </p>
-        <p>
-          Please consider joining thousands of passionate contributors with a
-          one-time or regular donation. You will be helping this ecosystem
-          grow into an honest archipelago of music lovers.
-        </p>
+        <div className="donations-page-footer">
+          <h3>Jokes aside</h3>
+          <p>
+            Join our music network, where <b>you aren&apos;t the product</b> and
+            your personal data isn&apos;t the price you pay.
+            <br />
+            We believe everyone should have access to all features —no paywalls,
+            no “Pro++” features.
+            <br />
+            <b>All features are free for everyone.</b>
+            <br />
+            <br />
+            While it takes real-world money to keep us going, all our data is
+            open-srouce and free for everyone.
+            <br />
+            Commercial users are expected to contribute back and support us, but
+            it&apos;s not enough to fund the new features you want.
+            <br />
+            <br />
+            By donating —either once or regularly— you&apos;ll join thousands of
+            music lovers in helping us build an honest, unbiased and
+            community-driven space for music discovery.
+          </p>
+        </div>
       </div>
-      <div
-        style={{
-          height: "65%",
-          bottom: 0,
-          clipPath: "polygon(0 25%, 100% 0, 100% 100%, 0% 100%)",
-          background: "#e9e9e9",
-          position: "absolute",
-          left: 0,
-          width: "100%",
-          zIndex: 0,
-        }}
-      />
+      <div className="grey-wedge" />
     </div>
   );
 }

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -17,11 +17,11 @@ export default function Data() {
       />
       <div>
         <div className="donations-page-header">
-          <h1>
+          <h2>
             Money can&apos;t buy happiness, but it can buy
             <br />
             <span style={{ fontWeight: 600 }}>LISTENBRAINZ HOSTING</span>
-          </h1>
+          </h2>
           <p>
             ListenBrainz is a free, open-source and non-profit project.
             <br />
@@ -49,30 +49,18 @@ export default function Data() {
           <div className="tier card">
             <div className="tier-heading">
               <h2>
-                <b>5$</b>
-                <br />
-                donation
-              </h2>
-              <br />
               <button
                 type="button"
                 className="btn btn-primary"
                 onClick={() =>
                   window.open("https://metabrainz.org/donate", "_blank")
                 }
-              >
-                Donate
+                >
+                Donate $5
               </button>
+              </h2>
             </div>
             <ul className="fa-ul">
-              <li className="perk">
-                <FontAwesomeIcon
-                  listItem
-                  icon={faCheck}
-                  color={COLOR_LB_GREEN}
-                />
-                <b>All website features, for free, forever</b>
-              </li>
               <li className="perk">
                 <FontAwesomeIcon
                   listItem
@@ -98,11 +86,6 @@ export default function Data() {
           <div className="tier card">
             <div className="tier-heading">
               <h2>
-                <b>20$</b>
-                <br />
-                donation
-              </h2>
-              <br />
               <button
                 type="button"
                 className="btn btn-primary"
@@ -110,19 +93,11 @@ export default function Data() {
                   window.open("https://metabrainz.org/donate", "_blank")
                 }
               >
-                Donate
+                Donate $20
               </button>
+                </h2>
             </div>
             <ul className="fa-ul">
-              <li className="perk">
-                <FontAwesomeIcon
-                  listItem
-                  icon={faCheck}
-                  color={COLOR_LB_GREEN}
-                />
-                <b>All website features, for free, forever</b>
-              </li>
-
               <li className="perk">
                 <FontAwesomeIcon
                   listItem
@@ -156,11 +131,6 @@ export default function Data() {
           <div className="tier card">
             <div className="tier-heading">
               <h2>
-                <b>50$</b>
-                <br />
-                donation
-              </h2>
-              <br />
               <button
                 type="button"
                 className="btn btn-primary"
@@ -168,19 +138,11 @@ export default function Data() {
                   window.open("https://metabrainz.org/donate", "_blank")
                 }
               >
-                Donate
+                Donate $50
               </button>
+              </h2>
             </div>
             <ul className="fa-ul">
-              <li className="perk">
-                <FontAwesomeIcon
-                  listItem
-                  icon={faCheck}
-                  color={COLOR_LB_GREEN}
-                />
-                <b>All website features, for free, forever</b>
-              </li>
-
               <li className="perk">
                 <FontAwesomeIcon
                   listItem
@@ -215,9 +177,7 @@ export default function Data() {
                   icon={faCheck}
                   color={COLOR_LB_GREEN}
                 />
-                <b>Make your momma proud</b>
-                <br />
-                <small>Or maybe show her you haven&apos;t changed</small>
+                <b>Make your family proud</b>
               </li>
               <li className="perk">
                 <FontAwesomeIcon
@@ -225,15 +185,15 @@ export default function Data() {
                   icon={faCheck}
                   color={COLOR_LB_GREEN}
                 />
-                <b>Bragging rights</b>
-                <br />
-                <small>
-                  When we have taken over the world, you can proudly say
-                  <i>
-                    &ldquo;I helped our music recommendation overlords get to
-                    where they are today&rdquo;
-                  </i>
-                </small>
+                <b>Instant street cred</b>
+              </li>
+              <li className="perk">
+                <FontAwesomeIcon
+                  listItem
+                  icon={faCheck}
+                  color={COLOR_LB_GREEN}
+                />
+                <b>De-shittify the internet</b>
               </li>
             </ul>
           </div>
@@ -248,13 +208,6 @@ export default function Data() {
             no “Pro++” features.
             <br />
             <b>All features are free for everyone.</b>
-            <br />
-            <br />
-            While it takes real-world money to keep us going, all our data is
-            open-source and free for everyone.
-            <br />
-            Commercial users are expected to contribute back and support us, but
-            it&apos;s not enough to fund the new features you want.
             <br />
             <br />
             By donating —either once or regularly— you&apos;ll join thousands of

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -51,7 +51,13 @@ export default function Data() {
                 donation
               </h2>
               <br />
-              <button type="button" className="btn btn-primary">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() =>
+                  window.open("https://metabrainz.org/donate", "_blank")
+                }
+              >
                 Donate
               </button>
             </div>
@@ -81,7 +87,13 @@ export default function Data() {
                 donation
               </h2>
               <br />
-              <button type="button" className="btn btn-primary">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() =>
+                  window.open("https://metabrainz.org/donate", "_blank")
+                }
+              >
                 Donate
               </button>
             </div>
@@ -116,7 +128,13 @@ export default function Data() {
                 donation
               </h2>
               <br />
-              <button type="button" className="btn btn-primary">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() =>
+                  window.open("https://metabrainz.org/donate", "_blank")
+                }
+              >
                 Donate
               </button>
             </div>

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -1,0 +1,147 @@
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import * as React from "react";
+import { COLOR_LB_GREEN } from "../../utils/constants";
+
+export default function Data() {
+  return (
+    <div id="donations-page">
+      <div className="">
+        <h1>Money can’t buy happiness, but it can buy LISTENBRAINZ HOSTING</h1>
+        <p>
+          ListenBrainz is open-source and non-profit, and you can help us
+          survive and thrive with repeating or one-time donations.
+        </p>
+        <div id="donations-tiers">
+          <div className="tier card">
+            <div className="tier-heading">
+              <h3>Free</h3>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>All website features, for free, forever</b>
+            </div>
+          </div>
+          <div className="tier card">
+            <div className="tier-heading">
+              <h3>10$ donation</h3>
+              <br />
+              <button type="button">Donate here</button>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>All website features, for free, forever</b>
+            </div>
+
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>User flair</b>
+              <br />
+              <small>
+                Your username will appear with a special effect on the website
+                for everyone to see
+              </small>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>Our eternal gratitude</b>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
+              &nbsp;
+              <b>Inner sense of peace and accomplishment</b>
+            </div>
+          </div>
+          <div className="tier card">
+            <div className="tier-heading">
+              <h3>50$ donation</h3>
+              <br />
+              <button type="button">Donate here</button>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>All website features, for free, forever</b>
+            </div>
+
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>User flair</b>
+              <br />
+              <small>
+                Your username will appear with a special effect on the website
+                for everyone to see
+              </small>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />{" "}
+              <b>Our eternal gratitude</b>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
+              &nbsp;
+              <b>Inner sense of peace and accomplishment</b>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
+              &nbsp;
+              <b>Make your momma proud</b>
+              <br />
+              <small>
+                Or maybe show her you haven&apos;t changed, depending.
+              </small>
+            </div>
+            <div className="perk">
+              <FontAwesomeIcon icon={faCheck} color={COLOR_LB_GREEN} />
+              &nbsp;
+              <b>Bragging rights</b>
+              <br />
+              <small>
+                When we have taken over the world, you&apos;ll be able to
+                proudly say
+                <i>
+                  &ldquo;I helped our music recommendation overlords get to
+                  where they are today&rdquo;
+                </i>
+              </small>
+            </div>
+          </div>
+        </div>
+        <hr />
+        <h3>Jokes aside</h3>
+        <p>
+          We believe in creating a free service for all where you do not pay
+          with your personal information and where <b>you</b> do not
+          become the product like so many other online services.
+          <br />
+          Similarly, we want all features to ba available to everyone, and steer
+          away from a pay-to-play, &quot;ListenBrainz Pro++&quot; model.
+        </p>
+        <p>
+          Of course, hosting and developing such a service costs money in the
+          real world, and we are not exempt from that reality. All the
+          information (listening history, popularity, etc.) is available
+          publicly and for free to anyone, but commercial entities are expected to support us
+          financially. That is not quite enough to pay for everything or to have
+          the resources we need to create the features you request.
+        </p>
+        <p>
+          Please consider joining thousands of passionate contributors with a
+          one-time or regular donation. You will be helping this ecosystem
+          grow into an honest archipelago of music lovers.
+        </p>
+      </div>
+      <div
+        style={{
+          height: "65%",
+          bottom: 0,
+          clipPath: "polygon(0 25%, 100% 0, 100% 100%, 0% 100%)",
+          background: "#e9e9e9",
+          position: "absolute",
+          left: 0,
+          width: "100%",
+          zIndex: 0,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -41,9 +41,12 @@ export default function Donate() {
               <h2>
                 <button
                   type="button"
-                  className="btn btn-primary"
+                  className="btn btn-success btn-lg btn-rounded"
                   onClick={() =>
-                    window.open("https://metabrainz.org/donate", "_blank")
+                    window.open(
+                      "https://metabrainz.org/donate?amount=5",
+                      "_blank"
+                    )
                   }
                 >
                   Donate $5
@@ -78,9 +81,12 @@ export default function Donate() {
               <h2>
                 <button
                   type="button"
-                  className="btn btn-primary"
+                  className="btn btn-success btn-lg btn-rounded"
                   onClick={() =>
-                    window.open("https://metabrainz.org/donate", "_blank")
+                    window.open(
+                      "https://metabrainz.org/donate?amount=20",
+                      "_blank"
+                    )
                   }
                 >
                   Donate $20
@@ -123,9 +129,12 @@ export default function Donate() {
               <h2>
                 <button
                   type="button"
-                  className="btn btn-primary"
+                  className="btn btn-success btn-lg btn-rounded"
                   onClick={() =>
-                    window.open("https://metabrainz.org/donate", "_blank")
+                    window.open(
+                      "https://metabrainz.org/donate?amount=50",
+                      "_blank"
+                    )
                   }
                 >
                   Donate $50

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -195,7 +195,7 @@ export default function Data() {
             <br />
             <br />
             While it takes real-world money to keep us going, all our data is
-            open-srouce and free for everyone.
+            open-source and free for everyone.
             <br />
             Commercial users are expected to contribute back and support us, but
             it&apos;s not enough to fund the new features you want.

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { COLOR_LB_GREEN } from "../../utils/constants";
 import Blob from "../../home/Blob";
 
-export default function Data() {
+export default function Donate() {
   return (
     <div id="donations-page">
       <Blob width={250} height={250} randomness={1.5} className="blob" />
@@ -17,19 +17,9 @@ export default function Data() {
       />
       <div>
         <div className="donations-page-header">
-          <h2>
-            Money can&apos;t buy happiness, but it can buy
-            <br />
-            <span style={{ fontWeight: 600 }}>LISTENBRAINZ HOSTING</span>
-          </h2>
-          <p>
-            ListenBrainz is a free, open-source and non-profit project.
-            <br />
-            If you enjoy it, you can help us survive and thrive with your
-            donations.
-            <br />
-            At our scale, every contribution matters.
-          </p>
+          Money can&apos;t buy happiness, but it can buy
+          <br />
+          <span style={{ fontWeight: 600 }}>LISTENBRAINZ HOSTING</span>
         </div>
         <div id="donations-tiers">
           <div className="tier card text-center">
@@ -49,15 +39,15 @@ export default function Data() {
           <div className="tier card">
             <div className="tier-heading">
               <h2>
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={() =>
-                  window.open("https://metabrainz.org/donate", "_blank")
-                }
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() =>
+                    window.open("https://metabrainz.org/donate", "_blank")
+                  }
                 >
-                Donate $5
-              </button>
+                  Donate $5
+                </button>
               </h2>
             </div>
             <ul className="fa-ul">
@@ -86,16 +76,16 @@ export default function Data() {
           <div className="tier card">
             <div className="tier-heading">
               <h2>
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={() =>
-                  window.open("https://metabrainz.org/donate", "_blank")
-                }
-              >
-                Donate $20
-              </button>
-                </h2>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() =>
+                    window.open("https://metabrainz.org/donate", "_blank")
+                  }
+                >
+                  Donate $20
+                </button>
+              </h2>
             </div>
             <ul className="fa-ul">
               <li className="perk">
@@ -131,15 +121,15 @@ export default function Data() {
           <div className="tier card">
             <div className="tier-heading">
               <h2>
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={() =>
-                  window.open("https://metabrainz.org/donate", "_blank")
-                }
-              >
-                Donate $50
-              </button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() =>
+                    window.open("https://metabrainz.org/donate", "_blank")
+                  }
+                >
+                  Donate $50
+                </button>
               </h2>
             </div>
             <ul className="fa-ul">
@@ -213,6 +203,8 @@ export default function Data() {
             By donating —either once or regularly— you&apos;ll join thousands of
             music lovers in helping us build an honest, unbiased and
             community-driven space for music discovery.
+            <br />
+            At our scale, every contribution matters.
           </p>
         </div>
       </div>

--- a/frontend/js/src/about/layout.tsx
+++ b/frontend/js/src/about/layout.tsx
@@ -10,6 +10,7 @@ type Section = {
 
 const sections: Section[] = [
   { to: "about/", label: "About" },
+  { to: "donate/", label: "Donate" },
   { to: "current-status/", label: "Site status" },
   { to: "add-data/", label: "Submitting data" },
   { to: "data/", label: "Using our data" },

--- a/frontend/js/src/about/routes/index.tsx
+++ b/frontend/js/src/about/routes/index.tsx
@@ -52,6 +52,13 @@ const getAboutRoutes = (): RouteObject[] => {
         },
       ],
     },
+    {
+      path: "donate/",
+      lazy: async () => {
+        const Donate = await import("../donations/Donate");
+        return { Component: Donate.default };
+      },
+    },
   ];
   return routes;
 };

--- a/frontend/js/src/components/Navbar.tsx
+++ b/frontend/js/src/components/Navbar.tsx
@@ -117,7 +117,7 @@ function Navbar() {
             About
           </NavLink>
           <NavLink to="/donors/" onClick={toggleSidebar}>
-            Donors
+            Donations
           </NavLink>
           <a
             href="https://community.metabrainz.org/c/listenbrainz"

--- a/frontend/js/src/donors/Donors.tsx
+++ b/frontend/js/src/donors/Donors.tsx
@@ -13,6 +13,7 @@ import Pagination from "../common/Pagination";
 import { getObjectForURLSearchParams } from "../utils/utils";
 import { RouteQuery } from "../utils/Loader";
 import Loader from "../components/Loader";
+import Blob from "../home/Blob";
 
 type DonorLoaderData = {
   data: {
@@ -71,6 +72,51 @@ function Donors() {
 
   return (
     <div role="main" id="donors">
+      <div className="donations-page-header">
+        <Blob
+          seed={42}
+          blur={8}
+          width={175}
+          height={175}
+          randomness={0.4}
+          className="blob"
+          style={{ left: "50%", top: "42%" }}
+        />
+        <Blob
+          seed={13}
+          blur={8}
+          width={250}
+          height={250}
+          randomness={0.8}
+          className="blob"
+          style={{ left: "12%", top: "-60%" }}
+        />
+        <Blob
+          seed={1234}
+          blur={8}
+          width={75}
+          height={75}
+          randomness={0.9}
+          className="blob"
+          style={{ right: "18%", top: "15%" }}
+        />
+        <Blob
+          seed={123}
+          blur={8}
+          width={150}
+          height={150}
+          randomness={0.5}
+          className="blob"
+          style={{ right: "0", top: "10%" }}
+        />
+        <div className="donation-header-text">
+          Money can&apos;t buy happiness, but it can buy&nbsp;
+          <span style={{ fontWeight: 600 }}>LISTENBRAINZ HOSTING</span>
+          <Link to="/donate" className="btn btn-warning">
+            Donate
+          </Link>
+        </div>
+      </div>
       <div className="listen-header">
         <h2 className="header-with-line">Donations</h2>
         <div className="flex" role="group" aria-label="Sort by">

--- a/frontend/js/src/donors/Donors.tsx
+++ b/frontend/js/src/donors/Donors.tsx
@@ -16,16 +16,7 @@ import Loader from "../components/Loader";
 import Blob from "../home/Blob";
 
 type DonorLoaderData = {
-  data: {
-    id: number;
-    donated_at: string;
-    donation: number;
-    currency: "usd" | "eur";
-    musicbrainz_id: string;
-    is_listenbrainz_user: boolean;
-    listenCount: number;
-    playlistCount: number;
-  }[];
+  data: DonationInfo[];
   totalPageCount: number;
 };
 

--- a/frontend/js/src/home/Blob.tsx
+++ b/frontend/js/src/home/Blob.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import * as blobs2Animate from "blobs/v2/animate";
+import { isUndefined } from "lodash";
 
 type BlobProps = {
   width: number;
   height: number;
   randomness: number;
+  seed?: number;
+  blur?: number;
   style?: React.CSSProperties;
 } & Pick<HTMLCanvasElement, "className">;
 
@@ -13,6 +16,8 @@ export default function Blob({
   height,
   className,
   randomness,
+  seed,
+  blur,
   style,
 }: BlobProps) {
   const blobCanvas = React.useRef<HTMLCanvasElement>(null);
@@ -24,7 +29,9 @@ export default function Blob({
     }
     const animation = blobs2Animate.canvasPath();
     const randomAngleStart = Math.random() * 360;
-
+    if (!isUndefined(blur) && Number.isFinite(blur)) {
+      ctx.filter = `blur(${blur}px)`;
+    }
     const renderAnimation: FrameRequestCallback = (time) => {
       ctx.clearRect(0, 0, width, height);
       let angle = (((time / 50) % 360) / 180) * Math.PI;
@@ -43,20 +50,26 @@ export default function Blob({
     };
     requestAnimationFrame(renderAnimation);
 
-    const size = Math.min(width, height);
-
+    let size = Math.min(width, height);
+    let offsetX = 0;
+    let offsetY = 0;
+    if (!isUndefined(blur) && Number.isFinite(blur)) {
+      size -= blur * 2;
+      offsetX = blur;
+      offsetY = blur;
+    }
     blobs2Animate.wigglePreset(
       animation,
       {
-        seed: Date.now(),
+        seed: seed ?? Date.now(),
         extraPoints: 3,
         randomness: randomness * 2,
         size,
       },
-      { offsetX: 0, offsetY: 0 },
+      { offsetX, offsetY },
       { speed: Math.random() * 1.7 }
     );
-  }, [blobCanvas, height, width, randomness]);
+  }, [blobCanvas, height, width, randomness, blur, seed]);
 
   return (
     <canvas

--- a/frontend/js/src/recent/RecentListens.tsx
+++ b/frontend/js/src/recent/RecentListens.tsx
@@ -9,11 +9,13 @@ import Card from "../components/Card";
 
 import { getTrackName } from "../utils/utils";
 import { useBrainzPlayerDispatch } from "../common/brainzplayer/BrainzPlayerContext";
+import RecentDonorsCard from "./components/RecentDonors";
 
 export type RecentListensProps = {
   listens: Array<Listen>;
   globalListenCount: number;
   globalUserCount: string;
+  recentDonors: Array<DonationInfoWithPinnedRecording>;
 };
 
 type RecentListensLoaderData = RecentListensProps;
@@ -36,7 +38,7 @@ export default class RecentListens extends React.Component<
 
   render() {
     const { listens } = this.state;
-    const { globalListenCount, globalUserCount } = this.props;
+    const { globalListenCount, globalUserCount, recentDonors } = this.props;
 
     return (
       <div role="main">
@@ -55,12 +57,15 @@ export default class RecentListens extends React.Component<
                 <small className="text-muted">songs played</small>
               </div>
             </Card>
-            <Card id="listen-count-card">
+            <Card id="listen-count-card" className="card-user-sn">
               <div>
                 {globalUserCount ?? "-"}
                 <br />
                 <small className="text-muted">users</small>
               </div>
+            </Card>
+            <Card className="hidden-xs card-user-sn">
+              <RecentDonorsCard donors={recentDonors} />
             </Card>
           </div>
           <div className="col-md-8 col-md-pull-4">

--- a/frontend/js/src/recent/components/RecentDonors.tsx
+++ b/frontend/js/src/recent/components/RecentDonors.tsx
@@ -1,0 +1,87 @@
+import { faThumbtack } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import * as React from "react";
+import { Link } from "react-router-dom";
+import {
+  getRecordingMBID,
+  getTrackName,
+  pinnedRecordingToListen,
+} from "../../utils/utils";
+
+type RecentDonorsCardProps = {
+  donors: DonationInfoWithPinnedRecording[];
+};
+
+function RecentDonorsCard(props: RecentDonorsCardProps) {
+  const { donors } = props;
+
+  if (!donors || donors.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <h3 className="text-center" style={{ marginTop: "10px" }}>
+        Recent Donors
+        <br />
+        <small>
+          <Link to="/donors/">See all donations</Link>
+        </small>
+      </h3>
+      <div className="similar-users-list">
+        {donors &&
+          donors.map((donor) => {
+            const pinnedRecordingListen = donor.pinnedRecording
+              ? pinnedRecordingToListen(donor.pinnedRecording)
+              : null;
+            return (
+              <div key={donor.id} className="recent-donor-card">
+                <div>
+                  {donor.musicbrainz_id &&
+                    (donor.is_listenbrainz_user ? (
+                      <Link
+                        to={`/user/${donor.musicbrainz_id}`}
+                        className="user-link"
+                      >
+                        {donor.musicbrainz_id}
+                      </Link>
+                    ) : (
+                      <Link
+                        to={`https://musicbrainz.org/user/${donor.musicbrainz_id}`}
+                        className="user-link"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {donor.musicbrainz_id}
+                      </Link>
+                    ))}
+                  <p>
+                    {donor.currency === "usd" ? "$" : "€"}
+                    {donor.donation}
+                  </p>
+                </div>
+                {pinnedRecordingListen && (
+                  <Link
+                    className="donor-pinned-recording btn btn-sm"
+                    to={`https://musicbrainz.org/recording/${getRecordingMBID(
+                      pinnedRecordingListen
+                    )}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    tabIndex={0}
+                  >
+                    <FontAwesomeIcon icon={faThumbtack} />
+                    <div className="text">
+                      {getTrackName(pinnedRecordingListen)}
+                    </div>
+                  </Link>
+                )}
+              </div>
+            );
+          })}
+      </div>
+    </>
+  );
+}
+
+export default RecentDonorsCard;

--- a/frontend/js/src/utils/donation.d.ts
+++ b/frontend/js/src/utils/donation.d.ts
@@ -1,0 +1,14 @@
+type DonationInfo = {
+	id: number;
+	donated_at: string;
+	donation: number;
+	currency: "usd" | "eur";
+	musicbrainz_id: string;
+	is_listenbrainz_user: boolean;
+	listenCount: number;
+	playlistCount: number;
+};
+
+type DonationInfoWithPinnedRecording = DonationInfo & {
+	pinnedRecording: PinnedRecording;
+};

--- a/frontend/js/tests/recent/RecentListens.test.tsx
+++ b/frontend/js/tests/recent/RecentListens.test.tsx
@@ -57,6 +57,7 @@ const props = {
   userPinnedRecording,
   globalListenCount,
   globalUserCount,
+  recentDonors: [],
 };
 
 // Create a new instance of GlobalAppContext


### PR DESCRIPTION
Following the discussions regarding donations as outlined in  https://docs.google.com/document/d/1Nt8vZa_EZN8qgP0sQmfb5jZyjGepcxe3fbphphA0uF8

Here we have a good starting point for a facescious "support tiers" type of page.
We might want to revisit some of the text, particualrly if we find better "perks" than the ones listed

![image](https://github.com/user-attachments/assets/df9a01b4-ef58-414a-a28b-154573f00a4a)

Also adds a link to the page in the side navbar. It is already in the footer as well be we might want a banner of some sort there instead.

Please be aware, currently the buttons to donate redirect to the metabrainz website while we are setting up donations on LB.