### PR TITLE
LB-1710: Add global stats monitoring endpoint

### DIFF
--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -234,10 +234,7 @@ def get_service_status():
             break
 
         age = current_ts - global_stats
-        if global_stats_age is None:
-            global_stats_age = age
-
-        if age > global_stats_age:
+        if global_stats_age is None or age > global_stats_age:
             global_stats_age = age
 
     return {

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -107,7 +107,7 @@ def get_global_stats_timestamp():
     last_updated = cache.get(cache_key)
 
     if last_updated is None:
-        stats = stats = db_stats.get_sitewide_stats("artists", "all_time")
+        stats = db_stats.get_sitewide_stats("artists", "all_time")
         if stats is None:
             return None
 


### PR DESCRIPTION
This is the server portion of LB-1710, which implements the "global_stats_age" timestamp as port of our status_api.

Now added support for checking entities/ranges -- everything ran fast enough to be done in one stat. Phew!