### PR TITLE
fix: incorrect documentation for `GET /1/metadata/lookup/` request

### DIFF
--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -242,9 +242,9 @@ def get_mbid_mapping():
     :param artist_name: artist name of the listen
     :type artist_name: ``str``
     :param recording_name: track name of the listen
-    :type artist_name: ``str``
-    :param recording_name: release name of the listen
-    :type artist_name: ``str``
+    :type recording_name: ``str``
+    :param release_name: release name of the listen
+    :type release_name: ``str``
     :param metadata: should extra metadata be also returned if a match is found,
                      see /metadata/recording for details.
     :type metadata: ``bool``


### PR DESCRIPTION
# Problem
The documentation for `GET /1/metadata/lookup/` parameters is wrong, `recording_name` doesn't list a type and is duplicated

# Solution
Likely due to hasty copy-paste, the `:type artist_name` doc was duplicated for all 3 params and `release_name` ended up as `recording_name` instead, this PR simply fixes that
