### PR TITLE
fix: Render Annotations for Playlist on Search page

### DIFF
--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -505,19 +505,6 @@
   }
 }
 
-.ellipsis {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.ellipsis-2-lines {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 #spacer {
   margin-top: 54px;
 }

--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -42,6 +42,7 @@
 @import "donations.less";
 @import "scroll-container.less";
 @import "flairs.less";
+@import "utilities.less";
 
 @icon-font-path: "/static/fonts/";
 

--- a/frontend/css/utilities.less
+++ b/frontend/css/utilities.less
@@ -1,0 +1,20 @@
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ellipsis-2-lines {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ellipsis-4-lines {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/js/src/search/PlaylistSearch.tsx
+++ b/frontend/js/src/search/PlaylistSearch.tsx
@@ -137,7 +137,12 @@ export default function PlaylistSearch(props: PlayListSearchProps) {
                       {playlist.title}
                     </Link>
                   </td>
-                  <td>{playlist?.annotation}</td>
+                  <td
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{
+                      __html: playlist?.annotation || "",
+                    }}
+                  />
                   <td>
                     <Link
                       to={`https://musicbrainz.org/user/${playlist?.creator}`}

--- a/frontend/js/src/search/PlaylistSearch.tsx
+++ b/frontend/js/src/search/PlaylistSearch.tsx
@@ -138,6 +138,7 @@ export default function PlaylistSearch(props: PlayListSearchProps) {
                     </Link>
                   </td>
                   <td
+                    className="ellipsis-4-lines"
                     // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{
                       __html: playlist?.annotation || "",


### PR DESCRIPTION
**Before:**
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/335cd2df-5c52-4051-94fb-daca6d4df778" />

**After:** 
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/f6c9f744-66f7-480a-815d-881f45a14640" />
