### PR TITLE
LB-1694: Catch a read timeout exception

### DIFF
--- a/listenbrainz/mbid_mapping_writer/mbid_mapper.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapper.py
@@ -276,7 +276,7 @@ class MBIDMapper:
                     sleep(5)
                 else:
                     raise
-            except typesense.exceptions.RequestMalformed:
+            except (typesense.exceptions.RequestMalformed, requests.exceptions.ReadTimeout):
                 return None
 
         if len(hits["hits"]) == 0:


### PR DESCRIPTION
When examining the logs for an unrelated issue, I noticed an error message. This PR catches that exception and will quiet the logs.