### PR TITLE
Docs: Add link to a Swift client

### DIFF
--- a/docs/users/clients.rst
+++ b/docs/users/clients.rst
@@ -26,3 +26,7 @@ Python
 Java
 ^^^^^^
 * `listenbrainz-client <https://github.com/rain0r/listenbrainz-client/>`_
+
+Swift
+^^^^^
+* `ListenBrainzKit <https://swiftpackageindex.com/samglt/ListenBrainzKit/>`_


### PR DESCRIPTION
There wasn't a Swift client so I linked to [the one I made](https://swiftpackageindex.com/samglt/ListenBrainzKit). It doesn't have full coverage at the moment, but it does support all the Core and Metadata endpoints.