### PR TITLE
Add OpenGraph meta tags in artist, album and user pages

### DIFF
--- a/listenbrainz/webserver/templates/index.html
+++ b/listenbrainz/webserver/templates/index.html
@@ -29,13 +29,15 @@
   <meta property="og:title" content="{{ opengraph_title }}" />
   <meta property="og:type" content="{{ opengraph_type }}" />
   <meta property="og:description" content="{{ opengraph_description }}" />
-  <!--  OpenGraph image meta tags -->
-  <meta
+  {%- if 'image' not in (og_meta_tags or {}) -%}
+    <!--  OpenGraph image meta tags -->
+    <meta
     property="og:image"
     content="{{ url_for('static', filename='img/share-header.png', _external=True) }}"
-  />
-  <meta property="og:image:width" content="1280" />
-  <meta property="og:image:height" content="640" />
+    />
+    <meta property="og:image:width" content="1280" />
+    <meta property="og:image:height" content="640" />
+  {%- endif -%}
   <!-- Other OpenGraph meta tags (title, type and description are already handled above) -->
   {%- for tagname, tagvalue in (og_meta_tags or {}).items() if tagname not in ['description', 'title', 'type']-%}
     <meta property="og:{{ tagname }}" content="{{ tagvalue }}" />

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -34,7 +34,7 @@ def sizeof_readable(num, suffix='B'):
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yb', suffix)
 
-def number_readable(num):
+def number_readable(num:int):
     # Solution by rtaft from https://stackoverflow.com/a/45846841/4904467
     """ Converts a number to a short human-readable format (1.2K, 6.6M, etc.)"""
     suffixes = ['', 'K', 'M', 'B', 'T']

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -34,6 +34,16 @@ def sizeof_readable(num, suffix='B'):
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yb', suffix)
 
+def number_readable(num):
+    # Solution by rtaft from https://stackoverflow.com/a/45846841/4904467
+    """ Converts a number to a short human-readable format (1.2K, 6.6M, etc.)"""
+    suffixes = ['', 'K', 'M', 'B', 'T']
+    num = float('{:.2g}'.format(num))
+    magnitude = 0
+    while abs(num) >= 1000:
+        magnitude += 1
+        num /= 1000.0
+    return '{}{}'.format('{:f}'.format(num).rstrip('0').rstrip('.'), suffixes[magnitude])
 
 def reformat_date(value, fmt="%b %d, %Y"):
     return value.strftime(fmt)

--- a/listenbrainz/webserver/utils.py
+++ b/listenbrainz/webserver/utils.py
@@ -34,7 +34,8 @@ def sizeof_readable(num, suffix='B'):
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yb', suffix)
 
-def number_readable(num:int):
+
+def number_readable(num: int):
     # Solution by rtaft from https://stackoverflow.com/a/45846841/4904467
     """ Converts a number to a short human-readable format (1.2K, 6.6M, etc.)"""
     suffixes = ['', 'K', 'M', 'B', 'T']
@@ -44,6 +45,7 @@ def number_readable(num:int):
         magnitude += 1
         num /= 1000.0
     return '{}{}'.format('{:f}'.format(num).rstrip('0').rstrip('.'), suffixes[magnitude])
+
 
 def reformat_date(value, fmt="%b %d, %Y"):
     return value.strftime(fmt)

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -113,7 +113,7 @@ def release_redirect(release_mbid):
 
 @artist_bp.route("/",  defaults={'path': ''})
 @artist_bp.route("/<artist_mbid>/", methods=["GET"])
-def artist_page(artist_mbid:str):
+def artist_page(artist_mbid: str):
     og_meta_tags = None
     if is_valid_uuid(artist_mbid) and artist_mbid not in {"89ad4ac3-39f7-470e-963a-56509c546377"}:
         artist_data = get_metadata_for_artist(ts_conn, [artist_mbid])
@@ -125,10 +125,12 @@ def artist_page(artist_mbid:str):
             release_group_data = artist.release_group_data
             release_group_mbids = [rg["mbid"] for rg in release_group_data]
             album_count = len(release_group_mbids)
-            listening_stats = get_entity_listener(db_conn, "artists", artist_mbid, "all_time")
+            listening_stats = get_entity_listener(
+                db_conn, "artists", artist_mbid, "all_time")
             total_listen_count = 0
             if listening_stats and "total_listen_count" in listening_stats:
-                total_listen_count = number_readable(listening_stats["total_listen_count"] or 0)
+                total_listen_count = number_readable(
+                    listening_stats["total_listen_count"] or 0)
 
             og_meta_tags = {
                 "title": f'{artist_name}',
@@ -143,7 +145,7 @@ def artist_page(artist_mbid:str):
 
 @artist_bp.route("/<artist_mbid>/", methods=["POST"])
 @web_listenstore_needed
-def artist_entity(artist_mbid:str):
+def artist_entity(artist_mbid: str):
     """ Show a artist page with all their relevant information """
     # VA artist mbid
     if artist_mbid in {"89ad4ac3-39f7-470e-963a-56509c546377"}:
@@ -235,7 +237,7 @@ def artist_entity(artist_mbid:str):
 
 @album_bp.route("/",  defaults={'path': ''})
 @album_bp.route("/<release_group_mbid>/", methods=["GET"])
-def album_page(release_group_mbid:str):
+def album_page(release_group_mbid: str):
     og_meta_tags = None
     if is_valid_uuid(release_group_mbid):
         metadata = fetch_release_group_metadata(
@@ -257,10 +259,12 @@ def album_page(release_group_mbid:str):
             album_name = release_group.get("release_group").get("name")
             artist_name = release_group.get("artist").get("name")
             track_count = len(recording_mbids)
-            listening_stats = get_entity_listener(db_conn, "release_groups", release_group_mbid, "all_time")
+            listening_stats = get_entity_listener(
+                db_conn, "release_groups", release_group_mbid, "all_time")
             total_listen_count = 0
             if listening_stats and "total_listen_count" in listening_stats:
-                total_listen_count = number_readable(listening_stats["total_listen_count"] or 0)
+                total_listen_count = number_readable(
+                    listening_stats["total_listen_count"] or 0)
 
             og_meta_tags = {
                 "title": f'{album_name} — {artist_name}',
@@ -273,13 +277,13 @@ def album_page(release_group_mbid:str):
                 "image:alt": f"Cover art for {album_name}",
                 "url": f'{current_app.config["SERVER_ROOT_URL"]}/album/{release_group_mbid}',
             }
-            
+
     return render_template("index.html", og_meta_tags=og_meta_tags)
 
 
 @album_bp.route("/<release_group_mbid>/", methods=["POST"])
 @web_listenstore_needed
-def album_entity(release_group_mbid:str):
+def album_entity(release_group_mbid: str):
     """ Show an album page with all their relevant information """
 
     if not is_valid_uuid(release_group_mbid):

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -8,6 +8,7 @@ from listenbrainz.db import popularity, similarity
 from listenbrainz.db.stats import get_entity_listener
 from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.decorators import web_listenstore_needed
+from listenbrainz.webserver.utils import number_readable
 from listenbrainz.db.metadata import get_metadata_for_artist
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
 from listenbrainz.webserver.views.metadata_api import fetch_release_group_metadata
@@ -129,7 +130,7 @@ def artist_page(artist_mbid:str):
 
             og_meta_tags = {
                 "title": f'{artist_name}',
-                "description": f'Artist - {total_listen_count} listens — {album_count} albums — ListenBrainz',
+                "description": f'Artist - {number_readable(total_listen_count)} listens — {album_count} albums — ListenBrainz',
                 "type": "profile",
                 "profile:username": artist_name,
                 "profile.gender": artist.artist_data.get("gender"),

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -268,7 +268,9 @@ def album_page(release_group_mbid:str):
                 "type": "music.album",
                 "music:musician": artist_name,
                 "music:release_date": release_group.get("release_group").get("date"),
-                "image": f'https://coverartarchive.org/release-group/{release_group_mbid}/front',
+                "image": f'https://coverartarchive.org/release-group/{release_group_mbid}/front-500',
+                "image:width": "500",
+                "image:alt": f"Cover art for {album_name}",
                 "url": f'{current_app.config["SERVER_ROOT_URL"]}/album/{release_group_mbid}',
             }
             

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -124,13 +124,15 @@ def artist_page(artist_mbid:str):
             artist_name = artist.artist_data.get("name")
             release_group_data = artist.release_group_data
             release_group_mbids = [rg["mbid"] for rg in release_group_data]
-            popularity_data, _ = popularity.get_counts(ts_conn, "release_group", release_group_mbids)
             album_count = len(release_group_mbids)
-            total_listen_count = sum(rg["total_listen_count"] or 0 for rg in popularity_data)
+            listening_stats = get_entity_listener(db_conn, "artists", artist_mbid, "all_time")
+            total_listen_count = 0
+            if listening_stats and "total_listen_count" in listening_stats:
+                total_listen_count = number_readable(listening_stats["total_listen_count"] or 0)
 
             og_meta_tags = {
                 "title": f'{artist_name}',
-                "description": f'Artist - {number_readable(total_listen_count)} listens — {album_count} albums — ListenBrainz',
+                "description": f'Artist - {total_listen_count} listens — {album_count} albums — ListenBrainz',
                 "type": "profile",
                 "profile:username": artist_name,
                 "profile.gender": artist.artist_data.get("gender"),

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -466,4 +466,4 @@ def index(user_name, path):
             "profile:username": user_name,
             "url": f'{current_app.config["SERVER_ROOT_URL"]}/user/{user_name}/',
         }
-    return render_template("index.html", og_meta_tags=og_meta_tags)
+    return render_template("index.html", og_meta_tags=og_meta_tags, user=user)

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -21,6 +21,7 @@ from listenbrainz.webserver import timescale_connection, db_conn, ts_conn
 from listenbrainz.webserver.errors import APIBadRequest
 from listenbrainz.webserver.login import User, api_login_required
 from listenbrainz.webserver.views.api import DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL
+from listenbrainz.webserver.utils import number_readable
 from werkzeug.exceptions import NotFound
 
 from brainzutils import cache
@@ -450,4 +451,19 @@ def year_in_music(user_name, year: int = 2024):
 @web_listenstore_needed
 def index(user_name, path):
     user = _get_user(user_name)
-    return render_template("index.html", user=user)
+    if not user:
+        og_meta_tags = None
+    else:
+        listen_count = None
+        try:
+            listen_count = timescale_connection._ts.get_listen_count_for_user(user.id)
+        except psycopg2.OperationalError as err:
+            current_app.logger.error("cannot fetch user listen count: ", str(err))
+        og_meta_tags = {
+            "title": f"{user_name} on ListenBrainz",
+            "description": f'User{f" — {number_readable(listen_count)} listens" if listen_count else ""} — ListenBrainz',
+            "type": "profile",
+            "profile:username": user_name,
+            "url": f'{current_app.config["SERVER_ROOT_URL"]}/user/{user_name}/',
+        }
+    return render_template("index.html", og_meta_tags=og_meta_tags)


### PR DESCRIPTION
### To be merged *after* #3078 

We talked SEO and OpenGraph tags recently with Ansh, and as I have been working on playlist OpenGraph tags  in #3078 (as requested by a user [on the forums](https://community.metabrainz.org/t/syndication-feeds-atom-rss-now-out-for-beta-testing/726559/18)), I thought now was the perfect time to implement OG tags in other relevant pages, while it's all fresh in my head.

#### Artist pages:
I haven't added a custom image yet, not exactly sure what to do.
We can't put a link to the SVGs we use in LB pages, because SVGs are not supported in OG tags.
![image](https://github.com/user-attachments/assets/f41af3e7-79a7-4786-8408-ccf5811859cc)
![image](https://github.com/user-attachments/assets/c2cf51a5-f294-4bb2-8b5b-aa77d9a8c70d)

#### Album pages:
![image](https://github.com/user-attachments/assets/2bd83c3a-ae49-4261-96e9-4b6d96fe87a0)
![image](https://github.com/user-attachments/assets/beec8130-ccce-4176-bcfb-4eb8a4140eff)

#### User pages:
![image](https://github.com/user-attachments/assets/f923e20f-9c74-4ae1-b75d-a574bdba47ac)
![image](https://github.com/user-attachments/assets/9385042e-9a59-45e9-9105-253f06b2f5ce)
