### PR TITLE
Fix doc build error

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -317,6 +317,8 @@ def create_app_rtfd():
         '..', 'rtd_config.py'
     ))
 
+    app.url_map.converters["not_api_path"] = NotApiPathConverter
+
     _register_blueprints(app)
     return app
 


### PR DESCRIPTION
# Problem

Docs have been [failing to build](https://app.readthedocs.org/projects/listenbrainz/builds/26799324/) after [this commit](https://github.com/metabrainz/listenbrainz-server/commit/6a86710c2c06c75d5923f3cd55369a30371c3305) since the added converter wasn't registered in the special initializer for RTD
