### PR TITLE
LB-1689: Improve last.fm loved tracks import

### DIFF
--- a/listenbrainz/domain/lastfm.py
+++ b/listenbrainz/domain/lastfm.py
@@ -107,6 +107,7 @@ def fetch_lfm_feedback(lfm_user: str):
 
 
 def bulk_get_msids(connection, items):
+    """ Fetch msids for all the specified items (recording, artist_credit) in batches. """
     query = """
         SELECT DISTINCT ON (key)
                lower(s.recording)  || '-' || lower(s.artist_credit) AS key

--- a/listenbrainz/domain/lastfm.py
+++ b/listenbrainz/domain/lastfm.py
@@ -1,8 +1,10 @@
+import logging
 import uuid
 
 import requests
 from flask import current_app
 from psycopg2.extras import execute_values
+from psycopg2.sql import SQL, Identifier
 from requests.adapters import HTTPAdapter, Retry
 from sqlalchemy import text
 
@@ -11,24 +13,26 @@ from brainzutils import musicbrainz_db
 from data.model.external_service import ExternalServiceType
 from listenbrainz.db import external_service_oauth
 from listenbrainz.domain.importer_service import ImporterService
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.errors import APINotFound
 
+logger = logging.getLogger(__name__)
 
-def bulk_insert_loved_tracks(user_id: int, feedback: list[tuple[int, str]]):
+
+def bulk_insert_loved_tracks(user_id: int, feedback: list[tuple[int, str]], column: str):
     """ Insert loved tracks imported from LFM into feedback table """
     # delete existing feedback for given mbids and then import new in same transaction
-    delete_query = """
-               WITH entries(user_id, recording_mbid) AS (VALUES %s)
+    delete_query = SQL("""
+               WITH entries(user_id, {column}) AS (VALUES %s)
         DELETE FROM recording_feedback rf
               USING entries e
               WHERE e.user_id = rf.user_id
-                AND e.recording_mbid::uuid = rf.recording_mbid
-    """
-    insert_query = """
-        INSERT INTO recording_feedback (user_id, created, recording_mbid, score)
+                AND e.{column}::uuid = rf.{column}
+    """).format(column=Identifier(column))
+    insert_query = SQL("""
+        INSERT INTO recording_feedback (user_id, created, {column}, score)
              VALUES %s
-    """
+    """).format(column=Identifier(column))
     with db_conn.connection.cursor() as cursor:
         execute_values(cursor, delete_query, [(mbid,) for ts, mbid in feedback], template=f"({user_id}, %s)")
         execute_values(cursor, insert_query, feedback, template=f"({user_id}, to_timestamp(%s), %s, 1)")
@@ -74,10 +78,7 @@ def fetch_lfm_feedback(lfm_user: str):
     total_pages = int(data["totalPages"])
     total_count = int(data["total"])
 
-    missing_mbid_count, invalid_mbid_count = 0, 0
-
-    track_data = []
-    track_mbids = []
+    items = []
 
     for page in range(1, total_pages + 1):
         params["page"] = page
@@ -88,27 +89,43 @@ def fetch_lfm_feedback(lfm_user: str):
 
         tracks = response.json()["lovedtracks"]["track"]
         for track in tracks:
-            if not track["mbid"]:
-                missing_mbid_count += 1
-                continue
+            item: dict = {
+                "timestamp": int(track["date"]["uts"]),
+                "track_name": track["name"],
+                "artist_name": track["artist"]["name"]
+            }
 
             try:
-                track_mbids.append(uuid.UUID(track["mbid"]))
-                track_data.append((int(track["date"]["uts"]), track["mbid"]))
-            except ValueError:
-                invalid_mbid_count += 1
-                continue
+                uuid.UUID(track["mbid"])
+                item["mbid"] = track["mbid"]
+            except (ValueError, TypeError):
+                item["mbid"] = None
 
-    counts = {
-        "total": total_count,
-        "missing_mbid": missing_mbid_count,
-        "invalid_mbid": invalid_mbid_count
-    }
+            items.append(item)
 
-    return track_mbids, track_data, counts
+    return items, total_count
 
 
-def import_feedback(user_id: int, lfm_user: str) -> dict:
+def bulk_get_msids(connection, items):
+    query = """
+        SELECT DISTINCT ON (key)
+               lower(s.recording)  || '-' || lower(s.artist_credit) AS key
+             , s.gid::text AS recording_msid
+          FROM messybrainz.submissions s
+         WHERE EXISTS(
+                    SELECT 1
+                      FROM (VALUES %s) AS t(track_name, artist_name)
+                     WHERE lower(s.recording) = lower(t.track_name)
+                       AND lower(s.artist_credit) = lower(t.artist_name)
+               )
+      ORDER BY key, s.submitted, recording_msid 
+    """
+    curs = connection.connection.cursor()
+    result = execute_values(curs, query, [(x["track_name"], x["artist_name"]) for x in items], fetch=True)
+    return {r[0]: r[1] for r in result}
+
+
+def import_feedback(user_id: int, lfm_user: str):
     """ Main entrypoint into importing a user's loved tracks from Last.FM into LB feedback table.
 
     This method first retrieves the entire list of loved tracks for a user from Last.FM, discards
@@ -122,25 +139,34 @@ def import_feedback(user_id: int, lfm_user: str) -> dict:
 
     Returns a dict having various counts associated with the import.
     """
-    track_mbids, track_data, counts = fetch_lfm_feedback(lfm_user)
-    recordings = load_recordings_from_tracks(track_mbids)
+    items, total_count = fetch_lfm_feedback(lfm_user)
 
-    recording_feedback = []
-    mbid_not_found_count = 0
+    all_mbids = [x["mbid"] for x in items if x["mbid"]]
+    recordings_from_tracks = load_recordings_from_tracks(all_mbids)
 
-    for track in track_data:
-        recording_mbid = recordings.get(track[1])
-        if not recording_mbid:
-            mbid_not_found_count += 1
-            continue
-        recording_feedback.append((track[0], recording_mbid))
+    items_with_mbids, items_without_mbids = [], []
+    for item in items:
+        if item["mbid"]:
+            if item["mbid"] in recordings_from_tracks:
+                item["mbid"] = recordings_from_tracks[item["mbid"]]
+            items_with_mbids.append(item)
+        else:
+            items_without_mbids.append(item)
 
-    counts["mbid_not_found"] = mbid_not_found_count
+    mbid_feedback = [(x["timestamp"], x["mbid"]) for x in items_with_mbids]
 
-    bulk_insert_loved_tracks(user_id, recording_feedback)
-    counts["inserted"] = len(recording_feedback)
+    msids_map = bulk_get_msids(ts_conn, items_without_mbids)
+    for item in items_without_mbids:
+        key = f"{item['track_name'].lower()}-{item['artist_name'].lower()}"
+        item["msid"] = msids_map.get(key)
+    msid_feedback = [(x["timestamp"], x["msid"]) for x in items_without_mbids if x["msid"]]
 
-    return counts
+    bulk_insert_loved_tracks(user_id, mbid_feedback, "recording_mbid")
+    bulk_insert_loved_tracks(user_id, msid_feedback, "recording_msid")
+    return {
+        "total_count": total_count,
+        "imported": len(mbid_feedback) + len(msid_feedback),
+    }
 
 
 class LastfmService(ImporterService):

--- a/listenbrainz/domain/lastfm.py
+++ b/listenbrainz/domain/lastfm.py
@@ -36,7 +36,7 @@ def bulk_insert_loved_tracks(user_id: int, feedback: list[tuple[int, str]], colu
     with db_conn.connection.cursor() as cursor:
         execute_values(cursor, delete_query, [(mbid,) for ts, mbid in feedback], template=f"({user_id}, %s)")
         execute_values(cursor, insert_query, feedback, template=f"({user_id}, to_timestamp(%s), %s, 1)")
-        db_conn.commit()
+        db_conn.connection.commit()
 
 
 def load_recordings_from_tracks(track_mbids: list) -> dict[str, str]:
@@ -163,8 +163,9 @@ def import_feedback(user_id: int, lfm_user: str):
 
     bulk_insert_loved_tracks(user_id, mbid_feedback, "recording_mbid")
     bulk_insert_loved_tracks(user_id, msid_feedback, "recording_msid")
+
     return {
-        "total_count": total_count,
+        "total": total_count,
         "imported": len(mbid_feedback) + len(msid_feedback),
     }
 

--- a/listenbrainz/domain/musicbrainz.py
+++ b/listenbrainz/domain/musicbrainz.py
@@ -2,13 +2,9 @@ import requests
 from flask import current_app, url_for
 
 from data.model.external_service import ExternalServiceType
-from listenbrainz.db.model.review import CBReviewMetadata
 from listenbrainz.domain.brainz_service import BaseBrainzService
 
-MUSICBRAINZ_SCOPES = ["tag", "rating", "profile", "critiquebrainz:review"]
-CRITIQUEBRAINZ_REVIEW_SUBMIT_URL = "https://critiquebrainz.org/ws/1/review/"
-CRITIQUEBRAINZ_REVIEW_FETCH_URL = "https://critiquebrainz.org/ws/1/reviews/"
-CRITIQUEBRAINZ_REVIEW_LICENSE = "CC BY-SA 3.0"
+MUSICBRAINZ_SCOPES = ["tag", "rating", "profile"]
 
 
 class MusicBrainzService(BaseBrainzService):
@@ -45,46 +41,3 @@ class MusicBrainzService(BaseBrainzService):
         )
         response.raise_for_status()
         return response.json()
-
-    def _submit_review_to_CB(self, token: str, review: CBReviewMetadata):
-        headers = {
-            "Authorization": f"Bearer {token}",
-        }
-        payload = review.dict(exclude_none=True)
-        payload["is_draft"] = False
-        payload["license_choice"] = CRITIQUEBRAINZ_REVIEW_LICENSE
-        return requests.post(CRITIQUEBRAINZ_REVIEW_SUBMIT_URL, json=payload, headers=headers)
-
-    def submit_review(self, user_id: int, review: CBReviewMetadata) -> str:
-        """ Submit a review for the user to CritiqueBrainz.
-
-        Args:
-            user_id: user id of the user for whom to submit the review
-            review: content of the review to be submitted
-
-        Returns:
-            the review uuid returned by the CritiqueBrainz API
-        """
-        # don't move this import outside otherwise will lead to a circular import error. you definitely
-        # don't want to spend an evening debugging that :sob:
-        from listenbrainz.webserver.errors import APIUnauthorized, APIError, APIInternalServerError
-
-        token = MusicBrainzService().get_user(user_id)
-        if token is None:
-            raise APIUnauthorized("You need to connect to the CritiqueBrainz service to write a review.")
-
-        response = self._submit_review_to_CB(token["access_token"], review)
-        data = response.json()
-
-        if response.status_code == 400 and data["error"] == "invalid_token":  # oauth token expired, refresh and retry
-            token = self.refresh_access_token(user_id, token["refresh_token"])
-            response = self._submit_review_to_CB(token["access_token"], review)
-            data = response.json()
-
-        if 400 <= response.status_code < 500:
-            raise APIError(data["description"], response.status_code)
-        elif response.status_code >= 500:
-            current_app.logger.error("CritiqueBrainz Server Error: %s", str(data))
-            raise APIInternalServerError("Something went wrong. Please try again later.")
-        else:
-            return data["id"]

--- a/listenbrainz/domain/musicbrainz.py
+++ b/listenbrainz/domain/musicbrainz.py
@@ -2,9 +2,13 @@ import requests
 from flask import current_app, url_for
 
 from data.model.external_service import ExternalServiceType
+from listenbrainz.db.model.review import CBReviewMetadata
 from listenbrainz.domain.brainz_service import BaseBrainzService
 
-MUSICBRAINZ_SCOPES = ["tag", "rating", "profile"]
+MUSICBRAINZ_SCOPES = ["tag", "rating", "profile", "critiquebrainz:review"]
+CRITIQUEBRAINZ_REVIEW_SUBMIT_URL = "https://critiquebrainz.org/ws/1/review/"
+CRITIQUEBRAINZ_REVIEW_FETCH_URL = "https://critiquebrainz.org/ws/1/reviews/"
+CRITIQUEBRAINZ_REVIEW_LICENSE = "CC BY-SA 3.0"
 
 
 class MusicBrainzService(BaseBrainzService):
@@ -41,3 +45,46 @@ class MusicBrainzService(BaseBrainzService):
         )
         response.raise_for_status()
         return response.json()
+
+    def _submit_review_to_CB(self, token: str, review: CBReviewMetadata):
+        headers = {
+            "Authorization": f"Bearer {token}",
+        }
+        payload = review.dict(exclude_none=True)
+        payload["is_draft"] = False
+        payload["license_choice"] = CRITIQUEBRAINZ_REVIEW_LICENSE
+        return requests.post(CRITIQUEBRAINZ_REVIEW_SUBMIT_URL, json=payload, headers=headers)
+
+    def submit_review(self, user_id: int, review: CBReviewMetadata) -> str:
+        """ Submit a review for the user to CritiqueBrainz.
+
+        Args:
+            user_id: user id of the user for whom to submit the review
+            review: content of the review to be submitted
+
+        Returns:
+            the review uuid returned by the CritiqueBrainz API
+        """
+        # don't move this import outside otherwise will lead to a circular import error. you definitely
+        # don't want to spend an evening debugging that :sob:
+        from listenbrainz.webserver.errors import APIUnauthorized, APIError, APIInternalServerError
+
+        token = MusicBrainzService().get_user(user_id)
+        if token is None:
+            raise APIUnauthorized("You need to connect to the CritiqueBrainz service to write a review.")
+
+        response = self._submit_review_to_CB(token["access_token"], review)
+        data = response.json()
+
+        if response.status_code == 400 and data["error"] == "invalid_token":  # oauth token expired, refresh and retry
+            token = self.refresh_access_token(user_id, token["refresh_token"])
+            response = self._submit_review_to_CB(token["access_token"], review)
+            data = response.json()
+
+        if 400 <= response.status_code < 500:
+            raise APIError(data["description"], response.status_code)
+        elif response.status_code >= 500:
+            current_app.logger.error("CritiqueBrainz Server Error: %s", str(data))
+            raise APIInternalServerError("Something went wrong. Please try again later.")
+        else:
+            return data["id"]


### PR DESCRIPTION
The existing importer only tries to import tracks with track_mbids. Extend it to recognise recording_mbids and for tracks without mbids do a messybrainz lookup.