### PR TITLE
Fix donor apis for local development

### DIFF
--- a/listenbrainz/webserver/views/donor_api.py
+++ b/listenbrainz/webserver/views/donor_api.py
@@ -1,5 +1,5 @@
 from brainzutils.ratelimit import ratelimit
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, current_app
 
 from listenbrainz.db.donation import get_recent_donors, get_biggest_donors
 from listenbrainz.webserver import db_conn, meb_conn
@@ -22,6 +22,9 @@ def recent_donors():
     count = _parse_int_arg("count", DEFAULT_DONOR_COUNT)
     offset = _parse_int_arg("offset", 0)
 
+    if not current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
+        return []
+
     donors, _ = get_recent_donors(meb_conn, db_conn, count, offset)
     return jsonify(donors)
 
@@ -35,6 +38,9 @@ def biggest_donors():
     """
     count = _parse_int_arg("count", DEFAULT_DONOR_COUNT)
     offset = _parse_int_arg("offset", 0)
+
+    if not current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
+        return []
 
     donors, _ = get_biggest_donors(meb_conn, db_conn, count, offset)
     return jsonify(donors)


### PR DESCRIPTION
If SQLALCHEMY_METABRAINZ_URI is not configured, return [] for donors.