### PR TITLE
LB-1673: Create endpoints for monitoring service status

### DIFF
--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -20,7 +20,7 @@ from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver import flash, db_conn, meb_conn, ts_conn
 from listenbrainz.webserver.timescale_connection import _ts
 from listenbrainz.webserver.redis_connection import _redis
-from listenbrainz.webserver.views.status_api import get_service_status 
+from listenbrainz.webserver.views.status_api import get_service_status
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user_relationship as db_user_relationship
 from listenbrainz.db.donation import get_recent_donors
@@ -90,7 +90,7 @@ def blog_data():
 @web_listenstore_needed
 def current_status():
 
-    service_status = get_service_status() 
+    service_status = get_service_status()
     listen_count = _ts.get_total_listen_count()
     try:
         user_count = format(int(_get_user_count()), ',d')

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -1,6 +1,7 @@
 import locale
 import requests
 import time
+import os
 
 from brainzutils import cache
 from datetime import datetime
@@ -90,6 +91,8 @@ def blog_data():
 @web_listenstore_needed
 def current_status():
 
+    load = "%.2f %.2f %.2f" % os.getloadavg()
+
     service_status = get_service_status()
     listen_count = _ts.get_total_listen_count()
     try:
@@ -112,6 +115,7 @@ def current_status():
         })
 
     data = {
+        "load": load,
         "service-status": service_status,
         "listenCount": format(int(listen_count), ",d") if listen_count else "0",
         "userCount": user_count,

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -1,5 +1,4 @@
 import locale
-import os
 import requests
 import time
 
@@ -21,6 +20,7 @@ from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver import flash, db_conn, meb_conn, ts_conn
 from listenbrainz.webserver.timescale_connection import _ts
 from listenbrainz.webserver.redis_connection import _redis
+from listenbrainz.webserver.views.status_api import get_service_status 
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user_relationship as db_user_relationship
 from listenbrainz.db.donation import get_recent_donors
@@ -90,8 +90,7 @@ def blog_data():
 @web_listenstore_needed
 def current_status():
 
-    load = "%.2f %.2f %.2f" % os.getloadavg()
-
+    service_status = get_service_status() 
     listen_count = _ts.get_total_listen_count()
     try:
         user_count = format(int(_get_user_count()), ',d')
@@ -113,7 +112,7 @@ def current_status():
         })
 
     data = {
-        "load": load,
+        "service-status": service_status,
         "listenCount": format(int(listen_count), ",d") if listen_count else "0",
         "userCount": user_count,
         "listenCountsPerDay": listen_counts_per_day,

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -327,6 +327,15 @@ def _get_entity_stats(user_name: str, entity: str, count_key: str):
     }})
 
 
+def get_entity_stats_last_updated(user_name: str, entity: str, count_key: str):
+    user, stats_range = _validate_stats_user_params(user_name)
+    stats = db_stats.get(user["id"], entity, stats_range, EntityRecord)
+    if stats is None:
+        return None
+
+    entity_list, total_entity_count = _process_user_entity(stats, 0, 1)
+    return stats.last_updated
+
 @stats_api_bp.route("/user/<user_name>/listening-activity")
 @crossdomain
 @ratelimit()

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -1,8 +1,15 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, current_app
+import requests
+from time import sleep
+
 from listenbrainz.webserver.errors import APIBadRequest, APINotFound
 from brainzutils.ratelimit import ratelimit
+from brainzutils import cache
 
 import listenbrainz.db.dump as db_dump
+
+STATUS_PREFIX = 'listenbrainz.status'  # prefix used in key to cache status
+CACHE_TIME = 60 * 60  # time in seconds we cache the stats
 
 status_api_bp = Blueprint("status_api_v1", __name__)
 
@@ -64,3 +71,38 @@ def _convert_timestamp_to_string_dump_format(timestamp):
         String of the format "20190625-170100"
     """
     return timestamp.strftime("%Y%m%d-%H%M%S")
+
+
+@status_api_bp.route("/get-stats-info", methods=["GET"])
+@ratelimit()
+def get_stats_info():
+    """ Check to see when statistics were last generated for a "random" user. Returns JSON:
+
+    .. code-block:: json
+
+        {
+            "last_updated": 19243535
+        }
+
+    :statuscode 200: You have data.
+    :resheader Content-Type: *application/json*
+    """
+
+    last_updated = cache.get(STATUS_PREFIX + ".stats")
+    if last_updated is None:
+        current_app.logger.warn("no cached data!")
+        url = current_app.config["API_URL"] + "/1/stats/user/rob/artists"
+        while True:
+            r = requests.get(url)
+            if r.status_code == 419:
+                sleep(1)
+                continue
+
+            if r.status_code == 200:
+                break
+
+        last_updated = r.json()["payload"]["last_updated"]
+        cache.set(STATUS_PREFIX + ".stats", last_updated, CACHE_TIME)
+
+    return jsonify({ "last_updated": last_updated })
+

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -225,8 +225,8 @@ def service_status():
     .. code-block:: json
 
         {
-            "time": 155574537,   
-            "stats": {                                  
+            "time": 155574537,
+            "stats": {
                 "seconds_since_last_update": 1204
             },
             "incoming_listens": {

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -108,8 +108,7 @@ def get_playlists_timestamp():
         if playlists is None or not playlists:
             return None
 
-        last_updated = playlists[0].last_updated
-        last_updated = int(datetime.fromisoformat(last_updated).timestamp())
+        last_updated = int(playlists[0].last_updated.timestamp())
         cache.set(cache_key, last_updated, PLAYLIST_CACHE_TIME)
 
     return last_updated
@@ -149,7 +148,8 @@ def get_dump_timestamp():
     dump_timestamp = cache.get(cache_key)
     if dump_timestamp is None:
         try:
-            dump_timestamp = db_dump.get_dump_entries()[0]  # return the latest dump
+            dump = db_dump.get_dump_entries()[0]  # return the latest dump
+            dump_timestamp = int(dump["created"].timestamp())
             cache.set(cache_key, dump_timestamp, DUMP_CACHE_TIME)
         except IndexError:
             return None
@@ -174,7 +174,7 @@ def get_service_status():
     if dump is None:
         dump_age = None
     else:
-        dump_age = current_ts - dump["created"]
+        dump_age = current_ts - dump
 
     listen_count = get_incoming_listens_count()
 


### PR DESCRIPTION
We desperately need to improve our monitoring of our ListenBrainz services (dumps, playlists, stats, incoming listens). This PR creates a new /1/status/service-status endpoint that returns:

{
  "dump_age": null,
  "incoming_listen_count": 2,
  "playlists_age": 63342,
  "stats_age": 418718,
  "time": 1731429416
}

To be completed in a new PR: https://tickets.metabrainz.org/browse/LB-1680