### PR TITLE
Add space before license link in GDPR text

### DIFF
--- a/frontend/js/src/gdpr/GDPR.tsx
+++ b/frontend/js/src/gdpr/GDPR.tsx
@@ -53,7 +53,7 @@ export default function GDPR() {
           <p>
             By signing into ListenBrainz, you grant the MetaBrainz Foundation
             permission to include your listening history in data dumps we make
-            publicly available under the
+            publicly available under the{" "}
             <a href="https://creativecommons.org/publicdomain/zero/1.0/">
               CC0 license
             </a>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

There's missing whitespace before the license link in the GDPR blurb that's displayed after signing up.

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution

I added the whitespace :)

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


