### PR TITLE
LB-1676: Kill lingering uWSGI processes on restart

### DIFF
--- a/docker/consul-template.conf
+++ b/docker/consul-template.conf
@@ -1,7 +1,6 @@
 template {
     source = "/code/listenbrainz/consul_config.py.ctmpl"
     destination = "/code/listenbrainz/listenbrainz/config.py"
-    command = "sv hup uwsgi"
 }
 template {
     source = "/code/listenbrainz/admin/config.sh.ctmpl"

--- a/docker/services/api_compat/api_compat.service
+++ b/docker/services/api_compat/api_compat.service
@@ -1,4 +1,13 @@
 #!/bin/bash
 
-sleep 1
+set -x
+
+UWSGI_PID_FILE=/tmp/uwsgi-api-compat.pid
+if [ -e "$UWSGI_PID_FILE" ]; then
+  UWSGI_PID=`cat "$UWSGI_PID_FILE"`
+  echo "Previous uwsgi master process pid file detected, killing process $UWSGI_PID..."
+  kill -TERM "$UWSGI_PID"
+  sleep 5
+fi
+
 exec run-consul-template -config /etc/consul-template-api-compat.conf

--- a/docker/services/api_compat/api_compat.service
+++ b/docker/services/api_compat/api_compat.service
@@ -7,7 +7,10 @@ if [ -e "$UWSGI_PID_FILE" ]; then
   UWSGI_PID=`cat "$UWSGI_PID_FILE"`
   echo "Previous uwsgi master process pid file detected, killing process $UWSGI_PID..."
   kill -TERM "$UWSGI_PID"
-  sleep 5
+  sleep 4
 fi
+
+# wait for syslog to start up
+sleep 1
 
 exec run-consul-template -config /etc/consul-template-api-compat.conf

--- a/docker/services/api_compat/uwsgi-api-compat.ini
+++ b/docker/services/api_compat/uwsgi-api-compat.ini
@@ -13,3 +13,4 @@ disable-logging = true
 ; quit uwsgi if the python app fails to load
 need-app = true
 die-on-term = true
+safe-pidfile = /tmp/uwsgi-api-compat.pid

--- a/docker/services/labs_api/labs_api.service
+++ b/docker/services/labs_api/labs_api.service
@@ -1,4 +1,13 @@
 #!/bin/bash
 
-sleep 1
+set -x
+
+UWSGI_PID_FILE=/tmp/uwsgi-labs-api.pid
+if [ -e "$UWSGI_PID_FILE" ]; then
+  UWSGI_PID=`cat "$UWSGI_PID_FILE"`
+  echo "Previous uwsgi master process pid file detected, killing process $UWSGI_PID..."
+  kill -TERM "$UWSGI_PID"
+  sleep 5
+fi
+
 exec run-consul-template -config /etc/consul-template-labs-api.conf

--- a/docker/services/labs_api/labs_api.service
+++ b/docker/services/labs_api/labs_api.service
@@ -7,7 +7,10 @@ if [ -e "$UWSGI_PID_FILE" ]; then
   UWSGI_PID=`cat "$UWSGI_PID_FILE"`
   echo "Previous uwsgi master process pid file detected, killing process $UWSGI_PID..."
   kill -TERM "$UWSGI_PID"
-  sleep 5
+  sleep 4
 fi
+
+# wait for syslog to start up
+sleep 1
 
 exec run-consul-template -config /etc/consul-template-labs-api.conf

--- a/docker/services/labs_api/uwsgi-labs-api.ini
+++ b/docker/services/labs_api/uwsgi-labs-api.ini
@@ -15,3 +15,4 @@ need-app = true
 ; increase buffer size for requests that send a lot of mbids in query params
 buffer-size = 8192
 die-on-term = true
+safe-pidfile = /tmp/uwsgi-labs-api.pid

--- a/docker/services/uwsgi/consul-template-uwsgi.conf
+++ b/docker/services/uwsgi/consul-template-uwsgi.conf
@@ -1,6 +1,7 @@
 template {
     source = "/etc/uwsgi/uwsgi.ini.ctmpl"
     destination = "/etc/uwsgi/uwsgi.ini"
+    command = "sv hup uwsgi"
 }
 
 template {

--- a/docker/services/uwsgi/uwsgi.ini.ctmpl
+++ b/docker/services/uwsgi/uwsgi.ini.ctmpl
@@ -20,3 +20,4 @@ need-app = true
 ; increase buffer size for requests that send a lot of mbids in query params
 buffer-size = 8192
 die-on-term = true
+safe-pidfile = /tmp/uwsgi.pid

--- a/docker/services/uwsgi/uwsgi.service
+++ b/docker/services/uwsgi/uwsgi.service
@@ -1,4 +1,13 @@
 #!/bin/bash
 
-sleep 1
+set -x
+
+UWSGI_PID_FILE=/tmp/uwsgi.pid
+if [ -e "$UWSGI_PID_FILE" ]; then
+  UWSGI_PID=`cat "$UWSGI_PID_FILE"`
+  echo "Previous uwsgi master process pid file detected, killing process $UWSGI_PID..."
+  kill -TERM "$UWSGI_PID"
+  sleep 5
+fi
+
 exec run-consul-template -config /etc/consul-template-uwsgi.conf

--- a/docker/services/uwsgi/uwsgi.service
+++ b/docker/services/uwsgi/uwsgi.service
@@ -7,7 +7,10 @@ if [ -e "$UWSGI_PID_FILE" ]; then
   UWSGI_PID=`cat "$UWSGI_PID_FILE"`
   echo "Previous uwsgi master process pid file detected, killing process $UWSGI_PID..."
   kill -TERM "$UWSGI_PID"
-  sleep 5
+  sleep 4
 fi
+
+# wait for syslog to start up
+sleep 1
 
 exec run-consul-template -config /etc/consul-template-uwsgi.conf


### PR DESCRIPTION
# Problem

We have had a long-running but rare issue with uWSGI failing to start, complaining that the address is already in use, and restarting in a loop every 10 seconds.

With a lot of help from zas, we investigated the cause and found that if consul template crashes (for an as-yet-unknown reason*), its child processes do not receive a termination signal and keep running in the background, unmanaged.

When consul-template starts uWSGI again, it finds the address in use as the previous process is still running, but it does not know about it.

* we don't know why consul-template crashes, but it has happened when the whole infrastructure loses connectivity (i.e. during Hetzner maintenance).
* This might be a bug in consul-template, or a "normal" mechanism that we are not expecting (such as terminating consul-template after X failed connection retries, but not killing child processes?)

# Solution

Use the config option to store the PID of the uWSGI main process in a file on startup.
Now on the next startup, if said file contains a PID, send a termination signal (SIGTERM) to it before starting a new process.


# Action

We will need to redeploy listenbrainz-labs-api and listenbrainz-api-compact which are the containers affected by this issue (they rely on uwsgi config changes with consul-template, other containers don't)






The second modification moves the command that restarts uWSGI when its config changes to the specific services that rely on those config changes, rather than all services.
There is no need to restart uWSGI when its config has not changed.

