### PR TITLE
LB-1647: use anchor links in MissingData pagination

### DIFF
--- a/frontend/js/src/settings/missing-data/MissingMBData.tsx
+++ b/frontend/js/src/settings/missing-data/MissingMBData.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { faLink, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { Helmet } from "react-helmet";
 
@@ -169,24 +169,6 @@ export default function MissingMBDataPage() {
           { toastId: "deleted-track-error" }
         );
       }
-    }
-  };
-
-  const handleClickPrevious = () => {
-    if (currPage && currPage > 1) {
-      setLoading(true);
-      const updatedPage = currPage - 1;
-      setSearchParams({ page: updatedPage.toString() });
-      afterDisplay();
-    }
-  };
-
-  const handleClickNext = () => {
-    if (currPage && currPage < totalPages) {
-      setLoading(true);
-      const updatedPage = currPage + 1;
-      setSearchParams({ page: updatedPage.toString() });
-      afterDisplay();
     }
   };
 
@@ -403,36 +385,26 @@ export default function MissingMBDataPage() {
           })}
         </div>
         <ul className="pager" style={{ display: "flex" }}>
-          <li
-            className={`previous ${currPage && currPage <= 1 ? "hidden" : ""}`}
-          >
-            <a
+          <li className={`previous ${currPage <= 1 ? "disabled" : ""}`}>
+            <Link
+              to={`?page=${Math.max(currPage - 1, 1)}`}
               role="button"
-              onClick={handleClickPrevious}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleClickPrevious();
-              }}
-              tabIndex={0}
+              aria-disabled={currPage >= totalPages}
             >
               &larr; Previous
-            </a>
+            </Link>
           </li>
           <li
-            className={`next ${
-              currPage && currPage >= totalPages ? "hidden" : ""
-            }`}
+            className={`next ${currPage >= totalPages ? "disabled" : ""}`}
             style={{ marginLeft: "auto" }}
           >
-            <a
+            <Link
+              to={`?page=${Math.min(currPage + 1, totalPages)}`}
               role="button"
-              onClick={handleClickNext}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleClickNext();
-              }}
-              tabIndex={0}
+              aria-disabled={currPage >= totalPages}
             >
               Next &rarr;
-            </a>
+            </Link>
           </li>
         </ul>
       </div>

--- a/frontend/js/src/settings/missing-data/MissingMBData.tsx
+++ b/frontend/js/src/settings/missing-data/MissingMBData.tsx
@@ -70,7 +70,7 @@ export default function MissingMBDataPage() {
   const dispatch = useBrainzPlayerDispatch();
   const location = useLocation();
   // Loader
-  const { data: loaderData } = useQuery<MissingMBDataLoaderData>(
+  const { data: loaderData, isLoading } = useQuery<MissingMBDataLoaderData>(
     RouteQuery(["missing-data"], location.pathname)
   );
   const { missing_data: missingDataProps = [], last_updated: lastUpdated } =
@@ -80,7 +80,6 @@ export default function MissingMBDataPage() {
   const pageSearchParam = searchParams.get("page");
 
   // State
-  const [loading, setLoading] = React.useState<boolean>(false);
   const [deletedListens, setDeletedListens] = React.useState<Array<string>>([]);
   const [missingData, setMissingData] = React.useState<Array<MissingMBData>>(
     missingDataProps
@@ -115,16 +114,7 @@ export default function MissingMBDataPage() {
     offset + EXPECTED_ITEMS_PER_PAGE
   );
 
-  // Ref
-  const missingMBDataTableRef = React.useRef<HTMLDivElement>(null);
-
   // Functions
-  const afterDisplay = () => {
-    if (missingMBDataTableRef?.current) {
-      missingMBDataTableRef.current.scrollIntoView({ behavior: "smooth" });
-    }
-    setLoading(false);
-  };
 
   const deleteListen = async (data: MissingMBData) => {
     if (user?.auth_token) {
@@ -221,7 +211,7 @@ export default function MissingMBDataPage() {
       )}
       <br />
       <div>
-        <div id="missingMBData" ref={missingMBDataTableRef}>
+        <div id="missingMBData">
           <div
             style={{
               height: 0,
@@ -230,7 +220,7 @@ export default function MissingMBDataPage() {
               zIndex: 1,
             }}
           >
-            <Loader isLoading={loading} />
+            <Loader isLoading={isLoading} />
           </div>
           {itemsOnThisPage.map((group) => {
             const releaseName = group.at(0)?.release_name ?? null;


### PR DESCRIPTION
On the Missing Data page, the pagination uses anchor links as buttons and does navigation programmatically.
This prevents opening the next page in new tab, for example.

Instead, use the react-router Link component which renders an anchor link.
See on hover that it is indeed a regular anchor link according tho the browser:
![image](https://github.com/user-attachments/assets/2189a382-de80-4da1-92a8-d8affda2cc1a)

Also opted for disabling prev/next buttons on first/last page respectively, instead of making them invisible which is not required and changes the UI elements for no good reason.
