### PR TITLE
LB-1724: Improve 'link listens' / 'link with musicbrainz' text

### DIFF
--- a/docs/general/data-update-intervals.rst
+++ b/docs/general/data-update-intervals.rst
@@ -13,6 +13,7 @@ Removing deleted listens from stats			    On the 2nd and 16th of each month
 Full dumps						                1st and 15th of each month
 Incremental dumps					            Daily
 Weekly playlists						           Monday morning, based on the users timezone setting
+Link listens						           Monday morning, based on the users timezone setting
 Daily playlists [#f3]_						          Every morning, based on the users timezone setting
 =============================================== =========================================
 

--- a/docs/general/data-update-intervals.rst
+++ b/docs/general/data-update-intervals.rst
@@ -12,8 +12,8 @@ Updating statistics for new listens			    Daily [#f2]_
 Removing deleted listens from stats			    On the 2nd and 16th of each month
 Full dumps						                1st and 15th of each month
 Incremental dumps					            Daily
-Weekly playlists						           Monday morning, based on the users timezone setting
 Link listens						           Monday morning, based on the users timezone setting
+Weekly playlists						           Monday morning, based on the users timezone setting
 Daily playlists [#f3]_						          Every morning, based on the users timezone setting
 =============================================== =========================================
 

--- a/docs/general/data-update-intervals.rst
+++ b/docs/general/data-update-intervals.rst
@@ -7,14 +7,14 @@ Expected schedule:
 System                                          Update schedule
 =============================================== =========================================
 Receiving listens, updating listen counts		Immediate [#f1]_
-Deleting listens					            Removed at the top of the next hour (UTC)
+Deleting listens					                  Removed at the top of the next hour (UTC)
 Updating statistics for new listens			    Daily [#f2]_
 Removing deleted listens from stats			    On the 2nd and 16th of each month
-Full dumps						                1st and 15th of each month
-Incremental dumps					            Daily
-Link listens						           Monday morning, based on the users timezone setting
-Weekly playlists						           Monday morning, based on the users timezone setting
-Daily playlists [#f3]_						          Every morning, based on the users timezone setting
+Full dumps						                      1st and 15th of each month
+Incremental dumps					                  Daily
+Link listens						                    Monday morning at 2AM (UTC)
+Weekly playlists						                Monday morning, based on the user's timezone setting
+Daily playlists [#f3]_						          Every morning, based on the user's timezone setting
 =============================================== =========================================
 
 Situations will occasionally arise where these take longer. If you have been a very patient user, and

--- a/frontend/js/src/settings/link-listens/LinkListens.tsx
+++ b/frontend/js/src/settings/link-listens/LinkListens.tsx
@@ -249,8 +249,7 @@ export default function LinkListensPage() {
         first.
       </ReactTooltip>
       <p>
-        You will find below your top 1000 listens (grouped by album) that
-        have&nbsp;
+        Your top 1,000 listens (grouped by album) that have&nbsp;
         <u
           className="link-listens-tooltip"
           data-tip
@@ -258,19 +257,19 @@ export default function LinkListensPage() {
         >
           not been automatically linked
         </u>
-        &nbsp; to a MusicBrainz recording. Link them below or&nbsp;
-        <a href="https://wiki.musicbrainz.org/How_to_Contribute">
-          submit new data to MusicBrainz
-        </a>
-        .
+        &nbsp;to a MusicBrainz recording.
       </p>
       <p className="small">
         <a href="https://musicbrainz.org/">MusicBrainz</a> is the open-source
-        music encyclopedia that ListenBrainz uses to display more information
-        about your music.
+        music encyclopedia that ListenBrainz uses to display information about
+        your music.&nbsp;
+        <a href="https://wiki.musicbrainz.org/How_to_Contribute">
+          Submit missing data to MusicBrainz
+        </a>
+        .
       </p>
       {!isNil(lastUpdated) && (
-        <p>Last updated {new Date(lastUpdated).toLocaleDateString()}</p>
+      <p className="small"> Updates Mondays, based on listen data. Last updated {new Date(lastUpdated).toLocaleDateString()}</p>
       )}
       <br />
       <div>

--- a/frontend/js/src/settings/link-listens/LinkListens.tsx
+++ b/frontend/js/src/settings/link-listens/LinkListens.tsx
@@ -13,7 +13,7 @@ import { Helmet } from "react-helmet";
 
 import NiceModal from "@ebay/nice-modal-react";
 
-import { groupBy, isNil, isNull, pick, size, sortBy } from "lodash";
+import { groupBy, isNil, isNull, isString, pick, size, sortBy } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useQuery } from "@tanstack/react-query";
 import ReactTooltip from "react-tooltip";
@@ -86,6 +86,15 @@ export default function LinkListensPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const pageSearchParam = searchParams.get("page");
 
+  const lastUpdatedHumanReadable = isString(lastUpdated)
+    ? new Date(lastUpdated).toLocaleString(undefined, {
+        day: "2-digit",
+        month: "short",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+      })
+    : "—";
   // State
   const [deletedListens, setDeletedListens] = React.useState<Array<string>>([]);
   const [unlinkedListens, setUnlinkedListens] = React.useState<
@@ -269,7 +278,10 @@ export default function LinkListensPage() {
         .
       </p>
       {!isNil(lastUpdated) && (
-      <p className="small"> Updates Mondays, based on listen data. Last updated {new Date(lastUpdated).toLocaleDateString()}</p>
+        <p className="small">
+          Updates every Monday at 2AM (UTC). Last updated{" "}
+          {lastUpdatedHumanReadable}
+        </p>
       )}
       <br />
       <div>


### PR DESCRIPTION
Clarifying when and how 'Link listens' page data gets updated.
Tightened up the text and text hierarchy while in there, to try avoid the text amount piling up.

Specifically:
- Added Link listens to the Data Update Intervals document table
- Changed the page text to have a succinct header/explanatory paragraph (without any how-to text)
- Moved some how-to text to the small print
- Added when the page updates (Monday) to the small print