### PR TITLE
LB-1528: Added shortcut to today's date in Fresh Releases using a Calendar Icon

### DIFF
--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCalendarCheck } from "@fortawesome/free-solid-svg-icons";
 import { formatReleaseDate, useMediaQuery } from "../utils";
 import { SortDirection } from "../FreshReleases";
+import { COLOR_LB_BLUE } from "../../../utils/constants";
 
 type ReleaseTimelineProps = {
   releases: Array<FreshReleaseItem>;
@@ -40,7 +41,7 @@ function createMarks(
         <FontAwesomeIcon
           icon={faCalendarCheck}
           size="2xl"
-          style={{ color: "#353070" }}
+          color={COLOR_LB_BLUE}
         />
       ) : (
         formatReleaseDate(item)

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import Slider from "rc-slider";
 import { countBy, debounce, zipObject } from "lodash";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCalendarCheck } from "@fortawesome/free-solid-svg-icons";
 import { formatReleaseDate, useMediaQuery } from "../utils";
 import { SortDirection } from "../FreshReleases";
 
@@ -15,7 +17,7 @@ function createMarks(
   sortDirection: string,
   order: string
 ) {
-  let dataArr: Array<string> = [];
+  let dataArr: Array<React.ReactNode> = [];
   let percentArr: Array<number> = [];
   // We want to filter out the keys that have less than 1.5% of the total releases
   const minReleasesThreshold = Math.floor(releases.length * 0.015);
@@ -24,11 +26,26 @@ function createMarks(
       releases,
       (item: FreshReleaseItem) => item.release_date
     );
-    const filteredDates = Object.keys(releasesPerDate).filter(
-      (date) => releasesPerDate[date] >= minReleasesThreshold
+    const today = new Date();
+    const todayString = today.toISOString().split("T")[0];
+    const formattedTodayString = formatReleaseDate(todayString);
+    const filteredDates = Object.keys(releasesPerDate).filter((date) =>
+      date !== todayString
+        ? releasesPerDate[date] >= minReleasesThreshold
+        : releasesPerDate[date] > 0
     );
 
-    dataArr = filteredDates.map((item) => formatReleaseDate(item));
+    dataArr = filteredDates.map((item) =>
+      formatReleaseDate(item) === formattedTodayString ? (
+        <FontAwesomeIcon
+          icon={faCalendarCheck}
+          size="2xl"
+          style={{ color: "#353070" }}
+        />
+      ) : (
+        formatReleaseDate(item)
+      )
+    );
     percentArr = filteredDates
       .map((item) => (releasesPerDate[item] / releases.length) * 100)
       .map((_, index, arr) =>
@@ -103,7 +120,9 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
   const { releases, order, direction } = props;
 
   const [currentValue, setCurrentValue] = React.useState<number | number[]>();
-  const [marks, setMarks] = React.useState<{ [key: number]: string }>({});
+  const [marks, setMarks] = React.useState<{ [key: number]: React.ReactNode }>(
+    {}
+  );
 
   const screenMd = useMediaQuery("(max-width: 992px)"); // @screen-md
 

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -129,9 +129,7 @@ export default function ReleaseTimeline(props: ReleaseTimelineProps) {
   const { releases, order, direction } = props;
 
   const [currentValue, setCurrentValue] = React.useState<number | number[]>();
-  const [marks, setMarks] = React.useState<{ [key: number]: React.ReactNode }>(
-    {}
-  );
+  const [marks, setMarks] = React.useState<{ [key: number]: React.ReactNode }>({});
 
   const screenMd = useMediaQuery("(max-width: 992px)"); // @screen-md
 

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -28,22 +28,21 @@ function createMarks(
       releases,
       (item: FreshReleaseItem) => item.release_date
     );
-    const today = new Date();
     const filteredDates = Object.keys(releasesPerDate).filter((date) =>
-      isToday(today)
-        ? releasesPerDate[date] >= minReleasesThreshold
-        : releasesPerDate[date] > 0
+      isToday(new Date(date))
+        ? releasesPerDate[date] >= 0
+        : releasesPerDate[date] > minReleasesThreshold
     );
 
-    dataArr = filteredDates.map((item) =>
-      isToday(new Date(item)) ? (
+    dataArr = filteredDates.map((date) =>
+      isToday(new Date(date)) ? (
         <FontAwesomeIcon
           icon={faCalendarCheck}
           size="2xl"
           color={COLOR_LB_BLUE}
         />
       ) : (
-        formatReleaseDate(item)
+        formatReleaseDate(date)
       )
     );
     percentArr = filteredDates

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseTimeline.tsx
@@ -3,6 +3,7 @@ import Slider from "rc-slider";
 import { countBy, debounce, zipObject } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCalendarCheck } from "@fortawesome/free-solid-svg-icons";
+import { isToday } from "date-fns";
 import { formatReleaseDate, useMediaQuery } from "../utils";
 import { SortDirection } from "../FreshReleases";
 import { COLOR_LB_BLUE } from "../../../utils/constants";
@@ -18,7 +19,7 @@ function createMarks(
   sortDirection: string,
   order: string
 ) {
-  let dataArr: Array<React.ReactNode> = [];
+  let dataArr: Array<string | JSX.Element> = [];
   let percentArr: Array<number> = [];
   // We want to filter out the keys that have less than 1.5% of the total releases
   const minReleasesThreshold = Math.floor(releases.length * 0.015);
@@ -28,16 +29,14 @@ function createMarks(
       (item: FreshReleaseItem) => item.release_date
     );
     const today = new Date();
-    const todayString = today.toISOString().split("T")[0];
-    const formattedTodayString = formatReleaseDate(todayString);
     const filteredDates = Object.keys(releasesPerDate).filter((date) =>
-      date !== todayString
+      isToday(today)
         ? releasesPerDate[date] >= minReleasesThreshold
         : releasesPerDate[date] > 0
     );
 
     dataArr = filteredDates.map((item) =>
-      formatReleaseDate(item) === formattedTodayString ? (
+      isToday(new Date(item)) ? (
         <FontAwesomeIcon
           icon={faCalendarCheck}
           size="2xl"


### PR DESCRIPTION
# Problem
[LB-1528](https://tickets.metabrainz.org/browse/LB-1528): Add shortcut to today's date in Fresh Releases

# Solution
Added a calendar icon in the datewise scroll bar as a ticker to directly refer to today's date.

![image](https://github.com/user-attachments/assets/8c71854a-9738-4f9d-92c7-b15951a538a0)

# Action

- Let me know if any additional details or corrections are required.
- If the changes look good, kindly proceed with merging the PR.
