### PR TITLE
Background tasks container stuck in a rollback loop

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,5 +43,8 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
       continue-on-error: true
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Run tests
       run: ./test.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,8 +43,5 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
       continue-on-error: true
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
     - name: Run tests
       run: ./test.sh

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -61,6 +61,7 @@ services:
       - lb_db
     environment:
       PYTHON_TESTS_RUNNING: 1
+    restart: unless-stopped
     user: "${LB_DOCKER_USER:-root}:${LB_DOCKER_GROUP:-root}"
     volumes:
       - ..:/code/listenbrainz:z

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -58,7 +58,7 @@ class BackgroundTasks:
                 break
             except Exception:
                 current_app.logger.error("Error in background tasks processor:", exc_info=True)
-
+                time.sleep(2)
                 # Exit the container, restart
                 current_app.logger.info("Exiting process, letting container restart.")
                 break

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -46,7 +46,14 @@ class BackgroundTasks:
         current_app.logger.info("Background tasks processor started.")
         while True:
             try:
+                # I suspect the following line is related to this failure:
+                # https://gist.github.com/mayhem/fbd21a146fd34f291cced7dee7e7fca7
+                # But, sadly it doesn't stop the failure -- there is some other connection
+                # that has a transaction open, making everything cranky. Until we find
+                # the root cause of this problem (tricky!) we can mitigate this better
+                # by simply exiting the container when this happens and start fresh.
                 db_conn.rollback()
+
                 task = get_task()
                 if task is None:
                     time.sleep(5)
@@ -59,7 +66,10 @@ class BackgroundTasks:
                 break
             except Exception:
                 current_app.logger.error("Error in background tasks processor:", exc_info=True)
-                time.sleep(5)
+
+                # Exit the container, restart
+                current_app.logger.info("Exiting process, letting container restart.")
+                break
 
 if __name__ == "__main__":
     bt = BackgroundTasks()

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -46,14 +46,6 @@ class BackgroundTasks:
         current_app.logger.info("Background tasks processor started.")
         while True:
             try:
-                # I suspect the following line is related to this failure:
-                # https://gist.github.com/mayhem/fbd21a146fd34f291cced7dee7e7fca7
-                # But, sadly it doesn't stop the failure -- there is some other connection
-                # that has a transaction open, making everything cranky. Until we find
-                # the root cause of this problem (tricky!) we can mitigate this better
-                # by simply exiting the container when this happens and start fresh.
-                db_conn.rollback()
-
                 task = get_task()
                 if task is None:
                     time.sleep(5)
@@ -70,6 +62,15 @@ class BackgroundTasks:
                 # Exit the container, restart
                 current_app.logger.info("Exiting process, letting container restart.")
                 break
+            finally:
+                # I suspect the following line is related to this failure:
+                # https://gist.github.com/mayhem/fbd21a146fd34f291cced7dee7e7fca7
+                # But, sadly it doesn't stop the failure -- there is some other connection
+                # that has a transaction open, making everything cranky. Until we find
+                # the root cause of this problem (tricky!) we can mitigate this better
+                # by simply exiting the container when this happens and start fresh.
+                db_conn.rollback()
+                ts_conn.rollback()
 
 if __name__ == "__main__":
     bt = BackgroundTasks()

--- a/test.sh
+++ b/test.sh
@@ -255,7 +255,6 @@ if [ $DB_RUNNING -eq 1 ] ; then
     echo "Running tests"
     docker_compose_run listenbrainz pytest "$@"
     RET=$?
-    unit_dcdown
     exit $RET
 else
     # Else, we have containers, just run tests


### PR DESCRIPTION
The background tasks container failed with a catch-all exception about an open transaction. It is very difficult to see exactly where that might haven't come from and how to fix this properly.

However, this problem is easy to mitigate -- when we have a catch-all exception, exit the container and let consul start the container again. We'll need to continue to look out for the root cause of this problem, but this should be a decent mitigation.