### PR TITLE
UI Improvement: Improved tooltip styling in settings page

### DIFF
--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -587,7 +587,7 @@
   text-decoration: unset !important;
 }
 
-.link-listens-tooltip{
+.link-listens-tooltip {
   border-bottom: 1px dotted #000;
   text-decoration: none;
 }

--- a/frontend/css/listens-page.less
+++ b/frontend/css/listens-page.less
@@ -586,3 +586,8 @@
   color: unset !important;
   text-decoration: unset !important;
 }
+
+.link-listens-tooltip{
+  border-bottom: 1px dotted #000;
+  text-decoration: none;
+}

--- a/frontend/js/src/settings/link-listens/LinkListens.tsx
+++ b/frontend/js/src/settings/link-listens/LinkListens.tsx
@@ -249,15 +249,16 @@ export default function LinkListensPage() {
         first.
       </ReactTooltip>
       <p>
-        You will find below your top 1000 listens (grouped by album) that have{" "}
+        You will find below your top 1000 listens (grouped by album) that
+        have&nbsp;
         <u
           className="link-listens-tooltip"
           data-tip
           data-for="matching-tooltip"
         >
           not been automatically linked
-        </u>{" "}
-        to a MusicBrainz recording. Link them below or&nbsp;
+        </u>
+        &nbsp; to a MusicBrainz recording. Link them below or&nbsp;
         <a href="https://wiki.musicbrainz.org/How_to_Contribute">
           submit new data to MusicBrainz
         </a>

--- a/frontend/js/src/settings/link-listens/LinkListens.tsx
+++ b/frontend/js/src/settings/link-listens/LinkListens.tsx
@@ -249,14 +249,14 @@ export default function LinkListensPage() {
         first.
       </ReactTooltip>
       <p>
-        You will find below your top 1000 listens (grouped by album) that have
-        not been automatically linked
-        <FontAwesomeIcon
-          icon={faQuestionCircle}
-          size="sm"
+        You will find below your top 1000 listens (grouped by album) that have{" "}
+        <u
+          className="link-listens-tooltip"
           data-tip
           data-for="matching-tooltip"
-        />{" "}
+        >
+          not been automatically linked
+        </u>{" "}
         to a MusicBrainz recording. Link them below or&nbsp;
         <a href="https://wiki.musicbrainz.org/How_to_Contribute">
           submit new data to MusicBrainz


### PR DESCRIPTION
# Problem

The tooltip in Link Listens page was not looking good earlier, so I tried fixing it by adding underlined tooltip toggle instead of the question mark icon which looked weird between the text.
Hope this change makes the UI slightly better and goes well with the website's theme.


# Solution
I think the underlined tooltip looks better. I can even change the cursor style on hovering the underlined part as well to make it more intuitive. Please let me know if its required.

Earlier it looked like this:
![image](https://github.com/user-attachments/assets/4509a6e1-22ad-4a1a-af1e-cbd072686096)

Now it looks like this:
![image](https://github.com/user-attachments/assets/d8fde20c-c225-4b5a-87cc-17207212400e)



