### PR TITLE
Explore page cards reorganization

### DIFF
--- a/frontend/css/explore.less
+++ b/frontend/css/explore.less
@@ -50,14 +50,16 @@
   padding: 0.5em;
 }
 
-.explore-card-text-name > a {
+.explore-card-text-name {
   font-size: 18pt;
   font-weight: 900;
   font-family: Roboto, sans-serif;
-  &:visited,
-  &:hover,
-  &:visited:hover {
-    color: @blue;
+  a {
+    &:visited,
+    &:hover,
+    &:visited:hover {
+      color: @blue;
+    }
   }
 }
 

--- a/frontend/css/explore.less
+++ b/frontend/css/explore.less
@@ -141,11 +141,8 @@
 .explore-page-divider {
   display: flex;
   align-items: baseline;
-  > *:first-child {
-    margin-right: 0.6em;
-    flex: 0;
-  }
+  gap: 1em;
   hr {
-    width: 100%;
+    flex: 1;
   }
 }

--- a/frontend/js/src/explore/Explore.tsx
+++ b/frontend/js/src/explore/Explore.tsx
@@ -6,6 +6,7 @@ import { useContext } from "react";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import GlobalAppContext from "../utils/GlobalAppContext";
+import { COLOR_LB_ORANGE } from "../utils/constants";
 
 type ExploreCardProps = {
   name: string;
@@ -80,36 +81,6 @@ export default function ExplorePage() {
             url="/explore/music-neighborhood/"
           />
         </div>
-        {currentUser?.name && (
-          <div>
-            <ExploreCard
-              name="Your Year in Music 2023"
-              desc="Review"
-              img_name="year-in-music-2023.jpg"
-              url={`/user/${currentUser.name}/year-in-music/2023/`}
-            />
-          </div>
-        )}
-        {currentUser?.name && (
-          <div>
-            <ExploreCard
-              name="Your Year in Music 2022"
-              desc="Review"
-              img_name="year-in-music-2022.jpg"
-              url={`/user/${currentUser.name}/year-in-music/2022/`}
-            />
-          </div>
-        )}
-        {currentUser?.name && (
-          <div>
-            <ExploreCard
-              name="Your Year in Music 2021"
-              desc="Review"
-              img_name="year-in-music-2021.jpg"
-              url={`/user/${currentUser.name}/year-in-music/2021/`}
-            />
-          </div>
-        )}
         <div>
           <ExploreCard
             name="Top Similar Users"
@@ -119,6 +90,40 @@ export default function ExplorePage() {
           />
         </div>
       </div>
+      {currentUser?.name && (
+        <>
+          <div className="explore-page-divider">
+            <h3>Your year in music</h3>
+            <hr />
+          </div>
+          <div className="row">
+            <div>
+              <ExploreCard
+                name="Your Year in Music 2023"
+                desc="Review"
+                img_name="year-in-music-2023.jpg"
+                url={`/user/${currentUser.name}/year-in-music/2023/`}
+              />
+            </div>
+            <div>
+              <ExploreCard
+                name="Your Year in Music 2022"
+                desc="Review"
+                img_name="year-in-music-2022.jpg"
+                url={`/user/${currentUser.name}/year-in-music/2022/`}
+              />
+            </div>
+            <div>
+              <ExploreCard
+                name="Your Year in Music 2021"
+                desc="Review"
+                img_name="year-in-music-2021.jpg"
+                url={`/user/${currentUser.name}/year-in-music/2021/`}
+              />
+            </div>
+          </div>
+        </>
+      )}
       <div className="explore-page-divider">
         <h3>Beta</h3>
         <hr />

--- a/frontend/js/src/explore/Explore.tsx
+++ b/frontend/js/src/explore/Explore.tsx
@@ -97,6 +97,35 @@ export default function ExplorePage() {
             <hr />
           </div>
           <div className="row">
+            <div className="explore-card-container">
+              <div className="explore-card">
+                <div
+                  className="explore-card-img-overlay"
+                  style={{ mixBlendMode: "difference" }}
+                >
+                  {" "}
+                </div>
+                <div className="explore-card-img-clip flex-center">
+                  <div
+                    style={{
+                      fontSize: "6em",
+                      fontWeight: "bold",
+                      fontFamily: "Roboto",
+                      transform: "rotate(-8deg)",
+                      color: COLOR_LB_ORANGE,
+                    }}
+                  >
+                    2024
+                  </div>
+                </div>
+                <div className="explore-card-text">
+                  <div className="explore-card-text-name">
+                    Your Year in Music 2024
+                  </div>
+                  <div>Coming Soon</div>
+                </div>
+              </div>
+            </div>
             <div>
               <ExploreCard
                 name="Your Year in Music 2023"


### PR DESCRIPTION
As mentioned in ticket [LB-1639](https://tickets.metabrainz.org/browse/LB-1639), it would be good to do a little bit of reorganization of the Explore page tiles by separating the YIM cards into their own section.

While I was in there I also took the oportunity to set up a card for YIM 2024 as a placeholder.

Overall result:

![image](https://github.com/user-attachments/assets/ba4038a9-185a-4afb-a29b-6ff8b4710893)
