### PR TITLE
LB-1635: Navigation history broken when clicking on a user's stats

### DIFF
--- a/frontend/js/src/search/Search.tsx
+++ b/frontend/js/src/search/Search.tsx
@@ -25,7 +25,10 @@ export default function Search() {
 
   React.useEffect(() => {
     if (invalidSearchTypes(searchType)) {
-      setSearchParams({ search_term: searchTerm, search_type: "artist" });
+      setSearchParams(
+        { search_term: searchTerm, search_type: "artist" },
+        { replace: true }
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchType]);

--- a/frontend/js/src/user/stats/UserReports.tsx
+++ b/frontend/js/src/user/stats/UserReports.tsx
@@ -44,7 +44,7 @@ export default function UserReports() {
 
   React.useEffect(() => {
     if (!range || isInvalidStatRange(range)) {
-      setSearchParams({ range: "week" });
+      setSearchParams({ range: "week" }, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [range]);


### PR DESCRIPTION
This PR fixes LB-1635.

Currently, stat range validation happens within the component, which causes an unwanted history entry due to redirections. As a result, users are unable to navigate back properly. This PR moves the validation logic to the loader, ensuring smoother navigation by avoiding history interference.