### PR TITLE
Fix absent state in YoutubePlayer

### DIFF
--- a/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
@@ -26,10 +26,6 @@ import {
 import { DataSourceProps, DataSourceType } from "./BrainzPlayer";
 import { dataSourcesInfo } from "../../settings/brainzplayer/BrainzPlayerSettings";
 
-export type YoutubePlayerState = {
-  currentListen?: Listen;
-};
-
 export type YoutubePlayerProps = DataSourceProps & {
   youtubeUser?: YoutubeUser;
   refreshYoutubeToken: () => Promise<string>;
@@ -41,8 +37,7 @@ type ExtendedYoutubePlayer = {
   getVideoData?: () => { video_id?: string; author: string; title: string };
 } & YT.Player;
 
-export default class YoutubePlayer
-  extends React.Component<YoutubePlayerProps, YoutubePlayerState>
+export default class YoutubePlayer extends React.Component<YoutubePlayerProps>
   implements DataSourceType {
   static getVideoIDFromListen(listen: Listen | JSPFTrack): string | undefined {
     // This may be either video ID or video link.
@@ -136,7 +131,7 @@ export default class YoutubePlayer
   };
 
   updateVideoInfo = (): void => {
-    let title;
+    let title = "";
     let images: MediaImage[] = [];
     const { onTrackInfoChange, onDurationChange } = this.props;
     const videoData =
@@ -148,10 +143,6 @@ export default class YoutubePlayer
       videoId = videoData.video_id as string;
       images = YoutubePlayer.getThumbnailsFromVideoid(videoId);
       videoUrl = YoutubePlayer.getURLFromVideoID(videoId);
-    } else {
-      // Fallback to track name from the listen we are playing
-      const { currentListen } = this.state;
-      title = getTrackName(currentListen);
     }
     onTrackInfoChange(title, videoUrl, undefined, undefined, images);
     const duration = this.youtubePlayer?.getDuration();
@@ -184,7 +175,7 @@ export default class YoutubePlayer
       // The player info is sometimes missing a title initially.
       // We fallback to getting it with getVideoData method once the information is loaded in the player
       if (!title || !videoId) {
-        setTimeout(this.updateVideoInfo.bind(this), 2000);
+        setTimeout(this.updateVideoInfo, 2000);
       } else {
         const images: MediaImage[] = YoutubePlayer.getThumbnailsFromVideoid(
           videoId

--- a/frontend/js/tests/common/brainzplayer/YoutubePlayer.test.tsx
+++ b/frontend/js/tests/common/brainzplayer/YoutubePlayer.test.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
-import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import { act } from "react-dom/test-utils";
-import YoutubePlayer, {
-  YoutubePlayerProps,
-  YoutubePlayerState,
-} from "../../../src/common/brainzplayer/YoutubePlayer";
+import YoutubePlayer from "../../../src/common/brainzplayer/YoutubePlayer";
 import { DataSourceTypes } from "../../../src/common/brainzplayer/BrainzPlayer";
 import APIService from "../../../src/utils/APIService";
 


### PR DESCRIPTION
Reported on sentry (`e.state is null`): https://sentry.metabrainz.org/organizations/metabrainz/issues/55/

This use of component state is left from previous code, as the state is not set or used anywhere else in this component. No wonder it is throwing an error while trying to access `currentListen` from the state as a fallback mechanism.