### PR TITLE
Order listen inside parquet files in dumps

### DIFF
--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -386,6 +386,7 @@ class DumpListenStore:
                        FROM listen_with_mbid l
                   LEFT JOIN mapping.mb_metadata_cache mbc
                          ON l.m_recording_mbid = mbc.recording_mbid
+                   ORDER BY {criteria}
                 """).format(criteria=psycopg2.sql.Identifier("l", criteria))  # l is the listen table's alias
 
         listen_count = 0


### PR DESCRIPTION
Makes it easier to make sense of the logs while tracking dumps' progress.