### PR TITLE
Fix flairs check in settings

### DIFF
--- a/frontend/js/src/settings/flairs/FlairsSettings.tsx
+++ b/frontend/js/src/settings/flairs/FlairsSettings.tsx
@@ -68,8 +68,8 @@ export default function FlairsSettings() {
         );
         const values = await response.text();
         const [shouldNag, daysLeft] = values.split(",");
-        setFlairUnlocked(Number(shouldNag) === 1);
-        setUnlockDaysLeft(Number(daysLeft));
+        setFlairUnlocked(Boolean(shouldNag));
+        setUnlockDaysLeft(Math.min(Number(daysLeft), 0));
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error("Could not fetch nag status:", error);


### PR DESCRIPTION
I coded it exactly the oppoisite as what it should be, in b0800a9e876ffced7a0437d7cff09b8d1d585866 . 
After fixing an issue with CORS to be able to hit the metabrainz.org nag-check endpoint, I realized it was showing me the worng information, i.e. that flairs were unlocked and i had negative 3 days remaining.

Fixed the inverted boolean check as well as limit to positive days remaining.