### PR TITLE
Add the StatsExplanationsModal to the created for you page

### DIFF
--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 
-import { faSave } from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle, faSave } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isUndefined, set } from "lodash";
 import { Link, useLoaderData } from "react-router-dom";
@@ -21,6 +21,8 @@ import { preciseTimestamp } from "../../utils/utils";
 import RecommendationPlaylistSettings from "./components/RecommendationPlaylistSettings";
 import { useBrainzPlayerDispatch } from "../../common/brainzplayer/BrainzPlayerContext";
 import HorizontalScrollContainer from "../../components/HorizontalScrollContainer";
+import StatsExplanationsModal from "../../common/stats/StatsExplanationsModal";
+import NiceModal from "@ebay/nice-modal-react";
 
 export type RecommendationsPageProps = {
   playlists?: JSPFObject[];
@@ -345,6 +347,19 @@ export default function RecommendationsPage() {
             Oh no. Either something’s gone wrong, or you need to submit more
             listens before we can prepare delicious fresh produce just for you.
           </p>
+          <button
+            type="button"
+            className="btn btn-link"
+            data-toggle="modal"
+            data-target="#StatsExplanationsModal"
+            onClick={() => {
+              NiceModal.show(StatsExplanationsModal);
+            }}
+          >
+            <FontAwesomeIcon icon={faInfoCircle} />
+            &nbsp; How and when are recommendations calculated?
+          </button>
+
         </div>
       ) : (
         <HorizontalScrollContainer

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -10,6 +10,7 @@ import { Link, useLoaderData } from "react-router-dom";
 import { ReactSortable } from "react-sortablejs";
 import { toast } from "react-toastify";
 import { Helmet } from "react-helmet";
+import NiceModal from "@ebay/nice-modal-react";
 import PlaylistItemCard from "../../playlists/components/PlaylistItemCard";
 import {
   getPlaylistExtension,
@@ -22,7 +23,6 @@ import RecommendationPlaylistSettings from "./components/RecommendationPlaylistS
 import { useBrainzPlayerDispatch } from "../../common/brainzplayer/BrainzPlayerContext";
 import HorizontalScrollContainer from "../../components/HorizontalScrollContainer";
 import StatsExplanationsModal from "../../common/stats/StatsExplanationsModal";
-import NiceModal from "@ebay/nice-modal-react";
 
 export type RecommendationsPageProps = {
   playlists?: JSPFObject[];
@@ -359,7 +359,6 @@ export default function RecommendationsPage() {
             <FontAwesomeIcon icon={faInfoCircle} />
             &nbsp; How and when are recommendations calculated?
           </button>
-
         </div>
       ) : (
         <HorizontalScrollContainer

--- a/frontend/js/src/user/recommendations/RecommendationsPage.tsx
+++ b/frontend/js/src/user/recommendations/RecommendationsPage.tsx
@@ -347,18 +347,20 @@ export default function RecommendationsPage() {
             Oh no. Either something’s gone wrong, or you need to submit more
             listens before we can prepare delicious fresh produce just for you.
           </p>
-          <button
-            type="button"
-            className="btn btn-link"
-            data-toggle="modal"
-            data-target="#StatsExplanationsModal"
-            onClick={() => {
-              NiceModal.show(StatsExplanationsModal);
-            }}
-          >
-            <FontAwesomeIcon icon={faInfoCircle} />
-            &nbsp; How and when are recommendations calculated?
-          </button>
+          <div>
+            <button
+              type="button"
+              className="btn btn-link"
+              data-toggle="modal"
+              data-target="#StatsExplanationsModal"
+              onClick={() => {
+                NiceModal.show(StatsExplanationsModal);
+              }}
+            >
+              <FontAwesomeIcon icon={faInfoCircle} />
+              &nbsp; How and when are recommendations calculated?
+            </button>
+          </div>
         </div>
       ) : (
         <HorizontalScrollContainer


### PR DESCRIPTION
When we don't have this data calculated, we only show users the image below with some text saying their stats haven't been calculated.
Adding a link to show more information to users about how often stats are calculated, otherwise they may be confused.

![image](https://github.com/user-attachments/assets/00a82b92-9e9a-42c6-baf8-e94ac7b6abb0)
