### PR TITLE
Make reusable scroll container with indicator arrows

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -38,6 +38,7 @@
 @import "release-card.less";
 @import "search.less";
 @import "accordion.less";
+@import "scroll-container.less";
 
 @icon-font-path: "/static/fonts/";
 

--- a/frontend/css/new-navbar.less
+++ b/frontend/css/new-navbar.less
@@ -336,17 +336,6 @@ body {
   }
 }
 
-.dragscroll {
-  /* We user the dragscroll library to handle dragging to scroll */
-  overflow-x: scroll;
-  /* But we want to hide the scrollbar: */
-  -ms-overflow-style: none; /* Internet Explorer and Edge */
-  scrollbar-width: none; /* Firefox */
-  &::-webkit-scrollbar {
-    /* Chrome, Safari and Opera */
-    display: none;
-  }
-}
 .tertiary-nav {
   /* This tertiary nav (pills at the top of the page) should be max full width and scrollable */
   display: flex;

--- a/frontend/css/recommendation-page.less
+++ b/frontend/css/recommendation-page.less
@@ -4,37 +4,6 @@
 }
 /* stylelint-enable */
 
-.playlists-masonry-container {
-  position: relative;
-  // hide overflow behind button with gradient to indicate there's more
-  .nav-button {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 55px;
-    border: none;
-    font-size: 2em;
-    color: @light-grey;
-    z-index: 1;
-    opacity: 1;
-    transition: opacity 300ms linear;
-    &.backward {
-      background: linear-gradient(to right, @white 10%, transparent);
-      text-align: left;
-      left: 0;
-    }
-    &.forward {
-      background: linear-gradient(to left, @white 10%, transparent);
-      right: 0;
-      text-align: right;
-    }
-  }
-  &.scroll-start .nav-button.backward,
-  &.scroll-end& .nav-button.forward {
-    opacity: 0;
-    pointer-events: none;
-  }
-}
 .playlists-masonry {
   width: 100%;
   display: grid;

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -1,0 +1,62 @@
+.horizontal-scroll-container {
+  position: relative;
+  // hide overflow behind button with gradient to indicate there's more
+  .nav-button {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 55px;
+    border: none;
+    font-size: 2em;
+    color: @light-grey;
+    z-index: 1;
+    opacity: 1;
+    transition: opacity 300ms linear;
+    &.backward {
+      background: linear-gradient(to right, @white 10%, transparent);
+      text-align: left;
+      left: 0;
+    }
+    &.forward {
+      background: linear-gradient(to left, @white 10%, transparent);
+      right: 0;
+      text-align: right;
+    }
+  }
+  &.scroll-start .nav-button.backward,
+  &.scroll-end& .nav-button.forward {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.dragscroll {
+  /* We user the dragscroll library to handle dragging to scroll */
+  overflow-x: scroll;
+  /* But we want to hide the scrollbar: */
+  -ms-overflow-style: none; /* Internet Explorer and Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    /* Chrome, Safari and Opera */
+    display: none;
+  }
+}
+
+.small-scrollbar {
+  scrollbar-width: unset;
+  &::-webkit-scrollbar {
+    height: 5px;
+    display:block;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: #f5f5f5;
+    border-radius:5px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #e6e6e6;
+    border-radius:5px;
+  }
+  &:hover::-webkit-scrollbar-thumb {
+    background-color: #ccc;
+  }
+}

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -1,5 +1,19 @@
 .horizontal-scroll-container {
   position: relative;
+
+  .horizontal-scroll {
+    .small-scrollbar();
+    &.no-scrollbar {
+      overflow-x: scroll;
+      /* Hide the scrollbar: */
+      -ms-overflow-style: none; /* Internet Explorer and Edge */
+      scrollbar-width: none; /* Firefox */
+      &::-webkit-scrollbar {
+        /* Chrome, Safari and Opera */
+        display: none;
+      }
+    }
+  }
   // hide overflow behind button with gradient to indicate there's more
   .nav-button {
     position: absolute;
@@ -41,22 +55,26 @@
     display: none;
   }
 }
+@scrollbar-background-color: #f5f5f5;
+@scrollbar-thumb-color: darken(@scrollbar-background-color, 10%);
+@scrollbar-thumb-color-dark: darken(@scrollbar-thumb-color, 15%);
 
 .small-scrollbar {
   scrollbar-width: unset;
+  padding-bottom: 1em;
   &::-webkit-scrollbar {
     height: 5px;
-    display:block;
+    display: block;
   }
   &::-webkit-scrollbar-track {
-    background-color: #f5f5f5;
-    border-radius:5px;
+    background-color: @scrollbar-background-color;
+    border-radius: 5px;
   }
   &::-webkit-scrollbar-thumb {
-    background-color: #e6e6e6;
-    border-radius:5px;
+    background-color: @scrollbar-thumb-color;
+    border-radius: 5px;
   }
   &:hover::-webkit-scrollbar-thumb {
-    background-color: #ccc;
+    background-color: @scrollbar-thumb-color-dark;
   }
 }

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -10,13 +10,13 @@ import { useDraggable } from "react-use-draggable-scroll-safe";
 type HorizontalScrollContainerProps = {
   showScrollbar?: Boolean;
   enableDragScroll?: Boolean;
-  scrollContainerCssClass?: string;
+  className?: string;
 };
 
 export default function HorizontalScrollContainer({
   showScrollbar = true,
   enableDragScroll = true,
-  scrollContainerCssClass,
+  className,
   children,
 }: PropsWithChildren<HorizontalScrollContainerProps>) {
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
@@ -91,9 +91,9 @@ export default function HorizontalScrollContainer({
         <FontAwesomeIcon icon={faChevronLeft} />
       </button>
       <div
-        className={`horizontal-scroll ${scrollContainerCssClass ?? ""} ${
+        className={`horizontal-scroll ${
           showScrollbar ? "small-scrollbar" : "no-scrollbar"
-        }`}
+        } ${className ?? ""}`}
         onScroll={throttledOnScroll}
         onMouseDown={enableDragScroll ? onMouseDown : undefined}
         onMouseUp={enableDragScroll ? onMouseUp : undefined}

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -5,18 +5,37 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { throttle } from "lodash";
 import React, { PropsWithChildren } from "react";
+import { useDraggable } from "react-use-draggable-scroll-safe";
 
 type HorizontalScrollContainerProps = {
   showScrollbar?: Boolean;
+  enableDragScroll?: Boolean;
   scrollContainerCssClass?: string;
 };
 
 export default function HorizontalScrollContainer({
   showScrollbar = true,
+  enableDragScroll = true,
   scrollContainerCssClass,
   children,
 }: PropsWithChildren<HorizontalScrollContainerProps>) {
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const { events } = useDraggable(scrollContainerRef, {
+    applyRubberBandEffect: true,
+  });
+
+  const onMouseDown: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    // Call the dragScrolluse-draggable-safe hook event
+    events.onMouseDown(event);
+    // Set our own class to allow for snap-scroll
+    (event.target as HTMLDivElement)?.parentElement?.classList.add("dragging");
+  };
+  const onMouseUp: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    (event.target as HTMLDivElement)?.parentElement?.classList.remove(
+      "dragging"
+    );
+  };
 
   const onScroll: React.ReactEventHandler<HTMLDivElement> = (event) => {
     const element = event.target as HTMLDivElement;
@@ -67,6 +86,7 @@ export default function HorizontalScrollContainer({
         className="nav-button backward"
         type="button"
         onClick={manualScroll}
+        tabIndex={0}
       >
         <FontAwesomeIcon icon={faChevronLeft} />
       </button>
@@ -75,7 +95,11 @@ export default function HorizontalScrollContainer({
           showScrollbar ? "small-scrollbar" : "no-scrollbar"
         }`}
         onScroll={throttledOnScroll}
+        onMouseDown={enableDragScroll ? onMouseDown : undefined}
+        onMouseUp={enableDragScroll ? onMouseUp : undefined}
         ref={scrollContainerRef}
+        role="grid"
+        tabIndex={-2}
       >
         {children}
       </div>
@@ -83,6 +107,7 @@ export default function HorizontalScrollContainer({
         className="nav-button forward"
         type="button"
         onClick={manualScroll}
+        tabIndex={0}
       >
         <FontAwesomeIcon icon={faChevronRight} />
       </button>

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -1,0 +1,91 @@
+import {
+  faChevronLeft,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { throttle } from "lodash";
+import React, { PropsWithChildren } from "react";
+
+type HorizontalScrollContainerProps = {
+  showScrollbar?: Boolean;
+  scrollContainerCssClass?: string;
+};
+
+export default function HorizontalScrollContainer({
+  showScrollbar,
+  scrollContainerCssClass,
+  children,
+}: PropsWithChildren<HorizontalScrollContainerProps>) {
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const onScroll: React.ReactEventHandler<HTMLDivElement> = (event) => {
+    const element = event.target as HTMLDivElement;
+    const parent = element.parentElement;
+    if (!element || !parent) {
+      return;
+    }
+    // calculate horizontal scroll percentage
+    const scrollPercentage =
+      (100 * element.scrollLeft) / (element.scrollWidth - element.clientWidth);
+
+    if (scrollPercentage > 95) {
+      parent.classList.add("scroll-end");
+      parent.classList.remove("scroll-start");
+    } else if (scrollPercentage < 5) {
+      parent.classList.add("scroll-start");
+      parent.classList.remove("scroll-end");
+    } else {
+      parent.classList.remove("scroll-end");
+      parent.classList.remove("scroll-start");
+    }
+  };
+
+  const manualScroll: React.ReactEventHandler<HTMLElement> = (event) => {
+    if (!scrollContainerRef?.current) {
+      return;
+    }
+    if (event?.currentTarget.classList.contains("forward")) {
+      scrollContainerRef.current.scrollBy({
+        left: 300,
+        top: 0,
+        behavior: "smooth",
+      });
+    } else {
+      scrollContainerRef.current.scrollBy({
+        left: -300,
+        top: 0,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const throttledOnScroll = throttle(onScroll, 400, { leading: true });
+
+  return (
+    <div className="horizontal-scroll-container scroll-start">
+      <button
+        className="nav-button backward"
+        type="button"
+        onClick={manualScroll}
+      >
+        <FontAwesomeIcon icon={faChevronLeft} />
+      </button>
+      <div
+        className={`horizontal-scroll dragscroll ${
+          scrollContainerCssClass ?? ""
+        } ${showScrollbar ? "small-scrollbar" : ""}`}
+        onScroll={throttledOnScroll}
+        ref={scrollContainerRef}
+      >
+        {children}
+      </div>
+      <button
+        className="nav-button forward"
+        type="button"
+        onClick={manualScroll}
+      >
+        <FontAwesomeIcon icon={faChevronRight} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -12,7 +12,7 @@ type HorizontalScrollContainerProps = {
 };
 
 export default function HorizontalScrollContainer({
-  showScrollbar,
+  showScrollbar = true,
   scrollContainerCssClass,
   children,
 }: PropsWithChildren<HorizontalScrollContainerProps>) {
@@ -71,9 +71,9 @@ export default function HorizontalScrollContainer({
         <FontAwesomeIcon icon={faChevronLeft} />
       </button>
       <div
-        className={`horizontal-scroll dragscroll ${
-          scrollContainerCssClass ?? ""
-        } ${showScrollbar ? "small-scrollbar" : ""}`}
+        className={`horizontal-scroll ${scrollContainerCssClass ?? ""} ${
+          showScrollbar ? "small-scrollbar" : "no-scrollbar"
+        }`}
         onScroll={throttledOnScroll}
         ref={scrollContainerRef}
       >

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -348,7 +348,7 @@ export default function RecommendationsPage() {
         </div>
       ) : (
         <HorizontalScrollContainer
-          scrollContainerCssClass="playlists-masonry"
+          className="playlists-masonry"
           showScrollbar={false}
         >
           {playlists.map((playlist, index) => {

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -347,7 +347,10 @@ export default function RecommendationsPage() {
           </p>
         </div>
       ) : (
-        <HorizontalScrollContainer scrollContainerCssClass="playlists-masonry">
+        <HorizontalScrollContainer
+          scrollContainerCssClass="playlists-masonry"
+          showScrollbar={false}
+        >
           {playlists.map((playlist, index) => {
             const extension = getPlaylistExtension(playlist);
             const sourcePatch =

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "react-sortablejs": "^6.1.4",
         "react-toastify": "^8.2.0",
         "react-tooltip": "^4.5.1",
+        "react-use-draggable-scroll-safe": "^0.5.4",
         "react-youtube": "^7.12.0",
         "socket.io-client": "^4.5.4",
         "sortablejs": "^1.12.0",
@@ -15354,6 +15355,17 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-use-draggable-scroll-safe": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/react-use-draggable-scroll-safe/-/react-use-draggable-scroll-safe-0.5.4.tgz",
+      "integrity": "sha512-T06uKjtzSi82bKKBqr76BnD9Y6CPLEQhqNQ2x7rrR1UrChoQhgt4m0oXRa7b2MZokD1oZA/d1KZ457/tq14itA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/react-youtube": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-sortablejs": "^6.1.4",
     "react-toastify": "^8.2.0",
     "react-tooltip": "^4.5.1",
+    "react-use-draggable-scroll-safe": "^0.5.4",
     "react-youtube": "^7.12.0",
     "socket.io-client": "^4.5.4",
     "sortablejs": "^1.12.0",


### PR DESCRIPTION
This PR makes a scroll container we are currently using on the "created for you" page reusable so we don't have to reimplement it elsewhere.
This follows a discussion on the LB channel regarding the artist page and its album grid, which is not very usable on desktop if you don't have a trackpad.
Preparations for https://tickets.metabrainz.org/browse/LB-1652, we can reuse this new component for said album grid allowing for arrows and styled scrollbar underneath.

In the meantime, in this PR it's only moving current functionality around and improving customizability with some extra options (optional scrollbar, optional drag-to-scroll, both active by default, and custom css class names for targeted styling).

Example with arrows and scrollbar:

![image](https://github.com/user-attachments/assets/6c344476-dd8d-483e-9e6a-35dd460d1396)
