### PR TITLE
Update example data for /metadata/ endpoints

### DIFF
--- a/listenbrainz/testdata/mb_artist_metadata_example.json
+++ b/listenbrainz/testdata/mb_artist_metadata_example.json
@@ -1,0 +1,41 @@
+[
+   {
+      "area": "United Kingdom",
+      "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+      "begin_year": 1991,
+      "mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+      "name": "Portishead",
+      "type": "Group",
+      "rels": {
+         "free streaming": "https://www.deezer.com/artist/1069",
+         "lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html",
+         "official homepage": "http://www.portishead.co.uk/",
+         "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/",
+         "social network": "https://www.facebook.com/portishead",
+         "streaming": "https://tidal.com/artist/27441",
+         "wikidata": "https://www.wikidata.org/wiki/Q191352",
+         "youtube": "https://www.youtube.com/user/portishead1002"
+      },
+      "tag": {
+         "artist": [
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 6,
+               "genre_mbid": "cc38aba3-48ed-439a-83b9-f81a34a66598",
+               "tag": "downtempo"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 13,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 7,
+               "tag": "trip-hop"
+            }
+         ]
+      }
+   }
+]

--- a/listenbrainz/testdata/mb_lookup_metadata_example.json
+++ b/listenbrainz/testdata/mb_lookup_metadata_example.json
@@ -1,0 +1,10 @@
+{
+   "artist_credit_name": "Rick Astley",
+   "artist_mbids": [
+      "db92a151-1ac2-438b-bc43-b82e149ddd50"
+   ],
+   "recording_mbid": "8f3471b5-7e6a-48da-86a9-c1c07a0f47ae",
+   "recording_name": "Never Gonna Give You Up",
+   "release_mbid": "18550a84-4ede-451c-a91a-dd9b3af9f71d",
+   "release_name": "Red Hot"
+}

--- a/listenbrainz/testdata/mb_metadata_cache_example.json
+++ b/listenbrainz/testdata/mb_metadata_cache_example.json
@@ -1,154 +1,111 @@
 {
-   "e97f805a-ab48-4c52-855e-07049142113d" : {
-      "tag" : {
-         "recording" : [
+   "e97f805a-ab48-4c52-855e-07049142113d": {
+      "tag": {
+         "recording": [
             {
-               "genre_mbid" : "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
-               "tag" : "trip hop",
-               "count" : 6
+               "count": 8,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
             },
             {
-               "count" : 1,
-               "tag" : "pop",
-               "genre_mbid" : "911c7bbb-172d-4df8-9478-dbff4296e791"
+               "count": 3,
+               "genre_mbid": "89255676-1f14-4dd8-bbad-fca839d6aff4",
+               "tag": "electronic"
             },
             {
-               "count" : 1,
-               "genre_mbid" : "608b0471-7531-4854-a348-e698c69cb699",
-               "tag" : "ambient"
-            },
-            {
-               "count" : 3,
-               "tag" : "trip-hop"
-            },
-            {
-               "count" : 1,
-               "genre_mbid" : "cc38aba3-48ed-439a-83b9-f81a34a66598",
-               "tag" : "downtempo"
-            },
-            {
-               "count" : 3,
-               "genre_mbid" : "89255676-1f14-4dd8-bbad-fca839d6aff4",
-               "tag" : "electronic"
-            },
-            {
-               "genre_mbid" : "b7864789-29e6-4965-84e4-463baaa869df",
-               "tag" : "chanson fran�aise",
-               "count" : 1
-            },
-            {
-               "genre_mbid" : "7dc2b20f-3953-4874-b9bf-41b8ba06d20c",
-               "tag" : "acid jazz",
-               "count" : 1
+               "count": 4,
+               "tag": "trip-hop"
             }
          ],
-         "artist" : [
+         "artist": [
             {
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "tag" : "uk",
-               "count" : 1
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 13,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
             },
             {
-               "genre_mbid" : "ba318056-9ddf-46cd-8b95-61fc993b962d",
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "tag" : "krautrock",
-               "count" : 2
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 7,
+               "tag": "trip-hop"
+            }
+         ],
+         "release_group": [
+            {
+               "count": 18,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
             },
             {
-               "count" : 4,
-               "tag" : "electronic",
-               "genre_mbid" : "89255676-1f14-4dd8-bbad-fca839d6aff4",
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
+               "count": 6,
+               "tag": "trip-hop"
             },
             {
-               "count" : 2,
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "genre_mbid" : "65c97e89-b42b-45c2-a70e-0eca1b8f0ff7",
-               "tag" : "experimental rock"
-            },
-            {
-               "genre_mbid" : "ec5a14c7-7793-46dc-b858-470183eb63f7",
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "tag" : "folktronica",
-               "count" : 1
-            },
-            {
-               "count" : 8,
-               "tag" : "trip hop",
-               "genre_mbid" : "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11"
-            },
-            {
-               "count" : 3,
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "tag" : "british"
-            },
-            {
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "genre_mbid" : "cc38aba3-48ed-439a-83b9-f81a34a66598",
-               "tag" : "downtempo",
-               "count" : 5
-            },
-            {
-               "tag" : "trip-hop",
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "count" : 8
-            },
-            {
-               "count" : 1,
-               "tag" : "electro-industrial",
-               "artist_mbid" : "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
-               "genre_mbid" : "6e2e809f-8c54-4e0f-aca0-0642771ab3cf"
+               "count": 1,
+               "tag": "mysterious"
             }
          ]
       },
-      "recording" : {
-         "rels" : [
+      "recording": {
+         "rels": [
             {
-               "artist_name" : "Beth Gibbons",
-               "instrument" : null,
-               "artist_mbid" : "5adcb9d9-5ea2-428d-af46-ef626966e106",
-               "type" : "vocal"
+               "artist_name": "Beth Gibbons",
+               "instrument": null,
+               "artist_mbid": "5adcb9d9-5ea2-428d-af46-ef626966e106",
+               "type": "vocal"
             },
             {
-               "artist_mbid" : "5082a11f-7203-4ff3-ae04-2a0150d3bbb6",
-               "type" : "instrument",
-               "instrument" : "Rhodes piano",
-               "artist_name" : "Geoff Barrow"
+               "artist_mbid": "5082a11f-7203-4ff3-ae04-2a0150d3bbb6",
+               "type": "instrument",
+               "instrument": "Rhodes piano",
+               "artist_name": "Geoff Barrow"
             },
             {
-               "type" : "instrument",
-               "artist_mbid" : "619b1116-740e-42e0-bdfe-96af274f79f7",
-               "instrument" : "guitar",
-               "artist_name" : "Adrian Utley"
+               "type": "instrument",
+               "artist_mbid": "619b1116-740e-42e0-bdfe-96af274f79f7",
+               "instrument": "guitar",
+               "artist_name": "Adrian Utley"
             },
             {
-               "artist_name" : "Clive Deamer",
-               "instrument" : "drums (drum set)",
-               "type" : "instrument",
-               "artist_mbid" : "d576e6be-03d1-489c-8c3e-692c6fbfb7ca"
+               "artist_name": "Clive Deamer",
+               "instrument": "drums (drum set)",
+               "type": "instrument",
+               "artist_mbid": "d576e6be-03d1-489c-8c3e-692c6fbfb7ca"
             }
          ]
       },
-      "release" : {
-         "caa_id" : 829521842,
-         "mbid" : "76df3287-6cda-33eb-8e9a-044b5e15ffdd"
+      "release": {
+         "album_artist_name": "Portishead",
+         "caa_id": 829521842,
+         "caa_release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
+         "mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
+         "name": "Dummy",
+         "release_group_mbid": "48140466-cff6-3222-bd55-63c27e43190d",
+         "year": 1994
       },
-      "artist" : [
-         {
-            "rels" : {
-               "official homepage" : "http://www.portishead.co.uk/",
-               "youtube" : "https://www.youtube.com/channel/UC243a5RnwmItLvwhl0YOxbg",
-               "purchase for download" : "https://itunes.apple.com/us/artist/id853090",
-               "wikidata" : "https://www.wikidata.org/wiki/Q191352",
-               "free streaming" : "https://open.spotify.com/artist/6liAMWkVf5LH7YR9yfFy1Y",
-               "social network" : "https://www.facebook.com/portishead",
-               "lyrics" : "https://muzikum.eu/en/122-6105/portishead/lyrics.html"
-            },
-            "begin_year" : 1991,
-            "area" : "United Kingdom",
-            "type" : "Group"
-         }
-      ]
+      "artist": {
+         "artist_credit_id": 65,
+         "name": "Portishead",
+         "artists": [
+            {
+               "area": "United Kingdom",
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "begin_year": 1991,
+               "join_phrase": "",
+               "name": "Portishead",
+               "rels": {
+                  "free streaming": "https://www.deezer.com/artist/1069",
+                  "lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html",
+                  "official homepage": "http://www.portishead.co.uk/",
+                  "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/",
+                  "social network": "https://www.facebook.com/portishead",
+                  "streaming": "https://tidal.com/artist/27441",
+                  "wikidata": "https://www.wikidata.org/wiki/Q191352",
+                  "youtube": "https://www.youtube.com/user/portishead1002"
+               },
+               "type": "Group"
+            }
+         ]
+      }
    }
 }

--- a/listenbrainz/testdata/mb_release_group_metadata_cache_example.json
+++ b/listenbrainz/testdata/mb_release_group_metadata_cache_example.json
@@ -1,0 +1,87 @@
+{
+   "48140466-cff6-3222-bd55-63c27e43190d": {
+      "artist": {
+         "artist_credit_id": 65,
+         "name": "Portishead",
+         "artists": [
+            {
+               "area": "United Kingdom",
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "begin_year": 1991,
+               "join_phrase": "",
+               "name": "Portishead",
+               "rels": {
+                  "free streaming": "https://www.deezer.com/artist/1069",
+                  "lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html",
+                  "official homepage": "http://www.portishead.co.uk/",
+                  "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/",
+                  "social network": "https://www.facebook.com/portishead",
+                  "streaming": "https://tidal.com/artist/27441",
+                  "wikidata": "https://www.wikidata.org/wiki/Q191352",
+                  "youtube": "https://www.youtube.com/user/portishead1002"
+               },
+               "type": "Group"
+            }
+         ]
+      },
+      "release": {
+         "caa_id": 829521842,
+         "caa_release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
+         "date": "1994-08-22",
+         "name": "Dummy",
+         "rels": [],
+         "type": "Album"
+      },
+      "release_group": {
+         "caa_id": 829521842,
+         "caa_release_mbid": "76df3287-6cda-33eb-8e9a-044b5e15ffdd",
+         "date": "1994-08-22",
+         "name": "Dummy",
+         "rels": [],
+         "type": "Album"
+      },
+      "tag": {
+         "artist": [
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 7,
+               "tag": "trip-hop"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 13,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 6,
+               "genre_mbid": "cc38aba3-48ed-439a-83b9-f81a34a66598",
+               "tag": "downtempo"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 5,
+               "genre_mbid": "65c97e89-b42b-45c2-a70e-0eca1b8f0ff7",
+               "tag": "experimental rock"
+            }
+         ],
+         "release_group": [
+            {
+               "count": 6,
+               "tag": "trip-hop"
+            },
+            {
+               "count": 4,
+               "genre_mbid": "cc38aba3-48ed-439a-83b9-f81a34a66598",
+               "tag": "downtempo"
+            },
+            {
+               "count": 18,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
+            }
+         ]
+      }
+   }
+}

--- a/listenbrainz/testdata/mv_artist_metadata_example.json
+++ b/listenbrainz/testdata/mv_artist_metadata_example.json
@@ -1,0 +1,41 @@
+[
+   {
+      "area": "United Kingdom",
+      "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+      "begin_year": 1991,
+      "mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+      "name": "Portishead",
+      "type": "Group",
+      "rels": {
+         "free streaming": "https://www.deezer.com/artist/1069",
+         "lyrics": "https://muzikum.eu/en/122-6105/portishead/lyrics.html",
+         "official homepage": "http://www.portishead.co.uk/",
+         "purchase for download": "https://www.junodownload.com/artists/Portishead/releases/",
+         "social network": "https://www.facebook.com/portishead",
+         "streaming": "https://tidal.com/artist/27441",
+         "wikidata": "https://www.wikidata.org/wiki/Q191352",
+         "youtube": "https://www.youtube.com/user/portishead1002"
+      },
+      "tag": {
+         "artist": [
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 6,
+               "genre_mbid": "cc38aba3-48ed-439a-83b9-f81a34a66598",
+               "tag": "downtempo"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 13,
+               "genre_mbid": "45eb1d9c-588c-4dc8-9394-a14b7c8f02bc",
+               "tag": "trip hop"
+            },
+            {
+               "artist_mbid": "8f6bd1e4-fbe1-4f50-aa9b-94c450ec0f11",
+               "count": 7,
+               "tag": "trip-hop"
+            }
+         ]
+      }
+   }
+]

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -239,6 +239,11 @@ def get_mbid_mapping():
     The total number of characters in the artist name, recording name and release name query arguments should be
     less than or equal to :data:`~webserver.views.metadata_api.MAX_MAPPING_QUERY_LENGTH`.
 
+    The data returned by this endpoint can be seen here:
+
+    .. literalinclude:: ../../../listenbrainz/testdata/mb_lookup_metadata_example.json
+       :language: json
+
     :param artist_name: artist name of the listen
     :type artist_name: ``str``
     :param recording_name: track name of the listen
@@ -522,7 +527,7 @@ def metadata_artist():
 
     The data returned by this endpoint can be seen here:
 
-    .. literalinclude:: ../../../listenbrainz/testdata/mb_metadata_cache_example.json
+    .. literalinclude:: ../../../listenbrainz/testdata/mb_artist_metadata_example.json
        :language: json
 
     :param artist_mbids: A comma separated list of recording_mbids


### PR DESCRIPTION
This updates some out of date example data for some of the /metadata/ endpoints:

/recording: tags for release group, updated artist shape, more information in release
/release_group: the example file was missing
/lookup: example was referred to but not included
/artist: used to be a copy of /recording

Also shortened the lists of tags so they're not super long on the page
