### PR TITLE
Rethink album grouping on artist page

### DIFF
--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -270,6 +270,7 @@
 .read-more {
   position: absolute;
   bottom: -10px;
+  z-index: 2;
   width: 100%;
   text-align: center;
   padding: 40px 0 0;

--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -162,21 +162,33 @@
         margin-top: 2em;
       }
     }
-    .albums {
-      width: 100%;
-      .cover-art-container {
-        display: grid;
-        grid-gap: 2em;
-        grid-auto-flow: column;
-        justify-items: center;
-        grid-template-columns: repeat(auto-fill, minmax(190px, max-content));
-        grid-template-rows: repeat(2, 1fr);
-        &.single-row {
-          grid-template-rows: repeat(1, 1fr);
+    .discography {
+      max-height: 860px;
+      overflow: hidden;
+      position: relative; // For the .read-more button absolute positioning
+      &.expanded {
+        max-height: fit-content;
+        .read-more {
+          position: relative;
+          bottom: 0;
         }
-        .cover-art {
-          aspect-ratio: 1;
-          background: lightgrey;
+      }
+      .albums {
+        width: 100%;
+        .cover-art-container {
+          display: grid;
+          grid-gap: 2em;
+          grid-auto-flow: column;
+          justify-items: center;
+          grid-template-columns: repeat(auto-fill, minmax(190px, max-content));
+          grid-template-rows: repeat(2, 1fr);
+          &.single-row {
+            grid-template-rows: repeat(1, 1fr);
+          }
+          .cover-art {
+            aspect-ratio: 1;
+            background: lightgrey;
+          }
         }
       }
     }

--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -164,6 +164,7 @@
     }
     .discography {
       max-height: 860px;
+      width: 100%;
       overflow: hidden;
       position: relative; // For the .read-more button absolute positioning
       &.expanded {

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -437,15 +437,19 @@ export default function ArtistPage(): JSX.Element {
               />
             );
           })}
-          <div className="read-more">
-            <button
-              type="button"
-              className="btn btn-outline"
-              onClick={() => setExpandPopularTracks((prevValue) => !prevValue)}
-            >
-              See {expandPopularTracks ? "less" : "more"}
-            </button>
-          </div>
+          {popularRecordings && popularRecordings?.length > 4 && (
+            <div className="read-more">
+              <button
+                type="button"
+                className="btn btn-outline"
+                onClick={() =>
+                  setExpandPopularTracks((prevValue) => !prevValue)
+                }
+              >
+                See {expandPopularTracks ? "less" : "more"}
+              </button>
+            </div>
+          )}
         </div>
         <div className="stats">
           <div className="listening-stats card flex-center">

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -265,6 +265,8 @@ export default function ArtistPage(): JSX.Element {
     );
   };
 
+  const releaseGroupTypesNames = Object.entries(groupedReleaseGroups);
+
   return (
     <div id="entity-page" className="artist-page" role="main">
       <Helmet>
@@ -494,7 +496,7 @@ export default function ArtistPage(): JSX.Element {
           )}
         </div>
         <div className={`discography ${expandDiscography ? "expanded" : ""}`}>
-          {Object.entries(groupedReleaseGroups).map(([type, rgGroup]) => (
+          {releaseGroupTypesNames.map(([type, rgGroup]) => (
             <div className="albums">
               <div className="listen-header">
                 <h3 className="header-with-line">{type}</h3>
@@ -511,15 +513,17 @@ export default function ArtistPage(): JSX.Element {
               </HorizontalScrollContainer>
             </div>
           ))}
-          <div className="read-more mb-10">
-            <button
-              type="button"
-              className="btn btn-outline"
-              onClick={() => setExpandDiscography((prevValue) => !prevValue)}
-            >
-              See {expandDiscography ? "less" : "full discography"}
-            </button>
-          </div>
+          {releaseGroupTypesNames.length >= 2 && (
+            <div className="read-more mb-10">
+              <button
+                type="button"
+                className="btn btn-outline"
+                onClick={() => setExpandDiscography((prevValue) => !prevValue)}
+              >
+                See {expandDiscography ? "less" : "full discography"}
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -237,6 +237,9 @@ export default function ArtistPage(): JSX.Element {
 
   const onArtistChange = (artist_mbid: string) => {
     navigate(`/artist/${artist_mbid}`);
+    // Reset default view
+    setExpandDiscography(false);
+    setExpandPopularTracks(false);
   };
 
   const graphParentElementRef = React.useRef<HTMLDivElement>(null);

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -148,13 +148,12 @@ export default function ArtistPage(): JSX.Element {
 
   const typeOrder = [
     "Album",
-    "Single",
     "EP",
+    "Single",
     "Live",
     "Compilation",
     "Remix",
     "Broadcast",
-    "Other",
   ];
   const last = Object.keys(rgGroups).length;
   const sortedRgGroupsKeys = sortBy(Object.keys(rgGroups), (type) =>

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -156,10 +156,10 @@ export default function ArtistPage(): JSX.Element {
     "Broadcast",
     "Other",
   ];
-  const sortedRgGroupsKeys = sortBy(Object.keys(rgGroups), [
-    (type) => typeOrder.indexOf(type),
-    "type",
-  ]);
+  const last = Object.keys(rgGroups).length;
+  const sortedRgGroupsKeys = sortBy(Object.keys(rgGroups), (type) =>
+    typeOrder.indexOf(type) !== -1 ? typeOrder.indexOf(type) : last
+  );
 
   const groupedReleaseGroups: Record<
     string,

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -517,7 +517,7 @@ export default function ArtistPage(): JSX.Element {
               className="btn btn-outline"
               onClick={() => setExpandDiscography((prevValue) => !prevValue)}
             >
-              {expandDiscography ? "See less" : "Full discography"}
+              See {expandDiscography ? "less" : "full discography"}
             </button>
           </div>
         </div>

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -126,11 +126,11 @@ export default function ArtistPage(): JSX.Element {
     false
   );
 
+  // Sort by the more precise secondary type first to create categories like "Live", "Compilation" and "Remix" instead of
+  // "Album + Live", "Single + Live", "EP + Live", "Broadcast + Live" and "Album + Remix", etc.
   const rgGroups = groupBy(
     releaseGroups,
-    (rg) =>
-      (rg.type ?? "Other") +
-      (rg.secondary_types?.[0] ? ` + ${rg.secondary_types?.[0]}` : "")
+    (rg) => rg.secondary_types?.[0] ?? rg.type ?? "Other"
   );
 
   const sortReleaseGroups = (
@@ -146,10 +146,19 @@ export default function ArtistPage(): JSX.Element {
       ["desc", "desc", "asc"]
     );
 
-  const typeOrder = ["Album", "Single", "EP", "Broadcast", "Other"];
+  const typeOrder = [
+    "Album",
+    "Single",
+    "EP",
+    "Live",
+    "Compilation",
+    "Remix",
+    "Broadcast",
+    "Other",
+  ];
   const sortedRgGroupsKeys = sortBy(Object.keys(rgGroups), [
-    (type) => typeOrder.indexOf(type.split(" + ")[0]),
-    (type) => type.split(" + ")[1] ?? "",
+    (type) => typeOrder.indexOf(type),
+    "type",
   ]);
 
   const groupedReleaseGroups: Record<

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -125,6 +125,9 @@ export default function ArtistPage(): JSX.Element {
   const [expandPopularTracks, setExpandPopularTracks] = React.useState<boolean>(
     false
   );
+  const [expandDiscography, setExpandDiscography] = React.useState<boolean>(
+    false
+  );
 
   // Sort by the more precise secondary type first to create categories like "Live", "Compilation" and "Remix" instead of
   // "Album + Live", "Single + Live", "EP + Live", "Broadcast + Live" and "Album + Remix", etc.
@@ -490,21 +493,34 @@ export default function ArtistPage(): JSX.Element {
             </div>
           )}
         </div>
-        {Object.entries(groupedReleaseGroups).map(([type, rgGroup]) => (
-          <div className="albums">
-            <div className="listen-header">
-              <h3 className="header-with-line">{type}</h3>
-              <SortingButtons sort={sort} setSort={setSort} />
+        <div className={`discography ${expandDiscography ? "expanded" : ""}`}>
+          {Object.entries(groupedReleaseGroups).map(([type, rgGroup]) => (
+            <div className="albums">
+              <div className="listen-header">
+                <h3 className="header-with-line">{type}</h3>
+                <SortingButtons sort={sort} setSort={setSort} />
+              </div>
+              <HorizontalScrollContainer
+                className={`cover-art-container ${
+                  rgGroup.length <= COVER_ART_SINGLE_ROW_COUNT
+                    ? "single-row"
+                    : ""
+                }`}
+              >
+                {rgGroup.map(getReleaseCard)}
+              </HorizontalScrollContainer>
             </div>
-            <HorizontalScrollContainer
-              className={`cover-art-container ${
-                rgGroup.length <= COVER_ART_SINGLE_ROW_COUNT ? "single-row" : ""
-              }`}
+          ))}
+          <div className="read-more mb-10">
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={() => setExpandDiscography((prevValue) => !prevValue)}
             >
-              {rgGroup.map(getReleaseCard)}
-            </HorizontalScrollContainer>
+              {expandDiscography ? "See less" : "Full discography"}
+            </button>
           </div>
-        ))}
+        </div>
       </div>
 
       {similarArtists && similarArtists.artists.length > 0 ? (

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -237,9 +237,6 @@ export default function ArtistPage(): JSX.Element {
 
   const onArtistChange = (artist_mbid: string) => {
     navigate(`/artist/${artist_mbid}`);
-    // Reset default view
-    setExpandDiscography(false);
-    setExpandPopularTracks(false);
   };
 
   const graphParentElementRef = React.useRef<HTMLDivElement>(null);
@@ -267,6 +264,12 @@ export default function ArtistPage(): JSX.Element {
       />
     );
   };
+
+  React.useEffect(() => {
+    // Reset default view
+    setExpandDiscography(false);
+    setExpandPopularTracks(false);
+  }, [artist?.artist_mbid]);
 
   const releaseGroupTypesNames = Object.entries(groupedReleaseGroups);
 


### PR DESCRIPTION
User rustynova had the excellent suggestion regarding the album sorting, following improvements in #2985 :
> Or maybe also add subtypes lists, but for all the types. I don't see any reason to separate single remixes and album remixes

On a technical level, what this means is that instead of grouping like on the MusicBrainz website each primary type followed by each secondary type, we are grouping *first* by secondary type and then by primary type.
We only use the first secondary type even if there are multiple, for extra simplifying.

This means we end up with secondary type categories like "live", "compilation", "demo" etc. regardless of the primary types they contain (so "album + remix", "single + remix" and "other + remix" all end up in the same "remix" category).

This results in a page with fewer categories, but ones that make sense from a user point of view.

Compare for example The Beatles' page: 
![image](https://github.com/user-attachments/assets/0c9a44d8-f4bd-4e3e-8812-324c132c50b7)

This PR:
![image](https://github.com/user-attachments/assets/cf81ad63-35b6-47c8-9c3e-267cde2c3e27)
