### PR TITLE
Add back button and secondary navbar to playlist pages

### DIFF
--- a/frontend/js/src/layout/LayoutWithBackButton.tsx
+++ b/frontend/js/src/layout/LayoutWithBackButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Outlet, ScrollRestoration, useNavigate } from "react-router-dom";
 
-export default function EntityPageLayout() {
+export default function LayoutWithBackButton() {
   const navigate = useNavigate();
 
   const goBack = () => {

--- a/frontend/js/src/routes/EntityPages.tsx
+++ b/frontend/js/src/routes/EntityPages.tsx
@@ -6,7 +6,7 @@ const getEntityPages = (): RouteObject[] => {
     {
       path: "/",
       lazy: async () => {
-        const EntityPageLayout = await import("../layout/EntityPages");
+        const EntityPageLayout = await import("../layout/LayoutWithBackButton");
         return { Component: EntityPageLayout.default };
       },
       children: [

--- a/frontend/js/src/routes/index.tsx
+++ b/frontend/js/src/routes/index.tsx
@@ -78,12 +78,23 @@ const getIndexRoutes = (): RouteObject[] => {
           },
         },
         {
-          path: "playlist/:playlistID/",
+          path: "playlist/",
           lazy: async () => {
-            const PlaylistPage = await import("../playlists/Playlist");
-            return { Component: PlaylistPage.default };
+            const LayoutWithBackButton = await import(
+              "../layout/LayoutWithBackButton"
+            );
+            return { Component: LayoutWithBackButton.default };
           },
-          loader: RouteLoader,
+          children: [
+            {
+              path: ":playlistID/",
+              lazy: async () => {
+                const PlaylistPage = await import("../playlists/Playlist");
+                return { Component: PlaylistPage.default };
+              },
+              loader: RouteLoader,
+            },
+          ],
         },
         {
           path: "/statistics/",


### PR DESCRIPTION
This was originally done in #2598 when we were still rendering everything in flask.
However it was lost in the move to single-page app architecture and front-end routing.
We did add the back button on artist and album pages (in a0cd3f5), but I am now making this layout component generic to be used for other such pages.

![image](https://github.com/user-attachments/assets/e846c34c-d76e-4459-bcd4-5d6f10b506d6)
