### PR TITLE
fix: Text not visible in YIM 2024 Stats image

### DIFF
--- a/frontend/js/src/user/year-in-music/2024/YearInMusic2024.tsx
+++ b/frontend/js/src/user/year-in-music/2024/YearInMusic2024.tsx
@@ -501,7 +501,6 @@ export default class YearInMusic extends React.Component<
     const linkToUserProfile = `https://listenbrainz.org/user/${user.name}`;
     const linkToThisPage = `${linkToUserProfile}/year-in-music/2024`;
     const imageShareCustomStyles = `.background {\nfill: ${backgroundColor};\n}\n`;
-    const statsImageCustomStyles = `.background, text {\nfill: ${backgroundColor};\n}\n.outline {\nstroke: ${selectedSeason.text};\n}\n`;
     const buddiesImages = [
       `/static/img/year-in-music-24/${selectedSeasonName}/buddies/yim24-buddy-01.png`,
       `/static/img/year-in-music-24/${selectedSeasonName}/buddies/yim24-buddy-02.png`,
@@ -1205,7 +1204,6 @@ export default class YearInMusic extends React.Component<
                     shareUrl={`${linkToThisPage}#stats`}
                     shareTitle="My music listening in 2024"
                     fileName={`${user.name}-stats-2024`}
-                    customStyles={statsImageCustomStyles}
                   />
                 </div>
               </div>


### PR DESCRIPTION
The text color and background color are being set in the backend and are correctly returned by the endpoint. However, when you try downloading the image, the custom styles change the text color, making it difficult to read.

Since these styles are not necessary, I have removed them.

This PR is live on https://test.listenbrainz.org/
 

Before:
![image](https://github.com/user-attachments/assets/8809c344-2ca2-4083-9e78-1915b140d735)

After:
![image](https://github.com/user-attachments/assets/9853dd9d-258f-4e06-a266-c584f8380661)
