### PR TITLE
Added LastFM save button in setting in accordance to LB-1721.

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -57,6 +57,10 @@ export default function MusicServices() {
       : undefined
   );
 
+  const [lastFMSubmit, setlastFMSubmit] = React.useState(
+    permissions.lastfm === "import" ? "LastFMConnect" : "disable"
+  );
+
   const handlePermissionChange = async (
     serviceName: string,
     newValue: string
@@ -99,6 +103,9 @@ export default function MusicServices() {
             break;
           case "critiquebrainz":
             if (critiquebrainzAuth) critiquebrainzAuth.access_token = undefined;
+            break;
+          case "lastfm":
+            setlastFMSubmit("disable");
             break;
           default:
             break;
@@ -438,6 +445,12 @@ export default function MusicServices() {
                     onChange={(e) => {
                       setLastfmUserId(e.target.value);
                     }}
+                    disabled={
+                      !(
+                        lastFMSubmit === "LastFMConnect" ||
+                        lastFMSubmit === "LastFMLovedTrack"
+                      )
+                    }
                   />
                 </div>
                 <div>
@@ -454,15 +467,41 @@ export default function MusicServices() {
                     }}
                     name="lastFMStartDatetime"
                     title="Date and time to start import at"
+                    disabled={
+                      !(
+                        lastFMSubmit === "LastFMConnect" ||
+                        lastFMSubmit === "LastFMLovedTrack"
+                      )
+                    }
                   />
+                </div>
+                <div style={{ flex: 0, alignSelf: "end" }}>
+                  <button
+                    disabled={
+                      !(
+                        lastFMSubmit === "LastFMConnect" ||
+                        lastFMSubmit === "LastFMLovedTrack"
+                      )
+                    }
+                    type="submit"
+                    className="btn btn-success"
+                    onClick={(e) => {
+                      if (lastFMSubmit === "LastFMLovedTrack") {
+                        handleImportFeedback(e, "lastfm");
+                      }
+                    }}
+                  >
+                    Submit
+                  </button>
                 </div>
               </div>
               <br />
               <div className="music-service-selection">
                 <button
-                  type="submit"
+                  type="button"
                   className="music-service-option"
                   style={{ width: "100%" }}
+                  onClick={() => setlastFMSubmit("LastFMConnect")}
                 >
                   <input
                     readOnly
@@ -470,7 +509,7 @@ export default function MusicServices() {
                     id="lastfm_import"
                     name="lastfm"
                     value="import"
-                    checked={permissions.lastfm === "import"}
+                    checked={lastFMSubmit === "LastFMConnect"}
                   />
                   <label htmlFor="lastfm_import">
                     <div className="title">
@@ -486,7 +525,7 @@ export default function MusicServices() {
                 <button
                   type="button"
                   className="music-service-option"
-                  onClick={(e) => handleImportFeedback(e, "lastfm")}
+                  onClick={() => setlastFMSubmit("LastFMLovedTrack")}
                 >
                   <input
                     readOnly
@@ -494,7 +533,7 @@ export default function MusicServices() {
                     id="lastfm_import_loved_tracks"
                     name="lastfm"
                     value="loved_tracks"
-                    checked={false}
+                    checked={lastFMSubmit === "LastFMLovedTrack"}
                   />
                   <label htmlFor="lastfm_import_loved_tracks">
                     <div className="title">Import loved tracks</div>
@@ -506,7 +545,7 @@ export default function MusicServices() {
                 </button>
                 <ServicePermissionButton
                   service="lastfm"
-                  current={permissions.lastfm ?? "disable"}
+                  current={lastFMSubmit === "disable" ? "disable" : ""}
                   value="disable"
                   title="Disable"
                   details="New scrobbles won't be imported from Last.FM"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
This solves a part of the ticket [LB-1721](https://tickets.metabrainz.org/browse/LB-1721), which aims to create a submit button in the LastFM connect services setting page to improve the UI.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The submit button and input fields are disabled in case someone has selected the Disable option. Other than that for "Connect to Last.FM" and "Import loved tracks", the submit button works according to the option selected. 
https://github.com/user-attachments/assets/a2a75f54-cedf-42a7-a26e-9ef7bea26544




