### PR TITLE
LB-1677: timescale robustness improvement, might be futile, lol

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -195,7 +195,9 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
                 break
             except Exception:
                 current_app.logger.error("Error in Timescale Writer:", exc_info=True)
-                time.sleep(3)
+                current_app.logger.error("Sleeping 3 seconds and exiting...", exc_info=True)
+                time.sleep(self.ERROR_RETRY_DELAY)
+                break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Last week during a DB outage, our timescale-writer got stuck and didn't come back once the DB came back. @MonkeyDo  and I wondered if this is a problem with the code, where the missing DB connection gets the code stuck somehow.

I audited the code and the recent timescale-writer logs and I didn't find anything that suggests that the code is at fault. This problem seems that its a consul problem, where no DB is defined in the config, and then when it comes back, something gets stuck before the container is really started.

Next time the timescale-writer gets stuck, we should carefully examine the logs to see if we can spot where the problem is. 

This PR changes that catch-all exception to actually exit the container, rather than just restarting the main loop. It is unclear how helpful this will be since, the error message from this catch-all was not found in the logs. But @MonkeyDo and I discussed that we should exit the container when something funky happens, rather than restarting the main loop.