### PR TITLE
LB-1640: Use artist MBID in radio prompt

### DIFF
--- a/frontend/js/src/album/AlbumPage.tsx
+++ b/frontend/js/src/album/AlbumPage.tsx
@@ -260,6 +260,7 @@ export default function AlbumPage(): JSX.Element {
       </div>
     );
   }
+  const artistForRadio = artist.artists?.[0]?.artist_mbid ?? encodeURIComponent(artistName);
 
   return (
     <div
@@ -315,9 +316,7 @@ export default function AlbumPage(): JSX.Element {
             <Link
               type="button"
               className="btn btn-info"
-              to={`/explore/lb-radio/?prompt=artist:(${encodeURIComponent(
-                artistName
-              )})&mode=easy`}
+              to={`/explore/lb-radio/?prompt=artist:(${artistForRadio})&mode=easy`}
             >
               <FontAwesomeIcon icon={faPlayCircle} /> Artist Radio
             </Link>
@@ -334,20 +333,16 @@ export default function AlbumPage(): JSX.Element {
             <ul className="dropdown-menu">
               <li>
                 <Link
-                  to={`/explore/lb-radio/?prompt=artist:(${encodeURIComponent(
-                    artistName
-                  )})::nosim&mode=easy`}
+                  to={`/explore/lb-radio/?prompt=artist:(${artistForRadio})&mode=easy`}
                 >
-                  This artist
+                  Artist radio
                 </Link>
               </li>
               <li>
                 <Link
-                  to={`/explore/lb-radio/?prompt=artist:(${encodeURIComponent(
-                    artistName
-                  )})&mode=easy`}
+                  to={`/explore/lb-radio/?prompt=artist:(${artistForRadio})::nosim&mode=easy`}
                 >
-                  Similar artists
+                  This artist only
                 </Link>
               </li>
               {Boolean(filteredTags?.length) && (

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -354,9 +354,7 @@ export default function ArtistPage(): JSX.Element {
               <Link
                 type="button"
                 className="btn btn-info"
-                to={`/explore/lb-radio/?prompt=artist:(${encodeURIComponent(
-                  artist?.name
-                )})&mode=easy`}
+                to={`/explore/lb-radio/?prompt=artist:(${artistMBID})&mode=easy`}
               >
                 <FontAwesomeIcon icon={faPlayCircle} /> Radio
               </Link>
@@ -373,20 +371,16 @@ export default function ArtistPage(): JSX.Element {
               <ul className="dropdown-menu">
                 <li>
                   <Link
-                    to={`/explore/lb-radio/?prompt=artist:(${encodeURIComponent(
-                      artist?.name
-                    )})::nosim&mode=easy`}
+                    to={`/explore/lb-radio/?prompt=artist:(${artistMBID})&mode=easy`}
                   >
-                    This artist
+                    Artist radio
                   </Link>
                 </li>
                 <li>
                   <Link
-                    to={`/explore/lb-radio/?prompt=artist:(${encodeURIComponent(
-                      artist?.name
-                    )})&mode=easy`}
+                    to={`/explore/lb-radio/?prompt=artist:(${artistMBID})::nosim&mode=easy`}
                   >
-                    Similar artists
+                    This artist only
                   </Link>
                 </li>
                 {Boolean(filteredTags?.length) && (


### PR DESCRIPTION
Currently, on artist and album pages, the "artist radio" button and links currently use the artist name instead of the much more precise MBID, resulting in some very bad results in some cases

Fallback to artist name (as before) in case there is no MBID for some unknown -possibly never happening- reason.

Also move the "artist radio" option to the top, and 'nosim' radio (rephrased to "this artist only") below the —arguably more interesting— artist radio.