### PR TITLE
Fixed global feed page crashing

### DIFF
--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -119,8 +119,8 @@ def recent_listens():
         user_count = format(int(_get_user_count()), ',d')
     except DatabaseException as e:
         user_count = 'Unknown'
-    
-    #Get recent donors in production environment only.
+
+    # Get recent donors in production environment only.
     if current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
         recent_donors, _ = get_recent_donors(meb_conn, db_conn, 25, 0)
     else:

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -119,8 +119,12 @@ def recent_listens():
         user_count = format(int(_get_user_count()), ',d')
     except DatabaseException as e:
         user_count = 'Unknown'
-
-    recent_donors, _ = get_recent_donors(meb_conn, db_conn, 25, 0)
+    
+    #Get recent donors in production environment only.
+    if current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
+        recent_donors, _ = get_recent_donors(meb_conn, db_conn, 25, 0)
+    else:
+        recent_donors = []
 
     # Get MusicBrainz IDs for donors who are ListenBrainz users
     musicbrainz_ids = [donor["musicbrainz_id"]


### PR DESCRIPTION

# Problem

    Global feed kept crashing because donor's database is not created in local environment.



# Solution


   I added a condition which would return an empty donors list if the environment is set to development, this way it wont crash by calling recent_donors function. 



# Action


    We can create a test donor's db so that index renders that donor panel.



