### PR TITLE
fix: rearranged the gaps arround the playlist sorter button

### DIFF
--- a/frontend/css/playlists.less
+++ b/frontend/css/playlists.less
@@ -4,7 +4,7 @@
 #playlists-container {
   display: flex;
   flex-wrap: wrap;
-  padding-top: 1.5em;
+  padding-top: 1em;
 
   .playlist {
     margin: 0.5em;
@@ -142,4 +142,5 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  margin-top: 0.8em;
 }


### PR DESCRIPTION
This PR rearrange the gaps before and after the sort button on the playlist page, giving more space before, and removing some after, making it more balanced.

Before:
![image](https://github.com/user-attachments/assets/3d6d94b6-5f80-4175-ae48-c1cdae2dbed2)

After:
![image](https://github.com/user-attachments/assets/bfd1f654-b147-43d9-9457-6c3250bd3af8)

(It's my first PR so hopefully I did the process correctly)

