### PR TITLE
LB-1686: Fix escaping in art templates

### DIFF
--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10-alt.svg
@@ -57,10 +57,10 @@
       {% endif %}
      </tspan>
      <tspan x="175" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-album">
-      {{ render_entity_link("release", release.release_mbid, release.release_name|e) }}
+      {{ render_entity_link("release", release.release_mbid, release.release_name) }}
      </tspan>
      <tspan x="175" y="{{ y_albums_start + loop.index0 * gap }}" class="artist-name" id="artist-{{ loop.index }}-name">
-      {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name|e) }}
+      {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name) }}
      </tspan>
     </text>
    {% endfor %}

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-10.svg
@@ -55,10 +55,10 @@
        {% endif %}
      </tspan>
      <tspan x="40" y="{{ y_artists_start + loop.index0 * gap }}" id="artist-{{ loop.index }}-album">
-       {{ render_entity_link("release", release.release_mbid, release.release_name|e) }}
+       {{ render_entity_link("release", release.release_mbid, release.release_name) }}
      </tspan>
      <tspan x="40" y="{{ y_albums_start + loop.index0 * gap }}" class="artist-name" id="artist-{{ loop.index }}-name">
-       {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name|e) }}
+       {{ render_entity_link("artist", release.artist_mbids[0], release.artist_name) }}
      </tspan>
    </text>
    {% endfor %}

--- a/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
+++ b/listenbrainz/webserver/templates/art/svg-templates/designer-top-5.svg
@@ -43,7 +43,7 @@
    {% for artist in artists[:5] %}
    <text id="artist_{{ loop.index }}">
     <tspan id="tspan2{{ loop.index }}" y="{{ y_start + loop.index0 * gap }}" x="-20">
-     {{ render_entity_link("artist", artist.artist_mbid, artist.artist_name|e) }}
+     {{ render_entity_link("artist", artist.artist_mbid, artist.artist_name) }}
     </tspan>
    </text>
    {% endfor %}

--- a/listenbrainz/webserver/templates/art/svg-templates/macros.j2
+++ b/listenbrainz/webserver/templates/art/svg-templates/macros.j2
@@ -6,12 +6,12 @@
       {% set hostURL = '' %}
     {% endif %}
     <a href="{{ host }}/{{ entity }}/{{ mbid }}" target="_blank">
-      {{ name|upper }}
-      <title>{{ name }}</title>
+      {{ name|upper|e }}
+      <title>{{ name|e }}</title>
     </a>
   {%- else -%}
-    {{ name|upper }}
-    <title>{{ name }}</title>
+    {{ name|upper|e }}
+    <title>{{ name|e }}</title>
   {%- endif -%}
 {% endmacro %}
 


### PR DESCRIPTION
Escape the string after calling upper to avoid distorting character escapes like `&amp;` -> `&AMP;`
