### PR TITLE
Fix cursor style and remove extra spaces on stats page

### DIFF
--- a/frontend/css/stats.less
+++ b/frontend/css/stats.less
@@ -23,6 +23,9 @@
     height: calc(100% * 0.6);
     position: relative;
   }
+  &.user-artist-map path[fill]:not([fill="#efefef"]):not([fill="none"]) {
+    cursor: pointer;
+  }
 }
 
 @bar-height: 4.5em;

--- a/frontend/js/src/user/stats/UserReports.tsx
+++ b/frontend/js/src/user/stats/UserReports.tsx
@@ -74,8 +74,8 @@ export default function UserReports() {
         NiceModal.show(StatsExplanationsModal);
       }}
     >
-      <FontAwesomeIcon icon={faInfoCircle} />
-      &nbsp; How and when are statistics calculated?
+      <FontAwesomeIcon icon={faInfoCircle} style={{ marginRight: "0.5rem" }} />
+      How and when are statistics calculated?
     </button>
   );
 


### PR DESCRIPTION
# Problem

1. The cursor on the statistics page was the default pointer instead of a hand pointer when hovering over clickable areas.

![image](https://github.com/user-attachments/assets/4918bd2a-3485-4003-b3c1-074b064ee93e)
2. There were unnecessary extra spaces on the info link in the statistics page, which appeared multiple times.

![image](https://github.com/user-attachments/assets/7a964288-217d-4180-9f97-a894d6f1d86c)


# Solution

1. Changed the cursor style to cursor: pointer to improve the user experience for clickable areas.

![image](https://github.com/user-attachments/assets/f00b2f93-0b98-421e-a0b9-4b742cbe0e5c)
2. Removed the extra spaces from the statistics page content wherever they appeared using a margin instead.

![image](https://github.com/user-attachments/assets/73037fd5-dbab-4ee9-88a2-7541525ab8d3)


# Action

1. Please review the changes to ensure they align with the project's style guide.
2. Verify that the updated cursor and spacing improvements work as intended on the live site.

