### PR TITLE
Update AddData.tsx with Discord BrainzBot + tidying

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -404,8 +404,8 @@ export default function AddData() {
             <a href="https://www.foobar2000.org/">Foobar2000</a>
           </em>{" "}
           plugin for syncing local playlists with ListenBrainz (+ Spotify).
-          Tracks playlists changes and resolves tracks with local content
-          and YouTube links.
+          Tracks playlists changes and resolves tracks with local content and
+          YouTube links.
         </li>
         <li>
           <em>
@@ -439,20 +439,21 @@ export default function AddData() {
         account
       </p>
       <ul>
-      <li>
+        <li>
           <em>
             <a href="https://github.com/coopw1/BrainzBot">BrainzBot</a>
           </em>
-          , a Discord bot that can be user-run or added to your server.
-          Showcase what you're listening to, share charts, album grids,
-          tag clouds, and more.
+          , a Discord bot that can be user-run or added to your server. Showcase
+          what you&apos;re listening to, share charts, album grids, tag clouds,
+          and more.
         </li>
         <li>
           <em>
             <a href="https://github.com/regorxxx/Wrapped-SMP">Wrapped-SMP</a>
           </em>
           , a Foobar2000 plugin that creates listening reports, similar to
-          Spotify's annual report. Can utilize ListenBrainz recommendations.
+          Spotify&apos;s annual report. Can utilize ListenBrainz
+          recommendations.
         </li>
       </ul>
 

--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -439,7 +439,7 @@ export default function AddData() {
         account
       </p>
       <ul>
- <li>
+      <li>
           <em>
             <a href="https://github.com/coopw1/BrainzBotP">BrainzBot</a>
           </em>

--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -390,7 +390,7 @@ export default function AddData() {
             </a>
           </em>
           , a Foobar2000 plugin for submitting and retrieving playlists from
-          ListenBrainz (+ Spotify). Can retrie recommendations and submit
+          ListenBrainz (+ Spotify). Can retrieve recommendations and submit
           track feedback.
         </li>
         <li>

--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -214,7 +214,7 @@ export default function AddData() {
           </em>
           , a free and open source media center:{" "}
           <a href="https://kodi.tv/addons/matrix/service.listenbrainz">
-            ListenBrainz add-on
+            <code>ListenBrainz add-on</code>
           </a>
         </li>
         <li>
@@ -389,13 +389,9 @@ export default function AddData() {
               ListenBrainz-SMP
             </a>
           </em>
-          , a{" "}
-          <em>
-            <a href="https://www.foobar2000.org/">Foobar2000</a>
-          </em>{" "}
-          plugin for submitting and retrieving playlists from ListenBrainz (+
-          Spotify), as well as retrieving recommendations or submitting feedback
-          on tracks.
+          , a Foobar2000 plugin for submitting and retrieving playlists from
+          ListenBrainz (+ Spotify). Can retrie recommendations and submit
+          track feedback.
         </li>
         <li>
           <em>
@@ -407,9 +403,9 @@ export default function AddData() {
           <em>
             <a href="https://www.foobar2000.org/">Foobar2000</a>
           </em>{" "}
-          plugin for syncing local playlists (in multiple formats) with
-          ListenBrainz (+ Spotify). Tracks playlists changes and also allows to
-          resolve tracks with local content and YouTube links.
+          plugin for syncing local playlists with ListenBrainz (+ Spotify).
+          Tracks playlists changes and resolves tracks with local content
+          and YouTube links.
         </li>
         <li>
           <em>
@@ -443,17 +439,20 @@ export default function AddData() {
         account
       </p>
       <ul>
+ <li>
+          <em>
+            <a href="https://github.com/coopw1/BrainzBotP">BrainzBot</a>
+          </em>
+          , a Discord bot that can be user-run or added to your server.
+          Showcase what you're listening to, share charts, album grids,
+          tag clouds, and more.
+        </li>
         <li>
           <em>
             <a href="https://github.com/regorxxx/Wrapped-SMP">Wrapped-SMP</a>
           </em>
-          , a{" "}
-          <em>
-            <a href="https://www.foobar2000.org/">Foobar2000</a>
-          </em>{" "}
-          plugin for creating reports based on user listens similar to the one
-          found at Spotify. Suggested playlists use ListenBrainz recommendations
-          (without requiring listens upload to the server).
+          , a Foobar2000 plugin that creates listening reports, similar to
+          Spotify's annual report. Can utilize ListenBrainz recommendations.
         </li>
       </ul>
 

--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -441,7 +441,7 @@ export default function AddData() {
       <ul>
       <li>
           <em>
-            <a href="https://github.com/coopw1/BrainzBotP">BrainzBot</a>
+            <a href="https://github.com/coopw1/BrainzBot">BrainzBot</a>
           </em>
           , a Discord bot that can be user-run or added to your server.
           Showcase what you're listening to, share charts, album grids,


### PR DESCRIPTION
Added the BrainzBot Discord bot. Additionally:

# Problem

A few of the items on this page/list have long descriptions, with extra links to other services, and lists of features.

If we do that for every item on the page it's going to be 4x as long, hard to keep up to date, and harder for users to browse. Similarly, if we link Foobar2000 then we should link every other service mentioned, which will make the page very hard to read.

I suggest that this page is useful as a reference list of tools and services that integrate with LB, not a description/advertisement of all the features they include. It is more practical to maintain feature lists on the tool's page. From a UX perspective, users are more likely to be visiting this page to find what they can do with ListenBrainz + the player/s etc that they are _already_ using. In other words, if they are not using Foobar2000, they should not need to scroll past long descriptions of Foobar2000 plugins. This applies to all players etc on this page.

# Solution

Shortened some feature descriptions.
Removed the links to Foobar2000.

# Action

Will need to have the tidying script run on it, thank you!

