### PR TITLE
Create popularity {self.entity}_mbid indexes

### DIFF
--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -47,7 +47,8 @@ class PopularityDataset(DatabaseDataset):
             prefix = "popularity"
         return [
             f"CREATE INDEX {prefix}_{self.entity}_listen_count_idx_{{suffix}} ON {{table}} (total_listen_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE INDEX {prefix}_{self.entity}_user_count_idx_{{suffix}} ON {{table}} (total_user_count) INCLUDE ({self.entity_mbid})"
+            f"CREATE INDEX {prefix}_{self.entity}_user_count_idx_{{suffix}} ON {{table}} (total_user_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE INDEX {prefix}_{self.entity}_{self.entity}_mbid_idx_{{suffix}} ON {{table}} ({self.entity}_mbid)"
         ]
 
 


### PR DESCRIPTION
I created the following indexes by hand on gaga to reduce the load we experienced last week. I believe this PR should create those missing indexes the next time this data is generated:

CREATE INDEX popularity_artist_artist_mbid_idx ON popularity.artist (artist_mbid);
CREATE INDEX popularity_mlhd_artist_artist_mbid_idx ON popularity.mlhd_artist (artist_mbid);

CREATE INDEX popularity_release_release_mbid_idx ON popularity.release (release_mbid);
CREATE INDEX popularity_mlhd_release_release_group_mbid_idx ON popularity.mlhd_release (release_mbid);

CREATE INDEX popularity_release_group_release_group_mbid_idx ON popularity.release_group (release_group_mbid);
CREATE INDEX popularity_mlhd_release_group_release_group_mbid_idx ON popularity.mlhd_release_group (release_group_mbid);

CREATE INDEX popularity_recording_recording_mbid_idx ON popularity.recording (recording_mbid);
CREATE INDEX popularity_mlhd_recording_recording_mbid_idx ON popularity.mlhd_recording (recording_mbid);
