### PR TITLE
LB-1652: Better horizontal scroll on the artist pages album grids

### DIFF
--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -117,19 +117,21 @@
       min-height: 150px;
       min-width: 0;
       .artist-page& {
-        max-height: 520px;
+        max-height: 500px;
         overflow-y: hidden;
         border-bottom-style: inset;
         position: relative;
-        &::after {
-          content: "";
-          background-image: @white-gradient;
-          position: absolute;
-          bottom: 0;
-          height: 8em;
-          width: 100%;
+        &.expanded {
+          max-height: initial;
+          padding-bottom: 4em;
         }
       }
+
+      .read-more {
+        bottom: 0;
+        padding: 1em 0;
+      }
+
       .album-page& .listen-card .track-position {
         flex: 0 3em;
         align-self: center;

--- a/frontend/css/release-card.less
+++ b/frontend/css/release-card.less
@@ -116,7 +116,7 @@
   }
 
   .release-coverart.hide-image {
-    display: none;
+    display: none !important;
     height: 0;
   }
 

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -1,10 +1,16 @@
 .horizontal-scroll-container {
   position: relative;
 
+  .horizontal-scroll-container.dragging .horizontal-scroll * {
+    // Prevent text selection and interactions when the user is actively dragging to scroll
+    pointer-events: none;
+    user-select: none;
+}
+
   .horizontal-scroll {
+    overflow-x: auto;
     .small-scrollbar();
     &.no-scrollbar {
-      overflow-x: scroll;
       /* Hide the scrollbar: */
       -ms-overflow-style: none; /* Internet Explorer and Edge */
       scrollbar-width: none; /* Firefox */

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -35,11 +35,11 @@
     &.backward {
       background: linear-gradient(to right, @white 10%, transparent);
       text-align: left;
-      left: 0;
+      left: -1px;
     }
     &.forward {
       background: linear-gradient(to left, @white 10%, transparent);
-      right: 0;
+      right: -1px;
       text-align: right;
     }
   }

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -29,7 +29,7 @@
     border: none;
     font-size: 2em;
     color: @light-grey;
-    z-index: 1;
+    z-index: 2;
     opacity: 1;
     transition: opacity 300ms linear;
     &.backward {

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -5,7 +5,7 @@
     // Prevent text selection and interactions when the user is actively dragging to scroll
     pointer-events: none;
     user-select: none;
-}
+  }
 
   .horizontal-scroll {
     overflow-x: auto;

--- a/frontend/css/scroll-container.less
+++ b/frontend/css/scroll-container.less
@@ -48,6 +48,10 @@
     opacity: 0;
     pointer-events: none;
   }
+  // Hide arrow buttons when the container does not overflow (class added with javascript)
+  &.no-scroll .nav-button {
+    display: none;
+  }
 }
 
 .dragscroll {

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -475,7 +475,7 @@ export default function ArtistPage(): JSX.Element {
           )}
         </div>
         {Object.entries(groupedReleaseGroups).map(([type, rgGroup]) => (
-          <div className="albums full-width scroll-start">
+          <div className="albums">
             <div className="listen-header">
               <h3 className="header-with-line">{type}</h3>
               <SortingButtons sort={sort} setSort={setSort} />

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -122,6 +122,10 @@ export default function ArtistPage(): JSX.Element {
     "release_date"
   );
 
+  const [expandPopularTracks, setExpandPopularTracks] = React.useState<boolean>(
+    false
+  );
+
   const rgGroups = groupBy(
     releaseGroups,
     (rg) =>
@@ -375,7 +379,7 @@ export default function ArtistPage(): JSX.Element {
         />
       </div>
       <div className="entity-page-content">
-        <div className="tracks">
+        <div className={`tracks ${expandPopularTracks ? "expanded" : ""}`}>
           <div className="header">
             <h3 className="header-with-line">
               Popular tracks
@@ -420,11 +424,15 @@ export default function ArtistPage(): JSX.Element {
               />
             );
           })}
-          {/* <div className="read-more">
-            <button type="button" className="btn btn-outline">
-              See more…
+          <div className="read-more">
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={() => setExpandPopularTracks((prevValue) => !prevValue)}
+            >
+              See {expandPopularTracks ? "less" : "more"}
             </button>
-          </div> */}
+          </div>
         </div>
         <div className="stats">
           <div className="listening-stats card flex-center">

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -40,6 +40,7 @@ import { useBrainzPlayerDispatch } from "../common/brainzplayer/BrainzPlayerCont
 import SimilarArtistComponent from "../explore/music-neighborhood/components/SimilarArtist";
 import CBReviewModal from "../cb-review/CBReviewModal";
 import Pill from "../components/Pill";
+import HorizontalScrollContainer from "../components/HorizontalScrollContainer";
 
 function SortingButtons({
   sort,
@@ -479,13 +480,13 @@ export default function ArtistPage(): JSX.Element {
               <h3 className="header-with-line">{type}</h3>
               <SortingButtons sort={sort} setSort={setSort} />
             </div>
-            <div
-              className={`cover-art-container dragscroll ${
+            <HorizontalScrollContainer
+              className={`cover-art-container ${
                 rgGroup.length <= COVER_ART_SINGLE_ROW_COUNT ? "single-row" : ""
               }`}
             >
               {rgGroup.map(getReleaseCard)}
-            </div>
+            </HorizontalScrollContainer>
           </div>
         ))}
       </div>

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -48,31 +48,28 @@ export default function HorizontalScrollContainer({
     []
   );
 
-  const onScroll: React.ReactEventHandler<HTMLElement> = React.useCallback(
-    (event) => {
-      const element = scrollContainerRef?.current;
-      const parent = element?.parentElement;
-      if (!element || !parent) {
-        return;
-      }
+  const onScroll = React.useCallback(() => {
+    const element = scrollContainerRef?.current;
+    const parent = element?.parentElement;
+    if (!element || !parent) {
+      return;
+    }
 
-      parent.classList.remove("scroll-end");
-      parent.classList.remove("scroll-start");
+    parent.classList.remove("scroll-end");
+    parent.classList.remove("scroll-start");
 
-      if (element.scrollLeft < MANUAL_SCROLL_AMOUNT) {
-        // We are at the beginning of the container and haven't scrolled more than MANUAL_SCROLL_AMOUNT
-        parent.classList.add("scroll-start");
-      } else if (
-        // We have scrolled to the end of the container, i.e. there is less than MANUAL_SCROLL_AMOUNT before the end of the scroll
-        // (with a 2px adjustement)
-        element.scrollWidth - element.scrollLeft - element.clientWidth <=
-        MANUAL_SCROLL_AMOUNT - 2
-      ) {
-        parent.classList.add("scroll-end");
-      }
-    },
-    []
-  );
+    if (element.scrollLeft < MANUAL_SCROLL_AMOUNT) {
+      // We are at the beginning of the container and haven't scrolled more than MANUAL_SCROLL_AMOUNT
+      parent.classList.add("scroll-start");
+    } else if (
+      // We have scrolled to the end of the container, i.e. there is less than MANUAL_SCROLL_AMOUNT before the end of the scroll
+      // (with a 2px adjustement)
+      element.scrollWidth - element.scrollLeft - element.clientWidth <=
+      MANUAL_SCROLL_AMOUNT - 2
+    ) {
+      parent.classList.add("scroll-end");
+    }
+  }, []);
 
   const throttledOnScroll = React.useMemo(
     () => throttle(onScroll, 400, { leading: true }),
@@ -99,13 +96,18 @@ export default function HorizontalScrollContainer({
       }
       // Also call the onScroll (throttled) event to ensure
       // the expected CSS classes are applied to the container
-      throttledOnScroll(event);
+      throttledOnScroll();
     },
     [throttledOnScroll]
   );
 
+  React.useEffect(() => {
+    // Run once on startup to set up expected CSS classes applied to the container
+    onScroll();
+  }, []);
+
   return (
-    <div className="horizontal-scroll-container scroll-start">
+    <div className="horizontal-scroll-container">
       <button
         className="nav-button backward"
         type="button"

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -55,6 +55,10 @@ export default function HorizontalScrollContainer({
       return;
     }
 
+    // Set up appropriate CSS classes to show or hide nav buttons
+    if (element.scrollWidth <= element.clientWidth) {
+      parent.classList.add("no-scroll");
+    }
     parent.classList.remove("scroll-end");
     parent.classList.remove("scroll-start");
 

--- a/frontend/js/src/components/HorizontalScrollContainer.tsx
+++ b/frontend/js/src/components/HorizontalScrollContainer.tsx
@@ -54,6 +54,11 @@ export default function HorizontalScrollContainer({
     if (!element || !parent) {
       return;
     }
+    // Don't expect so big a scroll before showing nav arrows on smaller screen sizes
+    const requiredMinimumScrollAmount = Math.min(
+      MANUAL_SCROLL_AMOUNT / 2,
+      element.clientWidth / 2
+    );
 
     // Set up appropriate CSS classes to show or hide nav buttons
     if (element.scrollWidth <= element.clientWidth) {
@@ -62,14 +67,14 @@ export default function HorizontalScrollContainer({
     parent.classList.remove("scroll-end");
     parent.classList.remove("scroll-start");
 
-    if (element.scrollLeft < MANUAL_SCROLL_AMOUNT) {
-      // We are at the beginning of the container and haven't scrolled more than MANUAL_SCROLL_AMOUNT
+    if (element.scrollLeft < requiredMinimumScrollAmount) {
+      // We are at the beginning of the container and haven't scrolled more than requiredMinimumScrollAmount
       parent.classList.add("scroll-start");
     } else if (
-      // We have scrolled to the end of the container, i.e. there is less than MANUAL_SCROLL_AMOUNT before the end of the scroll
+      // We have scrolled to the end of the container, i.e. there is less than requiredMinimumScrollAmount before the end of the scroll
       // (with a 2px adjustement)
       element.scrollWidth - element.scrollLeft - element.clientWidth <=
-      MANUAL_SCROLL_AMOUNT - 2
+      requiredMinimumScrollAmount - 2
     ) {
       parent.classList.add("scroll-end");
     }


### PR DESCRIPTION
Following up from #2995 whose main goal was to make our existing scroll container with arrows on the side reusable, in order to be used on the artist pages where we show scrollable album grids.
Users have been reporting this issue that was also bugging me, and as we are currently doing some improvements on the artist page albums view (#2985) it seemed like the appropriate time to look into it again.

In the process, I realized we previously used the dragscroll library, but lost that functionality by mistake during the single-page-app migration (the JS file was loaded in an HTML template and we forgot to move that over). That being said, for drag-to-scroll functionality we now use a React hook instead.


Before:
![image](https://github.com/user-attachments/assets/45403d59-f397-4e0e-b3a6-f24bdd1630f3)

After:
![image](https://github.com/user-attachments/assets/aabbc4f4-b392-4337-aff4-eded5d16b665)


________________________________________

I will make a note here of an uncertainty I have regarding the album grid itself:
Currently items are laid out in this column order (because of CSS grid peculiarities):
|        |        |        |     |
|--------|--------|--------|-----|
| item 1 | item 3 | item 5 | ... |
| item 2 | item 4 | item 6 | ... |

I dug into the issue for hours, and I do not think there is a way to have a CSS grid restricted to two rows and generating an arbitrary number of columns, which  we would need for a left-to-right order like this;
|        |        |        |     |
|--------|--------|--------|-----|
| item 1 | item 2 | item 3 | ... |
| item 25 | item 26 | item 27 | ... |

So I guess we are stuck with the former solution, which is not necessarily a big issue considering that leaves the higher-sorted elements visible on the page rather than requiring to scroll to see more top items (example above showing items 1-3 and 25-27).