### PR TITLE
Use SPA navigation for link to playlist after adding track

### DIFF
--- a/frontend/js/src/common/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/common/listens/AddToPlaylist.tsx
@@ -6,6 +6,7 @@ import {
   faPlusCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { toast } from "react-toastify";
+import { Link } from "react-router-dom";
 import NiceModal, { useModal } from "@ebay/nice-modal-react";
 import { ToastMsg } from "../../notifications/Notifications";
 import { PLAYLIST_URI_PREFIX, listenToJSPFTrack } from "../../playlists/utils";
@@ -100,7 +101,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
               message={
                 <>
                   Successfully added <i>{trackToSend.title}</i> to playlist{" "}
-                  <a href={playlistIdentifier}>{playlistName}</a>
+                  <Link to={playlistIdentifier}>{playlistName}</Link>
                 </>
               }
             />,

--- a/frontend/js/src/common/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/common/listens/AddToPlaylist.tsx
@@ -101,7 +101,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
               message={
                 <>
                   Successfully added <i>{trackToSend.title}</i> to playlist{" "}
-                  <Link to={playlistIdentifier}>{playlistName}</Link>
+                  <Link to={`/playlist/${playlistId}`}>{playlistName}</Link>
                 </>
               }
             />,

--- a/frontend/js/src/common/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/common/listens/AddToPlaylist.tsx
@@ -89,7 +89,6 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
           throw new Error(`No identifier for playlist ${playlistName}`);
         }
         const playlistId = playlistIdentifier?.replace(PLAYLIST_URI_PREFIX, "");
-        const playlistUrl = new URL(playlistIdentifier)
         const status = await APIService.addPlaylistItems(
           currentUser.auth_token,
           playlistId,
@@ -102,7 +101,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
               message={
                 <>
                   Successfully added <i>{trackToSend.title}</i> to playlist{" "}
-                  <Link to={playlistUrl.pathname}>{playlistName}</Link>
+                  <Link to={playlistIdentifier}>{playlistName}</Link>
                 </>
               }
             />,

--- a/frontend/js/src/common/listens/AddToPlaylist.tsx
+++ b/frontend/js/src/common/listens/AddToPlaylist.tsx
@@ -89,6 +89,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
           throw new Error(`No identifier for playlist ${playlistName}`);
         }
         const playlistId = playlistIdentifier?.replace(PLAYLIST_URI_PREFIX, "");
+        const playlistUrl = new URL(playlistIdentifier)
         const status = await APIService.addPlaylistItems(
           currentUser.auth_token,
           playlistId,
@@ -101,7 +102,7 @@ export default NiceModal.create((props: AddToPlaylistProps) => {
               message={
                 <>
                   Successfully added <i>{trackToSend.title}</i> to playlist{" "}
-                  <Link to={playlistIdentifier}>{playlistName}</Link>
+                  <Link to={playlistUrl.pathname}>{playlistName}</Link>
                 </>
               }
             />,


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

When adding a track to a playlist, a toast is displayed containing a success message and a link to the playlist. The link to the playlist will abort any currently playing track, because it doesn't use JS-based navigation to prevent a full reload.

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->



# Solution

I updated the link to use `<Link />` instead of `<a />`.

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

I wasn't able to test this locally, so I'm not sure if I accidentally broke the link completely. It builds fine, but there are some (unrelated I think?) failing tests.

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


