### PR TITLE
Atom feeds: Properly link to art API

### DIFF
--- a/listenbrainz/webserver/views/atom.py
+++ b/listenbrainz/webserver/views/atom.py
@@ -12,7 +12,7 @@ from listenbrainz.webserver.views.api_tools import (
     get_non_negative_param,
     is_valid_uuid,
 )
-from listenbrainz.webserver import db_conn, ts_conn
+from listenbrainz.webserver import db_conn, ts_conn, API_PREFIX
 from listenbrainz.db.fresh_releases import get_sitewide_fresh_releases
 from listenbrainz.db.fresh_releases import get_fresh_releases as db_get_fresh_releases
 from data.model.common_stat import StatisticsRange
@@ -881,14 +881,9 @@ def get_cover_art_grid_stats(user_name):
         )
 
     # Generate the data URL for the art
-    data_url = _external_url_for(
-        "art_api_v1.cover_art_grid_stats",
-        user_name=user_name,
-        time_range=range,
-        dimension=dimension,
-        layout=layout,
-        image_size=image_size,
-    )
+    # Using API_URL + API_PREFIX otherwise we link to lb.org/1/art/...
+    # which returns an error message to use api.lb.org/1/art/...
+    data_url = f'{current_app.config["API_URL"]}{API_PREFIX}/art/grid-stats/{user_name}/{range}/{dimension}/{layout}/{image_size}'
 
     this_feed_url = _external_url_for(".get_cover_art_grid_stats", user_name=user_name, range=range)
     user_stats_url = _external_url_for("user.index", path="stats", user_name=user_name, range=range)
@@ -983,13 +978,11 @@ def get_cover_art_custom_stats(user_name):
             f"Image size must be between {MIN_IMAGE_SIZE} and {MAX_IMAGE_SIZE}."
         )
 
-    data_url = _external_url_for(
-        "art_api_v1.cover_art_custom_stats",
-        custom_name=custom_name,
-        user_name=user_name,
-        time_range=range,
-        image_size=image_size,
-    )
+    # Generate the data URL for the art
+    # Using API_URL + API_PREFIX otherwise we link to lb.org/1/art/...
+    # which returns an error message to use api.lb.org/1/art/...
+    data_url = f'{current_app.config["API_URL"]}{API_PREFIX}/art/{custom_name}/{user_name}/{range}/{image_size}'
+
     this_feed_url = _external_url_for(".get_cover_art_custom_stats", user_name=user_name, range=range)
     user_stats_url = _external_url_for("user.index", path="stats", user_name=user_name, range=range)
     


### PR DESCRIPTION
Currently the use of _external_url_for results in a bad link to the API (lb.org/1/art/....) resulting in an error message "Please use the API at api.listenbrainz.org"

We need to manually construct a link to api.lb.org/1/art/... to fix that

Tested on test.LB with a couple different feed readers, the link is indeed fixed.
Some feed readers don't wan to render the SVG content of the feed items (for example for album grids SVGs), but having a link to the API endpoint serving the same SVG allows users to click somewhere to view the content in a browser.
Some readers have an integrated web view which can render the SVG content in a browser environment, some other feed readers also allow rendering the SVG content directly in the feed item.

I think this covers all bases.