### PR TITLE
Accept potentially invalid dates

### DIFF
--- a/frontend/js/src/explore/fresh-releases/components/ReleaseCard.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseCard.tsx
@@ -4,6 +4,7 @@ import { faPlay, faHourglass } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isArray, isString, isUndefined } from "lodash";
 import { Link } from "react-router-dom";
+import { isValid } from "date-fns";
 import { formatListenCount, formatReleaseDate } from "../utils";
 import {
   generateAlbumArtThumbnailLink,
@@ -68,7 +69,8 @@ export default function ReleaseCard(props: ReleaseCardProps) {
   const hasReleaseDate =
     !isUndefined(releaseDate) &&
     isString(releaseDate) &&
-    Boolean(releaseDate.length);
+    Boolean(releaseDate.length) &&
+    isValid(new Date(releaseDate));
   const futureRelease = hasReleaseDate && new Date(releaseDate) > new Date();
   const COVERART_PLACEHOLDER = "/static/img/cover-art-placeholder.jpg";
   const RELEASE_TYPE_UNKNOWN = "Unknown";

--- a/frontend/js/src/explore/fresh-releases/utils.tsx
+++ b/frontend/js/src/explore/fresh-releases/utils.tsx
@@ -1,3 +1,4 @@
+import { isValid } from "date-fns";
 import { useEffect, useState } from "react";
 
 export function formatReleaseDate(
@@ -7,7 +8,7 @@ export function formatReleaseDate(
     day: "numeric",
   }
 ) {
-  if (!releaseDate) {
+  if (!releaseDate || !isValid(new Date(releaseDate))) {
     return "-";
   }
   return new Intl.DateTimeFormat(undefined, formatOptions).format(

--- a/frontend/js/src/settings/link-listens/MultiTrackMBIDMappingModal.tsx
+++ b/frontend/js/src/settings/link-listens/MultiTrackMBIDMappingModal.tsx
@@ -11,6 +11,7 @@ import { toast } from "react-toastify";
 import Tooltip from "react-tooltip";
 import Fuse from "fuse.js";
 import { omit, size, uniq } from "lodash";
+import { isValid } from "date-fns";
 import ListenCard from "../../common/listens/ListenCard";
 import { ToastMsg } from "../../notifications/Notifications";
 import GlobalAppContext from "../../utils/GlobalAppContext";
@@ -461,11 +462,12 @@ export default NiceModal.create(
                   >
                     <strong>{selectedAlbum.title}</strong>
                   </a>
-                  {selectedAlbum.date && (
-                    <span>
-                      &nbsp;({new Date(selectedAlbum.date).getFullYear()})
-                    </span>
-                  )}
+                  {selectedAlbum.date &&
+                    isValid(new Date(selectedAlbum.date)) && (
+                      <span>
+                        &nbsp;({new Date(selectedAlbum.date).getFullYear()})
+                      </span>
+                    )}
                   &nbsp;–&nbsp;
                   {selectedAlbum["artist-credit"]
                     ?.map((artist) => `${artist.name}${artist.joinphrase}`)

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -17,7 +17,7 @@ import {
   uniqBy,
   without,
 } from "lodash";
-import { formatDuration } from "date-fns";
+import { formatDuration, isValid } from "date-fns";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
 import SearchAlbumOrMBID from "../../utils/SearchAlbumOrMBID";
@@ -242,7 +242,7 @@ export default function AddAlbumListens({
               >
                 <strong>{selectedAlbum.title}</strong>
               </a>
-              {selectedAlbum.date && (
+              {selectedAlbum.date && isValid(new Date(selectedAlbum.date)) && (
                 <span>
                   &nbsp;({new Date(selectedAlbum.date).getFullYear()})
                 </span>

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -468,7 +468,7 @@ const fullLocalizedDateFromTimestampOrISODate = (
 const convertDateToUnixTimestamp = (date: Date): number => {
   const newDate = new Date(date);
   const timestampInMs = newDate.getTime();
-  const unixTimestamp = Math.floor(newDate.getTime() / 1000);
+  const unixTimestamp = Math.floor(timestampInMs / 1000);
   return unixTimestamp;
 };
 


### PR DESCRIPTION
A user stumbled upon an issue with a partial date with a year and day but no month ("1993-??-01").
The browser's date parser does not like that at all and throws an error which breaks the page entirely.
We need to check if the date is valid before parsing, in a few places in the code where we might receive such dates.


For reference, the issue was trying to add [this recording](https://musicbrainz.org/recording/fe6bb919-b5d5-4e59-a096-4eda7ba4e504) for [this release](https://musicbrainz.org/release/774d0f07-a554-4be0-b259-f1e492e4cfc9)