### PR TITLE
LB1721: Added LastFM save button in connect services setting.

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -58,6 +58,9 @@ export default function MusicServices() {
   );
 
   const [lastFMEdit, setLastFMEdit] = React.useState(false);
+  const [lastFMEditButtonClass, setlastFMEditButtonClass] = React.useState(
+    permissions.lastfm !== "import" ? "btn-default" : "btn-warning"
+  );
 
   const handlePermissionChange = async (
     serviceName: string,
@@ -101,6 +104,10 @@ export default function MusicServices() {
             break;
           case "critiquebrainz":
             if (critiquebrainzAuth) critiquebrainzAuth.access_token = undefined;
+            break;
+          case "lastfm":
+            setLastFMEdit(false);
+            setlastFMEditButtonClass("btn-default");
             break;
           default:
             break;
@@ -228,6 +235,8 @@ export default function MusicServices() {
           ...prevState,
           lastfm: "import",
         }));
+        setlastFMEditButtonClass("btn-warning");
+        setLastFMEdit(false);
       } else {
         const body = await response.json();
         if (body?.error) {
@@ -491,12 +500,15 @@ export default function MusicServices() {
                   <button
                     disabled={permissions.lastfm !== "import"}
                     type={lastFMEdit ? "button" : "submit"}
-                    className={
-                      permissions.lastfm !== "import"
-                        ? "btn-default"
-                        : (lastFMEdit && "btn-success") || "btn-warning"
-                    }
-                    onClick={() => setLastFMEdit((prev) => !prev)}
+                    className={`btn ${lastFMEditButtonClass}`}
+                    onClick={() => {
+                      setLastFMEdit((prev) => !prev);
+                      setlastFMEditButtonClass((prevClass) =>
+                        prevClass === "btn-warning"
+                          ? "btn-success"
+                          : "btn-warning"
+                      );
+                    }}
                   >
                     {lastFMEdit ? "Save" : "Edit"}
                   </button>

--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -57,6 +57,10 @@ export default function MusicServices() {
       : undefined
   );
 
+  const [lastFMSubmit, setlastFMSubmit] = React.useState(
+    permissions.lastfm === "import" ? "LastFMConnect" : "disable"
+  );
+
   const handlePermissionChange = async (
     serviceName: string,
     newValue: string
@@ -99,6 +103,9 @@ export default function MusicServices() {
             break;
           case "critiquebrainz":
             if (critiquebrainzAuth) critiquebrainzAuth.access_token = undefined;
+            break;
+          case "lastfm":
+            setlastFMSubmit("disable");
             break;
           default:
             break;
@@ -451,6 +458,12 @@ export default function MusicServices() {
                     onChange={(e) => {
                       setLastfmUserId(e.target.value);
                     }}
+                    disabled={
+                      !(
+                        lastFMSubmit === "LastFMConnect" ||
+                        lastFMSubmit === "LastFMLovedTrack"
+                      )
+                    }
                   />
                 </div>
                 <div>
@@ -467,15 +480,41 @@ export default function MusicServices() {
                     }}
                     name="lastFMStartDatetime"
                     title="Date and time to start import at"
+                    disabled={
+                      !(
+                        lastFMSubmit === "LastFMConnect" ||
+                        lastFMSubmit === "LastFMLovedTrack"
+                      )
+                    }
                   />
+                </div>
+                <div style={{ flex: 0, alignSelf: "end" }}>
+                  <button
+                    disabled={
+                      !(
+                        lastFMSubmit === "LastFMConnect" ||
+                        lastFMSubmit === "LastFMLovedTrack"
+                      )
+                    }
+                    type="submit"
+                    className="btn btn-success"
+                    onClick={(e) => {
+                      if (lastFMSubmit === "LastFMLovedTrack") {
+                        handleImportFeedback(e, "lastfm");
+                      }
+                    }}
+                  >
+                    Submit
+                  </button>
                 </div>
               </div>
               <br />
               <div className="music-service-selection">
                 <button
-                  type="submit"
+                  type="button"
                   className="music-service-option"
                   style={{ width: "100%" }}
+                  onClick={() => setlastFMSubmit("LastFMConnect")}
                 >
                   <input
                     readOnly
@@ -483,7 +522,7 @@ export default function MusicServices() {
                     id="lastfm_import"
                     name="lastfm"
                     value="import"
-                    checked={permissions.lastfm === "import"}
+                    checked={lastFMSubmit === "LastFMConnect"}
                   />
                   <label htmlFor="lastfm_import">
                     <div className="title">
@@ -499,7 +538,7 @@ export default function MusicServices() {
                 <button
                   type="button"
                   className="music-service-option"
-                  onClick={(e) => handleImportFeedback(e, "lastfm")}
+                  onClick={() => setlastFMSubmit("LastFMLovedTrack")}
                 >
                   <input
                     readOnly
@@ -507,7 +546,7 @@ export default function MusicServices() {
                     id="lastfm_import_loved_tracks"
                     name="lastfm"
                     value="loved_tracks"
-                    checked={false}
+                    checked={lastFMSubmit === "LastFMLovedTrack"}
                   />
                   <label htmlFor="lastfm_import_loved_tracks">
                     <div className="title">Import loved tracks</div>
@@ -519,7 +558,11 @@ export default function MusicServices() {
                 </button>
                 <ServicePermissionButton
                   service="lastfm"
-                  current={permissions.lastfm ?? "disable"}
+                  // !(
+                  //   lastFMSubmit === "LastFMConnect" ||
+                  //   lastFMSubmit === "LastFMLovedTrack"
+                  // )
+                  current={lastFMSubmit === "disable" ? "disable" : ""}
                   value="disable"
                   title="Disable"
                   details="New scrobbles won't be imported from Last.FM"

--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -58,9 +58,10 @@ export default function MusicServices() {
   );
 
   const [lastFMEdit, setLastFMEdit] = React.useState(false);
-  const [lastFMEditButtonClass, setlastFMEditButtonClass] = React.useState(
-    permissions.lastfm !== "import" ? "btn-default" : "btn-warning"
-  );
+  const lastFMEditButtonClass =
+    permissions.lastfm !== "import"
+      ? "btn-default"
+      : (lastFMEdit && "btn-success") || "btn-warning";
 
   const handlePermissionChange = async (
     serviceName: string,
@@ -107,7 +108,6 @@ export default function MusicServices() {
             break;
           case "lastfm":
             setLastFMEdit(false);
-            setlastFMEditButtonClass("btn-default");
             break;
           default:
             break;
@@ -235,7 +235,6 @@ export default function MusicServices() {
           ...prevState,
           lastfm: "import",
         }));
-        setlastFMEditButtonClass("btn-warning");
         setLastFMEdit(false);
       } else {
         const body = await response.json();
@@ -503,11 +502,6 @@ export default function MusicServices() {
                     className={`btn ${lastFMEditButtonClass}`}
                     onClick={() => {
                       setLastFMEdit((prev) => !prev);
-                      setlastFMEditButtonClass((prevClass) =>
-                        prevClass === "btn-warning"
-                          ? "btn-success"
-                          : "btn-warning"
-                      );
                     }}
                   >
                     {lastFMEdit ? "Save" : "Edit"}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
This solves a part of the ticket [LB-1721](https://tickets.metabrainz.org/browse/LB-1721), which aims to create a submit button in the LastFM connect services setting page to improve the UI. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The submit button and input fields are disabled if someone has selected the Disable option. Other than that for "Connect to Last.FM" and "Import loved tracks," the submit button works according to the option selected. 

https://github.com/user-attachments/assets/95030a0b-4bc1-494a-ba83-a150b513a871




