### PR TITLE
LB-1599: Update troi to fix playlist descriptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pika == 1.2.1
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@upgrade-deps
 spotipy>=2.22.1
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@830ecb2b2120acbd5deed2dab4587784c7be04b6
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v2024.08.30.1
+troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v2024.12.03.0
 PyYAML==6.0
 eventlet == 0.35.2
 # eventlet fails to patch dnspython >= 2.3 https://github.com/eventlet/eventlet/issues/781


### PR DESCRIPTION
The weekly playlist descriptions were too long and the latest troi release fixes this.