### PR TITLE
Replace Twitter with Mastodon and Bluesky

### DIFF
--- a/frontend/js/src/listens-offline/ListensOffline.tsx
+++ b/frontend/js/src/listens-offline/ListensOffline.tsx
@@ -17,8 +17,8 @@ export default function ListensOffline() {
 
       <p>
         You may find out more about the current status of our services by
-        checking our <a href="https://twitter.com/ListenBrainz">Twitter feed</a>
-        .
+        checking our <a href="https://mastodon.social/@ListenBrainz">Mastodon</a>
+        or <a href="https://bsky.app/profile/listenbrainz.org">Bluesky</a> feeds.
       </p>
     </>
   );

--- a/frontend/js/src/musicbrainz-offline/MusicBrainzOffline.tsx
+++ b/frontend/js/src/musicbrainz-offline/MusicBrainzOffline.tsx
@@ -14,8 +14,8 @@ export default function MusicBrainzOffline() {
 
       <p>
         You may find out more about the current status of our services by
-        checking our <a href="https://twitter.com/ListenBrainz">Twitter feed</a>
-        .
+        checking our <a href="https://mastodon.social/@ListenBrainz">Mastodon</a>
+        or <a href="https://bsky.app/profile/listenbrainz.org">Bluesky</a> feeds.
       </p>
     </>
   );

--- a/listenbrainz/webserver/templates/emails/year_in_music.html
+++ b/listenbrainz/webserver/templates/emails/year_in_music.html
@@ -84,7 +84,6 @@
                         <div>
                           Discuss, share and feed back:
                           <a style="color: #253127 !important;" href="https://community.metabrainz.org/c/listenbrainz/18">forums</a>
-                          | <a style="color: #253127 !important;" href="https://twitter.com/ListenBrainz">X</a>
                           | <a style="color: #253127 !important;" href="https://mastodon.social/@metabrainz">Mastodon</a>
                           | <a style="color: #253127 !important;" href="https://bsky.app/profile/metabrainz.bsky.social">Bluesky</a>
                           | <a style="color: #253127 !important;" href="https://www.reddit.com/r/listenbrainz/">reddit</a>


### PR DESCRIPTION
This doesn't touch legacy YIM templates, but Twitter should be of course skipped when making YIM 2024.