### PR TITLE
LB-1682: run-metadata-cache-seeder manage.py endpoint no longer exists

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -35,9 +35,6 @@ MAILTO=""
 # Request user fresh releases daily
 0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --threshold 10 >> /logs/fresh_releases.log 2>&1
 
-# Run spotify metadata cache seeder
-0 4 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark run-metadata-cache-seeder >> /logs/metadata_cache.log 2>&1
-
 ## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
 0 4 1,15 * * root flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/dumps.log 2>&1
 ## Around 24 hours later, trigger a full import into the spark cluster, and this time wait for the lock, in case the dump hasn't finished.


### PR DESCRIPTION
And the cronjob was still being called, just writing errors to the log fle.