### PR TITLE
LB-1419: Fix broken partial dates

### DIFF
--- a/mbid_mapping/mapping/mb_artist_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_artist_metadata_cache.py
@@ -80,15 +80,21 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
 
         release_groups = []
         if row["release_groups"]:
-            for release_group_mbid, release_group_name, artist_credit_name, date, type, secondary_types, release_group_artists, caa_id, caa_release_mbid in row["release_groups"]:
+            for release_group_mbid, release_group_name, artist_credit_name, year, month, day, type, secondary_types, release_group_artists, caa_id, caa_release_mbid in row["release_groups"]:
                 release_group = {
                     "name": release_group_name,
                     "mbid": release_group_mbid,
                     "artist_credit_name": artist_credit_name,
                     "artists": release_group_artists
                 }
-                if date is not None:
+                if year is not None:
+                    date = str(year)
+                    if month is not None:
+                        date += "-%02d" % month
+                    if day is not None:
+                        date += "-%02d" % day
                     release_group["date"] = date
+
                 if type is not None:
                     release_group["type"] = type
                 if secondary_types is not None:
@@ -186,9 +192,9 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                  , ac.name AS artist_credit_name
                                  , rgca.caa_id AS caa_id
                                  , rgca.caa_release_mbid::TEXT AS caa_release_mbid
-                                 , (rgm.first_release_date_year::TEXT || '-' ||
-                                     LPAD(rgm.first_release_date_month::TEXT, 2, '0') || '-' ||
-                                     LPAD(rgm.first_release_date_day::TEXT, 2, '0')) AS date
+                                 , rgm.first_release_date_year AS year
+                                 , rgm.first_release_date_month AS month
+                                 , rgm.first_release_date_day AS day
                                  , rgpt.name AS type
                                  , array_agg(DISTINCT rgst.name ORDER BY rgst.name)
                                      FILTER (WHERE rgst.name IS NOT NULL)
@@ -246,12 +252,15 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                             rgd.release_group_mbid,
                                             rgd.release_group_name,
                                             rgd.artist_credit_name, 
-                                            rgd.date,
+                                            rgd.year,
+                                            rgd.month,
+                                            rgd.day,
                                             rgd.type,
+                                            rgd.secondary_types,
                                             rgd.release_group_artists,
                                             rgd.caa_id,
                                             rgd.caa_release_mbid
-                                        ) ORDER BY rgd.date
+                                        ) ORDER BY rgd.year, rgd.month, rgd.day
                                    )
                                     -- if the artist has no release groups, left join will cause a NULL row to be
                                     -- added to the array, filter ensures that it is removed

--- a/mbid_mapping/mapping/mb_release_group_cache.py
+++ b/mbid_mapping/mapping/mb_release_group_cache.py
@@ -133,9 +133,16 @@ class MusicBrainzReleaseGroupCache(MusicBrainzEntityMetadataCache):
                 tag["genre_mbid"] = genre_mbid
             release_group_tags.append(tag)
 
+
+        date = str(row["year"] or '')
+        if row["month"] is not None:
+            date += "-%02d" % row["month"]
+        if row["day"] is not None:
+            date += "-%02d" % row["day"]
+
         release_group = {
             "name": row["release_group_name"],
-            "date": row["date"],
+            "date": date,
             "type": row["type"],
             "caa_id": row["caa_id"],
             "caa_release_mbid": row["caa_release_mbid"],
@@ -428,9 +435,9 @@ class MusicBrainzReleaseGroupCache(MusicBrainzEntityMetadataCache):
                                  , rgca.caa_id
                                  , rgca.caa_release_mbid
                                  , rgpt.name AS type
-                                 , (rgm.first_release_date_year::TEXT || '-' ||
-                                    LPAD(rgm.first_release_date_month::TEXT, 2, '0') || '-' ||
-                                    LPAD(rgm.first_release_date_day::TEXT, 2, '0')) AS date
+                                 , rgm.first_release_date_year AS year
+                                 , rgm.first_release_date_month AS month
+                                 , rgm.first_release_date_day AS day
                                  , rec_data.mediums
                                  , rec_data.recordings_release_mbid
                               FROM musicbrainz.release_group rg


### PR DESCRIPTION
The MB data cashes have invalid partial dates for release_group data. The problem is that when any part of a || concat expression in PG is NULL, the entire result is NULL. The solution is to move the partial data logic into python code.
