### PR TITLE
Fix documentation build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask-WTF == 1.2.1
 Flask-SQLAlchemy == 3.1.1
 Flask-UUID == 0.2
 Flask-SocketIO==5.3.6
-bleach==5.0.0
+bleach==5.0.1
 click == 8.1.3
 jsonschema == 4.6.0
 rauth == 0.7.3


### PR DESCRIPTION
# Problem

Readthedocs builds have been failing for [several months](https://app.readthedocs.org/projects/listenbrainz/builds/), because of an issue in bleach 5.0.0's requirements:

```WARNING: Ignoring version 5.0.0 of bleach since it has invalid metadata:
Requested bleach==5.0.0 from [...]/requirements.txt (line 8)) has invalid metadata:
Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
    tinycss2 (>=1.1.0<1.2) ; extra == 'css'
             ~~~~~~~~^
Please use pip<24.1 if you need to use this version.
```

which means changes haven't been making it to the docs for that time.

# Solution

Updating bleach to 5.0.1 is the simplest fix and afterwards I was able to build the documentation locally.

Note also that [bleach has been deprecated](https://github.com/mozilla/bleach/issues/698) for almost two years