### PR TITLE
LB-1681: Fix 500 error on artist page

### DIFF
--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -26,6 +26,13 @@ def get_release_group_sort_key(release_group):
     if release_date is None:
         release_date = datetime.min
     else:
+        # Add default month/day if missing
+        parts = release_date.split('-')
+        if len(parts) == 1:  # YYYY
+            release_date += "-01-01"
+        elif len(parts) == 2:  # YYYY-MM
+            release_date += "-01"
+
         release_date = datetime.strptime(release_date, "%Y-%m-%d")
 
     return release_group["total_listen_count"] or 0, release_date

--- a/mbid_mapping/mapping/mb_artist_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_artist_metadata_cache.py
@@ -91,8 +91,8 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                     date = str(year)
                     if month is not None:
                         date += "-%02d" % month
-                    if day is not None:
-                        date += "-%02d" % day
+                        if day is not None:
+                            date += "-%02d" % day
                     release_group["date"] = date
 
                 if type is not None:

--- a/mbid_mapping/mapping/mb_release_group_cache.py
+++ b/mbid_mapping/mapping/mb_release_group_cache.py
@@ -134,11 +134,13 @@ class MusicBrainzReleaseGroupCache(MusicBrainzEntityMetadataCache):
             release_group_tags.append(tag)
 
 
-        date = str(row["year"] or '')
-        if row["month"] is not None:
-            date += "-%02d" % row["month"]
-        if row["day"] is not None:
-            date += "-%02d" % row["day"]
+        date = ''
+        if row["year"] is not None:
+            date = str(row["year"])
+            if row["month"] is not None:
+                date += "-%02d" % row["month"]
+                if row["day"] is not None:
+                    date += "-%02d" % row["day"]
 
         release_group = {
             "name": row["release_group_name"],


### PR DESCRIPTION
This PR fixes LB-1681.

The sorting function for release groups anticipated a complete date as input. However, after the partial date issue was resolved in the PR #3029, the sorting function malfunctioned.

Also, there’s a minor issue when we save the partial dates in our cache. As discussed in the pull request https://github.com/metabrainz/listenbrainz-server/pull/3029/files#r1842882407, we only support a limited set of date formats, but the current method of saving the dates can also result in -MM-DD, -DD, -MM, or YYYY-DD formats.


This PR has been deployed on [test.listenbrainz.org](test.listenbrainz.org).

For reference, here are the links:
- https://listenbrainz.org/artist/5f643039-147a-4fcd-b112-c0f60530a253/
- https://test.listenbrainz.org/artist/5f643039-147a-4fcd-b112-c0f60530a253/
