### PR TITLE
fix: Fetch Artist info for redirected MBIDs

### DIFF
--- a/listenbrainz/db/artist.py
+++ b/listenbrainz/db/artist.py
@@ -23,7 +23,7 @@ def load_artists_from_mbids_with_redirects(mb_curs, mbids: Iterable[str]) -> lis
              JOIN mbids m
                ON a.gid = m.gid::UUID
      """
-    results = execute_values(mb_curs, query, [(mbid,) for mbid in mbids], fetch=True)
+    results = execute_values(mb_curs, query, [(mbid,) for mbid in redirected_mbids], fetch=True)
     metadata_idx = {row["artist_mbid"]: row for row in results}
 
     # Finally collate all the results, ensuring that we have one entry with original_recording_mbid for each input
@@ -32,15 +32,17 @@ def load_artists_from_mbids_with_redirects(mb_curs, mbids: Iterable[str]) -> lis
         redirected_mbid = index.get(mbid, mbid)
         if redirected_mbid not in metadata_idx:
             item = {
-                "artist_mbid": mbid,
+                "artist_mbid": redirected_mbid,
                 "name": None,
                 "comment": None,
                 "type": None,
-                "gender": None
+                "gender": None,
+                "original_artist_mbid": mbid
             }
         else:
             data = metadata_idx[redirected_mbid]
             item = dict(data)
+            item["original_artist_mbid"] = mbid
 
         output.append(item)
 

--- a/listenbrainz/db/similarity.py
+++ b/listenbrainz/db/similarity.py
@@ -114,6 +114,6 @@ def get_artists(mb_curs, ts_curs, mbids, algorithm, count):
 
     metadata = load_artists_from_mbids_with_redirects(mb_curs, similar_mbids)
     for item in metadata:
-        item["score"] = score_idx.get(item["artist_mbid"])
+        item["score"] = score_idx.get(item["original_artist_mbid"])
         item["reference_mbid"] = mbid_idx.get(item["artist_mbid"])
     return metadata


### PR DESCRIPTION
As reported on https://community.metabrainz.org/t/empty-neighboor-bubble/732844, the artist information is not being fetched for redirected MBID. 

This PR fixes that by fetching the data for the `redirected_mbids`.