### PR TITLE
LB-1707: Add sort name and disambiguation in artist search pages

### DIFF
--- a/frontend/js/src/search/ArtistSearch.tsx
+++ b/frontend/js/src/search/ArtistSearch.tsx
@@ -105,7 +105,17 @@ export default function ArtistSearch(props: ArtistSearchProps) {
               <tr key={artist?.id}>
                 <td>{(currPageNo - 1) * ARTIST_COUNT_PER_PAGE + index + 1}</td>
                 <td>
-                  <Link to={`/artist/${artist?.id}/`}>{artist?.name}</Link>
+                  <Link
+                    to={`/artist/${artist?.id}/`}
+                    title={`(${artist["sort-name"]}${
+                      artist?.disambiguation ? `, ${artist.disambiguation}` : ""
+                    })`}
+                  >
+                    {artist?.name}
+                  </Link>
+                  {artist?.disambiguation && (
+                    <small>&nbsp;({artist.disambiguation})</small>
+                  )}
                 </td>
                 <td>{artist?.type}</td>
                 <td>{_.capitalize(artist?.gender)}</td>

--- a/frontend/js/src/search/types.d.ts
+++ b/frontend/js/src/search/types.d.ts
@@ -42,6 +42,17 @@ type TrackTypeSearchResult = {
   }[];
 };
 
+type Alias = {
+  "sort-name": string;
+  "type-id": string;
+  name: string;
+  locale: string | null;
+  type: string;
+  primary: boolean | null;
+  "begin-date": number | null;
+  "end-date": number | null;
+};
+
 type ArtistTypeSearchResult = {
   count: number;
   offset: number;
@@ -51,9 +62,12 @@ type ArtistTypeSearchResult = {
     type?: string;
     country?: string;
     gender?: string;
+    "sort-name"?: string;
+    disambiguation?: string;
     area?: {
       name: string;
     };
+    aliases?: Alias[];
   }[];
 };
 


### PR DESCRIPTION
Sort name and disambiguation are easily accessible in the MB API search results so no reason not to show them on the page.
Showing disambiguation after the artist name, and adding the sort name  + disambiguation on hover over the name.

On artist pages and listen cards it's going to be more complicated as we don't necessarily have access to that metadata in the same way.