### PR TITLE
LB 1455: Fix missing releases in release-group cache

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -5,9 +5,6 @@ MAILTO=""
 # Delete pending listens and update our listen counts, timestamps hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens >> /logs/listen_metadata.log 2>&1
 
-# Update the canonical release mapping data
-50 0,6,12,18 * * * root /usr/local/bin/python /code/listenbrainz/mbid_mapping/manage.py update-canonical-releases >> /logs/canonical_releases.log 2>&1
-
 # Generating troi daily playlists runs hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run-daily-jams >> /logs/troi.log 2>&1
 # Batch generate weekly playlists

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -5,6 +5,9 @@ MAILTO=""
 # Delete pending listens and update our listen counts, timestamps hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete_listens >> /logs/listen_metadata.log 2>&1
 
+# Update the canonical release mapping data
+50 0,6,12,18 * * * root /usr/local/bin/python /code/listenbrainz/mbid_mapping/manage.py update-canonical-releases >> /logs/canonical_releases.log 2>&1
+
 # Generating troi daily playlists runs hourly
 0 * * * * root /usr/local/bin/python /code/listenbrainz/manage.py run-daily-jams >> /logs/troi.log 2>&1
 # Batch generate weekly playlists

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -190,7 +190,6 @@ def cron_build_all_mb_caches(ctx):
     """ Build all mb entity metadata cache and tables it depends on in production in appropriate
      databases. After building the cache, cleanup mbid_mapping table.
     """
-    ctx.invoke(update_canonical_release_data)
     ctx.invoke(cron_build_mb_metadata_cache)
     ctx.invoke(build_mb_artist_metadata_cache)
     ctx.invoke(build_mb_release_group_cache)
@@ -200,6 +199,7 @@ def cron_build_all_mb_caches(ctx):
 @click.pass_context
 def cron_update_all_mb_caches(ctx):
     """ Update all mb entity metadata cache in ListenBrainz. """
+    ctx.invoke(update_canonical_release_data)
     ctx.invoke(update_mb_metadata_cache)
     ctx.invoke(update_mb_artist_metadata_cache)
     ctx.invoke(update_mb_release_group_cache)

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -6,7 +6,7 @@ import subprocess
 
 import click
 
-from mapping.canonical_musicbrainz_data import create_canonical_musicbrainz_data
+from mapping.canonical_musicbrainz_data import create_canonical_musicbrainz_data, update_canonical_release_data
 from mapping.mb_artist_metadata_cache import create_mb_artist_metadata_cache, \
     incremental_update_mb_artist_metadata_cache
 from mapping.soundcloud_metadata_index import create_soundcloud_metadata_index
@@ -23,6 +23,7 @@ from mapping.mb_release_group_cache import create_mb_release_group_cache, \
 from mapping.spotify_metadata_index import create_spotify_metadata_index
 from mapping.apple_metadata_index import create_apple_metadata_index
 from similar.tag_similarity import create_tag_similarity
+
 
 
 @click.group()
@@ -47,6 +48,14 @@ def canonical_data(use_lb_conn):
     """
     create_canonical_musicbrainz_data(use_lb_conn)
 
+
+@cli.command()
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def update_canonical_releases(use_lb_conn):
+    """
+        Update only the canonical releases table
+    """
+    update_canonical_release_data(use_lb_conn)
 
 @cli.command()
 def test_mapping():

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -190,6 +190,7 @@ def cron_build_all_mb_caches(ctx):
     """ Build all mb entity metadata cache and tables it depends on in production in appropriate
      databases. After building the cache, cleanup mbid_mapping table.
     """
+    ctx.invoke(update_canonical_release_data)
     ctx.invoke(cron_build_mb_metadata_cache)
     ctx.invoke(build_mb_artist_metadata_cache)
     ctx.invoke(build_mb_release_group_cache)

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -126,3 +126,24 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
             mb_conn.commit()
 
         log("canonical_musicbrainz_data: done done done!")
+
+
+def update_canonical_release_data(use_lb_conn: bool):
+    """
+        Run only the canonical release data, apart from the other tables.
+
+        Arguments:
+            use_lb_conn: whether to use LB conn or not
+    """
+    mb_uri = config.MB_DATABASE_MASTER_URI or config.MBID_MAPPING_DATABASE_URI
+
+    with psycopg2.connect(mb_uri) as mb_conn:
+
+        lb_conn = None
+        if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
+            lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
+
+        releases = CanonicalRelease(mb_conn, unlogged=False)
+        releases.run()
+
+        log("canonical_release_data: updated.")

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -128,7 +128,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         log("canonical_musicbrainz_data: done done done!")
 
 
-def update_canonical_release_data(use_lb_conn: bool):
+def update_canonical_release_data(use_lb_conn: bool = True):
     """
         Run only the canonical release data, apart from the other tables.
 

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -142,8 +142,9 @@ def update_canonical_release_data(use_lb_conn: bool = True):
         lb_conn = None
         if use_lb_conn and config.SQLALCHEMY_TIMESCALE_URI:
             lb_conn = psycopg2.connect(config.SQLALCHEMY_TIMESCALE_URI)
-
-        releases = CanonicalRelease(mb_conn, unlogged=False)
+            releases = CanonicalRelease(mb_conn, lb_conn, unlogged=False)
+        else:
+            releases = CanonicalRelease(mb_conn, unlogged=False)
         releases.run()
 
         log("canonical_release_data: updated.")

--- a/mbid_mapping/mapping/mb_artist_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_artist_metadata_cache.py
@@ -248,6 +248,7 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                             rgd.artist_credit_name, 
                                             rgd.date,
                                             rgd.type,
+                                            rgd.secondary_types,
                                             rgd.release_group_artists,
                                             rgd.caa_id,
                                             rgd.caa_release_mbid


### PR DESCRIPTION
LB-1455 describes how tracklists sometimes take weeks to update -- the cause is that the canonical release data is only updated when the data dumps are generated. Luckily this query doesn't take long, so we can go this a few times a day. With the PR we update the data every 6 hours.