### PR TITLE
Fix cover art in release card component

### DIFF
--- a/frontend/css/entity-pages.less
+++ b/frontend/css/entity-pages.less
@@ -178,7 +178,7 @@
         width: 100%;
         .cover-art-container {
           display: grid;
-          grid-gap: 2em;
+          grid-gap: 1.5em;
           grid-auto-flow: column;
           justify-items: center;
           grid-template-columns: repeat(auto-fill, minmax(190px, max-content));

--- a/frontend/css/release-card.less
+++ b/frontend/css/release-card.less
@@ -5,6 +5,8 @@
   .release-item {
     position: relative;
     width: fit-content;
+    height: fit-content;
+    aspect-ratio: 1;
   }
 
   .release-information {

--- a/frontend/css/release-card.less
+++ b/frontend/css/release-card.less
@@ -116,7 +116,7 @@
   }
 
   .release-coverart.hide-image {
-    display: none !important;
+    display: none;
     height: 0;
   }
 


### PR DESCRIPTION
In commit 5e9d882 I made a big mistake, changing a display value to fix a sizing issue but not realizing it resulted in hiding the cover art entirely (at the time I was coding #2997 the cover art archive was down so I could not have realized the issue).

This PR reverts the offending change, and resolves the issue it was trying to solve, but using a different approach that doesn't end up hiding the cover art... :facepalm: 