### PR TITLE
Fix build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ dnspython==2.6.1
 pyjwt[crypto]==2.7.0
 packaging~=23.1
 feedgen==1.0.0
+WTForms<=3.1.2


### PR DESCRIPTION
flask-admin is using an outdated import which has been removed in wtforms 3.2.0. Hence, apply a max version limit on WTForms.
