### PR TITLE
Add Cache_Control private header to server responses

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -177,6 +177,12 @@ def create_app(debug=None):
     @app.after_request
     def after_request_callbacks(response):
         return inject_x_rate_headers(response)
+    
+    @app.after_request
+    def add_cache_header(response):
+        response.cache_control.private = True
+        response.cache_control.public = False
+        return response
 
     # Template utilities
     app.jinja_env.add_extension('jinja2.ext.do')

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -177,7 +177,7 @@ def create_app(debug=None):
     @app.after_request
     def after_request_callbacks(response):
         return inject_x_rate_headers(response)
-    
+
     @app.after_request
     def add_cache_header(response):
         response.cache_control.private = True


### PR DESCRIPTION
We have seen issues where it seems that a user's cookies are sent to the wrong user, making it appear like you are logged into another user's account. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#private_caches as well as  https://stackoverflow.com/a/26813182

I created this branch months ago and promptly forgot about it entirely.
Now I anm cleaning old branches, here we are :)