### PR TITLE
LB-1664: Only show "full discography" button when required

### DIFF
--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -275,6 +275,16 @@ export default function ArtistPage(): JSX.Element {
 
   const releaseGroupTypesNames = Object.entries(groupedReleaseGroups);
 
+  // Only show "full discography" button if there are more than 4 rows
+  // in total across categories, after which we crop the container
+  const showFullDiscographyButton =
+    releaseGroupTypesNames.reduce(
+      (rows, curr) =>
+        // add up the number of rows (max of 2 rows in the css grid)
+        rows + (curr[1].length > COVER_ART_SINGLE_ROW_COUNT ? 2 : 1),
+      0
+    ) > 4;
+
   return (
     <div id="entity-page" className="artist-page" role="main">
       <Helmet>
@@ -507,7 +517,11 @@ export default function ArtistPage(): JSX.Element {
             </div>
           )}
         </div>
-        <div className={`discography ${expandDiscography ? "expanded" : ""}`}>
+        <div
+          className={`discography ${
+            expandDiscography || !showFullDiscographyButton ? "expanded" : ""
+          }`}
+        >
           {releaseGroupTypesNames.map(([type, rgGroup]) => (
             <div className="albums">
               <div className="listen-header">
@@ -525,7 +539,7 @@ export default function ArtistPage(): JSX.Element {
               </HorizontalScrollContainer>
             </div>
           ))}
-          {releaseGroupTypesNames.length >= 2 && (
+          {showFullDiscographyButton && (
             <div className="read-more mb-10">
               <button
                 type="button"


### PR DESCRIPTION
### Deployed to test.LB for testing: https://test.listenbrainz.org/artist/2fe63f6c-3c54-4151-a6b1-845d030dcb0d/
On the artist page, adding some logic to show the "see full discography" button only if there are more than 4 rows in total across type categories.
This can show up to 4 categories of 1 row, 2 categories of 2 rows, or 1 of 2 rows + 2 of one rows.
After that, like before, crop the container and show the "see full discography" button