### PR TITLE
Service status: monitor recommendation playlists separately

### DIFF
--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -168,7 +168,6 @@ def get_service_status():
         {
           "dump_age": null,
           "incoming_listen_count": 2,
-          "playlists_age": 63229,
           "stats_age": 418605,
           "time": 1731429303
         }
@@ -190,6 +189,33 @@ def get_service_status():
     else:
         stats_age = current_ts - stats
 
+    return {
+        "time": current_ts,
+        "dump_age": dump_age,
+        "stats_age": stats_age,
+        "incoming_listen_count": listen_count
+    }
+
+
+def get_playlist_status():
+    """ Fetch the age of the last output of recommendation playlists and return a dict:
+        {
+          "playlists": [
+               {
+                name: "daily-jams",
+                "age": 1234,
+                },
+                {
+                name: "weekly-jams",
+                "age": 1234,
+                },
+          ]
+          "time": 1731429303
+        }
+    """
+
+    current_ts = int(time())
+
     playlists_ts = get_playlists_timestamp()
     playlists = []
     for patch_name in MONITORED_PLAYLIST_PATCHES:
@@ -197,32 +223,25 @@ def get_service_status():
             if patch_name in playlists_ts else None
         playlists.append({"name": patch_name, "age": playlist_age})
 
-
     return {
         "time": current_ts,
-        "dump_age": dump_age,
-        "stats_age": stats_age,
         "playlists": playlists,
-        "incoming_listen_count": listen_count
     }
 
 
 @status_api_bp.route("/service-status", methods=["GET"])
 @ratelimit()
 def service_status():
-    """ Fetch the recently updated metrics for age of stats, playlists, dumps and the number of items in the incoming
+    """ Fetch the recently updated metrics for age of stats, dumps and the number of items in the incoming
         queue. This function returns JSON:
 
     .. code-block:: json
 
         {
-            "time": 155574537,
-            "stats": {
-                "seconds_since_last_update": 1204
-            },
-            "incoming_listens": {
-                "count": 1028
-            }
+            "dump_age": 60309,
+            "incoming_listen_count": 0,
+            "stats_age": 38715,
+            "time": 1734021912
         }
 
     :statuscode 200: You have data.
@@ -230,3 +249,37 @@ def service_status():
     """
 
     return jsonify(get_service_status())
+
+
+@status_api_bp.route("/playlist-status", methods=["GET"])
+@ratelimit()
+def playlist_status():
+    """ Fetch the recently updated metrics for age of recommendation playlists.
+        This function returns JSON:
+
+    .. code-block:: json
+
+        {
+            "playlists": [
+                {
+                "age": 55671,
+                "name": "daily-jams"
+                },
+                {
+                "age": 919392,
+                "name": "weekly-jams"
+                },
+                {
+                "age": 919184,
+                "name": "weekly-exploration"
+                }
+            ],
+            "time": 1734013745
+        }
+
+
+    :statuscode 200: You have data.
+    :resheader Content-Type: *application/json*
+    """
+
+    return jsonify(get_playlist_status())

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -101,7 +101,7 @@ def get_stats_timestamp():
 def get_playlists_timestamp():
     """ Check to see when recommendations playlists were last generated for a "random" user. Returns unix epoch timestamp"""
 
-    cache_key = STATUS_PREFIX + ".playlist-timestamp"
+    cache_key = STATUS_PREFIX + ".playlist-timestamps"
     last_updated = cache.get(cache_key)
     if last_updated is None:
         playlists = get_recommendation_playlists_for_user(db_conn, ts_conn, 1)

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -191,8 +191,12 @@ def get_service_status():
         stats_age = current_ts - stats
 
     playlists_ts = get_playlists_timestamp()
-    playlists = [{"name": patch_name, "age": playlists_ts.get(
-        patch_name, None)} for patch_name in MONITORED_PLAYLIST_PATCHES]
+    playlists = []
+    for patch_name in MONITORED_PLAYLIST_PATCHES:
+        playlist_age = current_ts - playlists_ts[patch_name] \
+            if patch_name in playlists_ts else None
+        playlists.append({"name": patch_name, "age": playlist_age})
+
 
     return {
         "time": current_ts,

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -109,8 +109,7 @@ def get_playlists_timestamp():
             return None
         last_updated = {}
         for playlist in playlists:
-            source_patch = playlist.get("additional_metadata", {}).get(
-                "algorithm_metadata", {}).get("source_patch")
+            source_patch = playlist.additional_metadata["algorithm_metadata"]["source_patch"]
             last_updated_ts = int(playlist.last_updated.timestamp())
             last_updated[source_patch] = last_updated_ts
         cache.set(cache_key, last_updated, PLAYLIST_CACHE_TIME)


### PR DESCRIPTION
This allows us more fine-grained monitoring of playlists generation timestamps, instead of using whichever first playlist we find.
The reason is daily-jams playlists can be generated while weekly playlists aren't.
Weekly playlists are the only ones most users have access to, hence the ones we really want to monitor.

This PR implements a new endpoint `/status/playlist-status` that serves the following json:
```json
{
  "playlists": [
    {
      "age": 65884,
      "name": "daily-jams"
    },
    {
      "age": 929605,
      "name": "weekly-jams"
    },
    {
      "age": 929397,
      "name": "weekly-exploration"
    }
  ],
  "time": 1734023958
}
```
https://chatlogs.metabrainz.org/libera/metabrainz/2024-12-10/?msg=5408756&page=1