### PR TITLE
fix: error in donation eligibility calculation

### DIFF
--- a/listenbrainz/db/donation.py
+++ b/listenbrainz/db/donation.py
@@ -87,7 +87,7 @@ def get_recent_donors(meb_conn, db_conn, count: int, offset: int):
              , bool_or(
                     (
                         (amount + fee)
-                       / ceiling(EXTRACT(days from now() - payment_date) / 30.0)
+                       / GREATEST(ceiling(EXTRACT(days from now() - payment_date) / 30.0), 1)
                     )
                     >= :threshold
                ) OVER (PARTITION BY editor_id) AS show_flair
@@ -123,7 +123,7 @@ def get_biggest_donors(meb_conn, db_conn, count: int, offset: int):
              , (
                  (
                     (amount + fee) 
-                   / ceiling(EXTRACT(days from now() - payment_date) / 30.0)
+                   / GREATEST(ceiling(EXTRACT(days from now() - payment_date) / 30.0), 1)
                  )
                  >= :threshold
                ) AS is_donation_eligible

--- a/listenbrainz/db/donation.py
+++ b/listenbrainz/db/donation.py
@@ -94,6 +94,7 @@ def get_recent_donors(meb_conn, db_conn, count: int, offset: int):
           FROM payment
          WHERE editor_id IS NOT NULL
            AND is_donation = 't'
+           AND (anonymous != 't' OR anonymous IS NULL)
            AND payment_date >= (NOW() - INTERVAL '1 year')
       ORDER BY payment_date DESC
          LIMIT :count
@@ -130,6 +131,7 @@ def get_biggest_donors(meb_conn, db_conn, count: int, offset: int):
           FROM payment
          WHERE editor_id IS NOT NULL
            AND is_donation = 't'
+           AND (anonymous != 't' OR anonymous IS NULL)
            AND payment_date >= (NOW() - INTERVAL '1 year')
         )
         SELECT editor_name


### PR DESCRIPTION
This PR fixes an issue where 
1. the calculation for determining donation eligibility could result in a division by zero when the payment_date is too recent (i.e., 0 days between now() and the payment_date).
2. the donations are set as anonymous