### PR TITLE
LB-1718: fix top discoveries playlist

### DIFF
--- a/listenbrainz_spark/year_in_music/top_discoveries.py
+++ b/listenbrainz_spark/year_in_music/top_discoveries.py
@@ -2,6 +2,7 @@ from datetime import datetime, date, time
 
 from more_itertools import chunked
 
+from listenbrainz_spark.constants import LAST_FM_FOUNDING_YEAR
 from listenbrainz_spark.path import RECORDING_ARTIST_DATAFRAME
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import get_listens_from_dump
@@ -66,7 +67,7 @@ def generate_top_discoveries(year):
 
 
 def create_tracks_of_the_year(year):
-    start = datetime(year, 1, 1)
+    start = datetime(LAST_FM_FOUNDING_YEAR, 1, 1)
     end = datetime.combine(date(year, 12, 31), time.max)
     listens = get_listens_from_dump(start, end)
     listens.createOrReplaceTempView("listens_for_tracks_of_year")


### PR DESCRIPTION
To find tracks discovered in a year correctly, need to use all listens.