### PR TITLE
LB-1455 again

### DIFF
--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -199,7 +199,9 @@ def cron_build_all_mb_caches(ctx):
 @click.pass_context
 def cron_update_all_mb_caches(ctx):
     """ Update all mb entity metadata cache in ListenBrainz. """
-    ctx.invoke(update_canonical_release_data)
+
+    # In this context we want to use mb_conn, not lb_conn, like the functions that follow
+    update_canonical_release_data(False)
     ctx.invoke(update_mb_metadata_cache)
     ctx.invoke(update_mb_artist_metadata_cache)
     ctx.invoke(update_mb_release_group_cache)

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -128,7 +128,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         log("canonical_musicbrainz_data: done done done!")
 
 
-def update_canonical_release_data(use_lb_conn: bool = True):
+def update_canonical_release_data(use_lb_conn: bool = False):
     """
         Run only the canonical release data, apart from the other tables.
 

--- a/mbid_mapping/mapping/canonical_musicbrainz_data.py
+++ b/mbid_mapping/mapping/canonical_musicbrainz_data.py
@@ -128,7 +128,7 @@ def create_canonical_musicbrainz_data(use_lb_conn: bool):
         log("canonical_musicbrainz_data: done done done!")
 
 
-def update_canonical_release_data(use_lb_conn: bool = False):
+def update_canonical_release_data(use_lb_conn: bool):
     """
         Run only the canonical release data, apart from the other tables.
 


### PR DESCRIPTION
The previous fix was writing the canonical release data to the lb_conn, not like the mb_conn like the cache functions do. Tested on gaga, should be working fine.