### PR TITLE
fix: Release Group Artist Credits are duplicated

### DIFF
--- a/mbid_mapping/mapping/mb_artist_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_artist_metadata_cache.py
@@ -85,7 +85,7 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                     "name": release_group_name,
                     "mbid": release_group_mbid,
                     "artist_credit_name": artist_credit_name,
-                    "artists": release_group_artists
+                    "artists": sorted(release_group_artists, key=lambda x: x.pop("position", float('inf')))
                 }
                 if date is not None:
                     release_group["date"] = date
@@ -193,11 +193,12 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                  , array_agg(DISTINCT rgst.name ORDER BY rgst.name)
                                      FILTER (WHERE rgst.name IS NOT NULL)
                                    AS secondary_types
-                                 , jsonb_agg(jsonb_build_object(
+                                 , jsonb_agg(DISTINCT jsonb_build_object(
                                         'artist_mbid', a2.gid::TEXT,
                                         'artist_credit_name', acn2.name,
-                                        'join_phrase', acn2.join_phrase
-                                   ) ORDER BY acn2.position) AS release_group_artists
+                                        'join_phrase', acn2.join_phrase,
+                                        'position', acn2.position
+                                   )) AS release_group_artists
                               FROM musicbrainz.artist a
                               JOIN musicbrainz.artist_credit_name acn
                                 ON a.id = acn.artist
@@ -418,3 +419,4 @@ def create_mb_artist_metadata_cache(use_lb_conn: bool):
 def incremental_update_mb_artist_metadata_cache(use_lb_conn: bool):
     """ Update the MB metadata cache incrementally """
     incremental_update_metadata_cache(MusicBrainzArtistMetadataCache, MB_ARTIST_METADATA_CACHE_TIMESTAMP_KEY, use_lb_conn)
+


### PR DESCRIPTION
This PR fixes the Release Group Artist Credits which are duplicated due to the second join to the artist_credit_name.