### PR TITLE
Fix 404 errors

### DIFF
--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -19,6 +19,7 @@ from listenbrainz.background.background_tasks import add_task
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver import flash, db_conn, meb_conn, ts_conn
+from listenbrainz.webserver.errors import APINotFound
 from listenbrainz.webserver.timescale_connection import _ts
 from listenbrainz.webserver.redis_connection import _redis
 from listenbrainz.webserver.views.status_api import get_service_status
@@ -303,4 +304,9 @@ def _get_user_count():
 @index_bp.route('/<path:path>/')
 @web_listenstore_needed
 def index_pages(path):
+    # this is a catch-all route, all unmatched urls match this route instead of raising a 404
+    # at least in the case the of API urls, we don't want this behavior. hence detect api urls
+    # and raise 404 errors manually
+    if path.startswith("1/"):
+        raise APINotFound(f"Page not found: {path}")
     return render_template("index.html")


### PR DESCRIPTION
The catch-all index route prevents 404 errors for invalid urls that don't match any view. This is undesirable for API urls, hence check and raise 404 errors if the catch-all view captures an api url.