### PR TITLE
Update brainzutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ eventlet == 0.35.2
 # eventlet fails to patch dnspython >= 2.3 https://github.com/eventlet/eventlet/issues/781
 dnspython==2.6.1
 uWSGI==2.0.26
-sentry-sdk[flask]==1.38.0
+sentry-sdk[flask]==2.19.2
 pydantic == 1.10.13
 pycountry==22.3.5
 Flask==3.0.0
@@ -39,8 +39,7 @@ Flask-UUID==0.2
 msgpack==0.5.6
 requests==2.32.0
 SQLAlchemy==2.0.23
-mbdata@git+https://github.com/amCap1712/mbdata.git@fix-sqlalchemy-warnings
-sqlalchemy-dst==1.0.1
+mbdata@git+https://github.com/acoustid/mbdata.git@v29.0.0
 typesense==0.14.0
 unidecode>=1.3.4
 Levenshtein==0.20.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ yattag == 1.14.0
 xmltodict == 0.13.0
 oauth2client == 4.1.3
 pika == 1.2.1
-brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@upgrade-deps
+brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v2.9.0
 spotipy>=2.22.1
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@830ecb2b2120acbd5deed2dab4587784c7be04b6
 troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@v2024.12.04.0


### PR DESCRIPTION
CI image build currently fails because the upgrade-deps tag of brainzutils-python cannot be found. Maybe the branch was deleted or something? In any case, the last change to this package was last year so an upgrade is overdue

Example of failure:
https://github.com/metabrainz/listenbrainz-server/actions/runs/12470852347/job/34806935084
> WARNING: Did not find branch or tag 'upgrade-deps', assuming revision or ref.
#26 2.478   Running command git checkout -q upgrade-deps
#26 2.485   error: pathspec 'upgrade-deps' did not match any file(s) known to git
#26 2.488   error: subprocess-exited-with-error