### PR TITLE
Force size of icons for Youtube

### DIFF
--- a/frontend/css/brainzplayer.less
+++ b/frontend/css/brainzplayer.less
@@ -213,6 +213,16 @@
         stroke: #dedede !important;
         color: #dedede !important;
       }
+      &.music-service-icon {
+        max-width: 1.5em;
+        > svg {
+          // Youtube forces us to follow their branding guidelines to the letter,
+          // so we need to force a minimum height of 20px for the icon path inside the svg
+          // [poo emoji]
+          min-height: 26.7px;
+          vertical-align: middle;
+        }
+      }
     }
 
     .love,

--- a/frontend/js/src/album/utils.tsx
+++ b/frontend/js/src/album/utils.tsx
@@ -69,6 +69,7 @@ export type ListeningStats = {
 export function getRelIconLink(relName: string, relValue: string) {
   let icon;
   let color;
+  let isYoutube = false;
   switch (relName) {
     case "streaming":
     case "free streaming":
@@ -84,6 +85,7 @@ export function getRelIconLink(relName: string, relValue: string) {
     case "youtube music":
       icon = faYoutube;
       color = dataSourcesInfo.youtube.color;
+      isYoutube = true;
       break;
     case "soundcloud":
       icon = faSoundcloud;
@@ -130,6 +132,13 @@ export function getRelIconLink(relName: string, relValue: string) {
       icon = faLink;
       break;
   }
+  let style = {};
+  if (isYoutube) {
+    // Youtube forces us to follow their branding guidelines to the letter,
+    // so we need to force a minimum height of 20px for the icon path inside the svg
+    // [poo emoji]
+    style = { height: "26.7px", width: "auto" };
+  }
   return (
     <a
       key={relName}
@@ -139,7 +148,12 @@ export function getRelIconLink(relName: string, relValue: string) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      <FontAwesomeIcon icon={icon} fixedWidth color={color} />
+      <FontAwesomeIcon
+        icon={icon}
+        fixedWidth={!isYoutube}
+        color={color}
+        style={style}
+      />
     </a>
   );
 }

--- a/frontend/js/src/common/brainzplayer/BrainzPlayerUI.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayerUI.tsx
@@ -266,6 +266,7 @@ function BrainzPlayerUI(props: React.PropsWithChildren<BrainzPlayerUIProps>) {
           {isPlayingATrack && currentDataSourceName && (
             <a
               href={trackUrl || "#"}
+              className="music-service-icon"
               aria-label={`Open in ${currentDataSourceName}`}
               title={`Open in ${currentDataSourceName}`}
               target="_blank"


### PR DESCRIPTION
Youtube forces us to follow their [branding guidelines](https://www.youtube.com/howyoutubeworks/resources/brand-resources/#logos-icons-and-colors) to the letter, so we need to force a minimum height of 20px for the icon path inside the svg.
They reported two "infractions" in the BrainzPlayer UI and on the artist/album page header icons.
For the Brainzplayer UI I made all icons bigger, for the artist page just the youtube icon.
![image](https://github.com/user-attachments/assets/ecc97620-c460-4b5b-a698-7d40887ac08c)

![image](https://github.com/user-attachments/assets/eb0a103b-918c-4ec5-a38f-5ea0c6c25c02)
