### PR TITLE
LB-1715: BrainzPlayer overlaps filters on Fresh Releases page

### DIFF
--- a/frontend/css/fresh-releases.less
+++ b/frontend/css/fresh-releases.less
@@ -316,10 +316,10 @@
   }
   .sidebar-fresh-releases {
     max-height: 85vh;
-    
+
     @media screen and (max-width: @screen-md) {
       max-height: calc(100vh - @brainzplayer-height);
-    }    
+    }
   }
 }
 

--- a/frontend/css/fresh-releases.less
+++ b/frontend/css/fresh-releases.less
@@ -314,6 +314,9 @@
   .sidebar {
     flex: 0 0 250px;
   }
+  .sidebar-fresh-releases {
+    max-height: 85vh;
+  }
 }
 
 .sidebar {

--- a/frontend/css/fresh-releases.less
+++ b/frontend/css/fresh-releases.less
@@ -316,6 +316,10 @@
   }
   .sidebar-fresh-releases {
     max-height: 85vh;
+    
+    @media screen and (max-width: @screen-md) {
+      max-height: calc(100vh - @brainzplayer-height);
+    }    
   }
 }
 

--- a/frontend/css/sidebar.less
+++ b/frontend/css/sidebar.less
@@ -74,10 +74,6 @@
   }
 }
 
-.sidebar-fresh-releases {
-  max-height: 85vh;
-}
-
 .sidebar-overlay {
   position: fixed;
   top: 0;

--- a/frontend/css/sidebar.less
+++ b/frontend/css/sidebar.less
@@ -74,6 +74,10 @@
   }
 }
 
+.sidebar-fresh-releases {
+  max-height: 85vh;
+}
+
 .sidebar-overlay {
   position: fixed;
   top: 0;

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
@@ -210,7 +210,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
   ]);
 
   return (
-    <SideBar>
+    <SideBar className="sidebar-fresh-releases">
       <div
         className="sidebar-header"
         data-testid="sidebar-header-fresh-releases"

--- a/frontend/js/src/settings/link-listens/MultiTrackMBIDMappingModal.tsx
+++ b/frontend/js/src/settings/link-listens/MultiTrackMBIDMappingModal.tsx
@@ -300,7 +300,8 @@ export default NiceModal.create(
       matchingTracks && Object.entries(matchingTracks);
     const hasMatches = Boolean(matchingTracksEntries?.length);
     const unmatchedItems =
-      unlinkedListens.filter((md) => !matchingTracks?.[md.recording_msid]) ?? [];
+      unlinkedListens.filter((md) => !matchingTracks?.[md.recording_msid]) ??
+      [];
 
     // We may need to escape or replace the Lucene search special characters
     // + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /     as described in


### PR DESCRIPTION
# Problem

The problem is mentioned in this ticket: [LB-1715](https://tickets.metabrainz.org/browse/LB-1715)
Some of the fresh releases sidebar options were hidden due to the BrainzPlayer.



# Solution

Made a new class and changed the max-height to 85vh instead of 100vh. Applied that class to the sidebar component in fresh releases page.

![Ubuntu-2024-12-29-23-50-17](https://github.com/user-attachments/assets/fd61a3d5-0607-4b44-aa31-01e6caf0cd0d)

