### PR TITLE
LB-1608, LB-1614 :Add flash messages to index page

### DIFF
--- a/listenbrainz/webserver/templates/index.html
+++ b/listenbrainz/webserver/templates/index.html
@@ -1,3 +1,5 @@
+{% from 'macros.html' import print_message %}
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -51,6 +53,12 @@
 </head>
 
 <body>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+      {{ print_message(message, category) }}
+    {% endfor %}
+  {% endwith %}
 
 <div id="react-container">
   {%- block content -%}

--- a/listenbrainz/webserver/templates/macros.html
+++ b/listenbrainz/webserver/templates/macros.html
@@ -9,5 +9,5 @@
     {% set alert_class="alert-info" %}
   {% endif %}
 
-  <div class="alert {{ alert_class }}">{{ message }}</div>
+  <div class="alert {{ alert_class }}" style="margin-bottom: 0;">{{ message }}</div>
 {% endmacro %}


### PR DESCRIPTION
The flash messages that were shown on the page were mistakenly removed during refactoring to a single-page app and we lost critical messages telling users their email is not validated, for example.

See the test error "bob" at the top here

![image](https://github.com/user-attachments/assets/e7e22579-b9db-4327-a8c7-3072f1fa7098)
