### PR TITLE
Store sitewide stats in a separate db

### DIFF
--- a/admin/timescale/reset_tables.sql
+++ b/admin/timescale/reset_tables.sql
@@ -7,5 +7,6 @@ DELETE FROM mbid_mapping                CASCADE;
 DELETE FROM mapping.mb_metadata_cache   CASCADE;
 DELETE FROM messybrainz.submissions     CASCADE;
 DELETE FROM mbid_manual_mapping         CASCADE;
+DELETE FROM playlist.playlist           CASCADE;
 
 COMMIT;

--- a/listenbrainz/db/tests/test_playlist.py
+++ b/listenbrainz/db/tests/test_playlist.py
@@ -1,7 +1,9 @@
+import os
+
 import listenbrainz.db.user as db_user
 import listenbrainz.db.playlist as db_playlist
 
-from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.tests.integration import IntegrationTestCase, TIMESCALE_SQL_DIR
 from listenbrainz.db import timescale
 from listenbrainz.db.model.playlist import WritablePlaylist
 
@@ -13,6 +15,10 @@ class PlaylistTestCase(IntegrationTestCase):
         self.user_1 = db_user.get_or_create(self.db_conn, 1, 'ansh')
         self.user_2 = db_user.get_or_create(self.db_conn, 2, 'ansh_2')
         self.ts_conn = timescale.engine.connect()
+
+    def tearDown(self):
+        timescale.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))
+        self.ts_conn.close()
 
     def test_create(self):
         playlist_1 = WritablePlaylist(

--- a/listenbrainz/spark/handlers.py
+++ b/listenbrainz/spark/handlers.py
@@ -72,12 +72,6 @@ def handle_user_daily_activity(message):
 
 def _handle_sitewide_stats(message, stat_type, has_count=False):
     try:
-        stats_range = message["stats_range"]
-        databases = couchdb.list_databases(f"{stat_type}_{stats_range}")
-        if not databases:
-            current_app.logger.error(f"No database found to insert {stats_range} sitewide {stat_type} stats")
-            return
-
         stats = {
             "data": message["data"]
         }
@@ -85,7 +79,8 @@ def _handle_sitewide_stats(message, stat_type, has_count=False):
             stats["count"] = message["count"]
 
         db_stats.insert_sitewide_stats(
-            databases[0],
+            stat_type,
+            message["stats_range"],
             message["from_ts"],
             message["to_ts"],
             stats

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -303,27 +303,12 @@ class HandlersTestCase(DatabaseTestCase):
         }
         CouchDbDataset.handle_start({"database": "artists_all_time_20220818"})
         handle_sitewide_entity(data)
-        stats = db_stats.get(
-            db_stats.SITEWIDE_STATS_USER_ID,
-            "artists",
-            "all_time",
-            ArtistRecord
-        )
-        self.assertEqual(stats, StatApi[ArtistRecord](
-            user_id=db_stats.SITEWIDE_STATS_USER_ID,
-            to_ts=10,
-            from_ts=1,
-            count=1,
-            stats_range='all_time',
-            data=StatRecordList[ArtistRecord](__root__=[
-                ArtistRecord(
-                    artist_name='Coldplay',
-                    artist_mbid=None,
-                    listen_count=20,
-                )
-            ]),
-            last_updated=stats.last_updated
-        ))
+        stats = db_stats.get_sitewide_stats("artists","all_time")
+        self.assertEqual(stats["count"], data["count"])
+        self.assertEqual(stats["from_ts"], data["from_ts"])
+        self.assertEqual(stats["to_ts"], data["to_ts"])
+        self.assertEqual(stats["data"], data["data"])
+
 
     @mock.patch('listenbrainz.spark.handlers.db_recommendations_cf_recording.insert_user_recommendation')
     @mock.patch('listenbrainz.spark.handlers.db_user.get')

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -49,7 +49,7 @@ class StatsAPITestCase(IntegrationTestCase):
         # otherwise we will get an error.
         with open(cls.path_to_data_file('sitewide_top_artists_db_data_for_api_test.json'), 'r') as f:
             cls.sitewide_artist_payload = json.load(f)
-        db_stats.insert_sitewide_stats('artists_all_time_20220718', 0, 5, cls.sitewide_artist_payload)
+        db_stats.insert_sitewide_stats('artists', 'all_time', 0, 5, cls.sitewide_artist_payload)
 
     def setUp(self):
         self.maxDiff = None
@@ -495,7 +495,7 @@ class StatsAPITestCase(IntegrationTestCase):
                     with open(self.path_to_data_file(f'sitewide_top_{entity}_db_data_for_api_test_{range_}.json'),
                               'r') as f:
                         payload = json.load(f)
-                    db_stats.insert_sitewide_stats(f"{entity}_{range_}_20220718", 0, 5, payload)
+                    db_stats.insert_sitewide_stats(entity, range_, 0, 5, payload)
                     response = self.client.get(self.custom_url_for(endpoint), query_string={'range': range_})
                     self.assertSitewideStatEqual(payload, response, entity, range_, 25)
 
@@ -507,7 +507,7 @@ class StatsAPITestCase(IntegrationTestCase):
             with self.subTest(f"test api returns at most 100 stats in a response for {entity}", entity=entity):
                 with open(self.path_to_data_file(f'sitewide_top_{entity}_db_data_for_api_test_week.json'), 'r') as f:
                     payload = json.load(f)
-                db_stats.insert_sitewide_stats(f"{entity}_week_20220718", 0, 5, payload)
+                db_stats.insert_sitewide_stats(entity, "week", 0, 5, payload)
                 response = self.client.get(self.custom_url_for(endpoint), query_string={'count': 200, 'range': 'week'})
                 self.assertSitewideStatEqual(payload, response, entity, "week", 200)
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -1004,7 +1004,6 @@ def _get_sitewide_stats(entity: str):
         raise APINoContent("")
 
     count = min(count, MAX_ITEMS_PER_GET)
-    count = count + offset
     total_entity_count = stats["count"]
 
     return jsonify({

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -999,20 +999,23 @@ def _get_sitewide_stats(entity: str):
     offset = get_non_negative_param("offset", default=0)
     count = get_non_negative_param("count", default=DEFAULT_ITEMS_PER_GET)
 
-    stats = db_stats.get(db_stats.SITEWIDE_STATS_USER_ID, entity, stats_range, EntityRecord)
+    stats = db_stats.get_sitewide_stats(entity, stats_range)
     if stats is None:
         raise APINoContent("")
 
-    entity_list, total_entity_count = _process_user_entity(stats, offset, count)
+    count = min(count, MAX_ITEMS_PER_GET)
+    count = count + offset
+    total_entity_count = stats["count"]
+
     return jsonify({
         "payload": {
-            entity: entity_list,
+            entity: stats["data"][offset:count + offset],
             "range": stats_range,
             "offset": offset,
             "count": total_entity_count,
-            "from_ts": stats.from_ts,
-            "to_ts": stats.to_ts,
-            "last_updated": stats.last_updated
+            "from_ts": stats["from_ts"],
+            "to_ts": stats["to_ts"],
+            "last_updated": stats["last_updated"]
         }
     })
 
@@ -1076,23 +1079,19 @@ def get_sitewide_listening_activity():
     if not _is_valid_range(stats_range):
         raise APIBadRequest(f"Invalid range: {stats_range}")
 
-    stats = db_stats.get(
-        db_stats.SITEWIDE_STATS_USER_ID,
-        "listening_activity",
-        stats_range,
-        ListeningActivityRecord
-    )
+    stats = db_stats.get_sitewide_stats("listening_activity", stats_range)
     if stats is None:
         raise APINoContent('')
 
-    listening_activity = [x.dict() for x in stats.data.__root__]
-    return jsonify({"payload": {
-        "listening_activity": listening_activity,
-        "from_ts": stats.from_ts,
-        "to_ts": stats.to_ts,
-        "range": stats_range,
-        "last_updated": stats.last_updated
-    }})
+    return jsonify({
+        "payload": {
+            "listening_activity": stats["data"],
+            "from_ts": stats["from_ts"],
+            "to_ts": stats["to_ts"],
+            "range": stats_range,
+            "last_updated": stats["last_updated"]
+        }
+    })
 
 
 @stats_api_bp.route("/sitewide/artist-map")
@@ -1151,15 +1150,48 @@ def get_sitewide_artist_map():
     if not _is_valid_range(stats_range):
         raise APIBadRequest(f"Invalid range: {stats_range}")
 
-    result = _get_artist_map_stats(db_stats.SITEWIDE_STATS_USER_ID, stats_range)
+    stats = db_stats.get_sitewide_stats("artistmap", stats_range)
+    if stats is not None:
+        return jsonify({
+            "payload": {
+                "artist_map": stats["data"],
+                "from_ts": stats["from_ts"],
+                "to_ts": stats["to_ts"],
+                "last_updated": stats["last_updated"],
+                "stats_range": stats_range
+            }
+        })
+
+    artist_stats = db_stats.get_sitewide_stats("artists", stats_range)
+    if artist_stats is None:
+        raise APINoContent('')
+
+    # Calculate the data
+    artist_mbid_counts = defaultdict(int)
+    for artist in artist_stats["data"]:
+        if artist["artist_mbid"]:
+            artist_mbid_counts[artist["artist_mbid"]] += artist["listen_count"]
+
+    country_code_data = _get_country_wise_counts(artist_mbid_counts)
+    artist_map_stats = [x.dict() for x in country_code_data]
+    try:
+        db_stats.insert_sitewide_stats(
+            "artistmap",
+            stats_range,
+            artist_stats["from_ts"],
+            artist_stats["to_ts"],
+            {"data": artist_map_stats}
+        )
+    except HTTPError as e:
+        current_app.logger.error(f"{e}. Response: %s", e.response.json(), exc_info=True)
 
     return jsonify({
         "payload": {
-            "range": stats_range,
-            "from_ts": result.from_ts,
-            "to_ts": result.to_ts,
-            "last_updated": result.last_updated,
-            "artist_map": [x.dict() for x in result.data.__root__]
+            "artist_map": artist_map_stats,
+            "from_ts": artist_stats["from_ts"],
+            "to_ts": artist_stats["to_ts"],
+            "last_updated": artist_stats["last_updated"],
+            "stats_range": stats_range
         }
     })
 


### PR DESCRIPTION
Currently sitewide stats are stored alongside user stats in a couchdb database. When a day's user stats have been generated, the old day's database is removed, deleting the older sitewide stats as well. Between then and the time today's sitewide stats are generated they are unavailable to view on the site. To avoid this issue store sitewide stats in a different db.