### PR TITLE
Docs: Update link to Java client

### DIFF
--- a/docs/users/clients.rst
+++ b/docs/users/clients.rst
@@ -25,4 +25,4 @@ Python
 
 Java
 ^^^^^^
-* `listenbrainz-java <https://github.com/rain0r/listenbrainz-client/>`_
+* `listenbrainz-client <https://github.com/rain0r/listenbrainz-client/>`_

--- a/docs/users/clients.rst
+++ b/docs/users/clients.rst
@@ -25,4 +25,4 @@ Python
 
 Java
 ^^^^^^
-* `listenbrainz-java <https://github.com/rain0r/listenbrainz-java/>`_
+* `listenbrainz-java <https://github.com/rain0r/listenbrainz-client/>`_


### PR DESCRIPTION
The docs linked to [this Java client](https://github.com/rain0r/listenbrainz-java) which is now archived by the creator and replaced with [listenbrainz-client](https://github.com/rain0r/listenbrainz-client). This change updates the link to the new client