### PR TITLE
LB-1726: Fixed following status glitching when followed from similar pane

### DIFF
--- a/frontend/js/src/user/components/follow/UserSocialNetwork.tsx
+++ b/frontend/js/src/user/components/follow/UserSocialNetwork.tsx
@@ -254,22 +254,36 @@ export default class UserSocialNetwork extends React.Component<
   ) => {
     const { currentUser } = this.context;
     const { user: profileUser } = this.props;
-    const { followingList } = this.state;
+    const { followingList, currentUserFollowingList } = this.state;
+
+    if (!currentUser) return;
+
+    // update the logged-in user's following list (for similar users pane)
+    const newCurrentUserFollowingList = [...currentUserFollowingList];
+    const currentUserIndex = newCurrentUserFollowingList.indexOf(user.name);
+
+    if (action === "follow" && currentUserIndex === -1) {
+      newCurrentUserFollowingList.push(user.name);
+    } else if (action === "unfollow" && currentUserIndex !== -1) {
+      newCurrentUserFollowingList.splice(currentUserIndex, 1);
+    }
+
+    // update the users following list (for followers/following pane)
     const newFollowingList = [...followingList];
-    const index = newFollowingList.findIndex(
-      (following) => following === user.name
-    );
-    if (action === "follow" && index === -1) {
-      newFollowingList.push(user.name);
+    if (profileUser.name === currentUser.name) {
+      const profileUserIndex = newFollowingList.indexOf(user.name);
+      if (action === "follow" && profileUserIndex === -1) {
+        newFollowingList.push(user.name);
+      } else if (action === "unfollow" && profileUserIndex !== -1) {
+        newFollowingList.splice(profileUserIndex, 1);
+      }
     }
-    if (
-      action === "unfollow" &&
-      index !== -1 &&
-      profileUser.name === currentUser?.name
-    ) {
-      newFollowingList.splice(index, 1);
-    }
-    this.setState({ followingList: newFollowingList });
+
+    // Update both lists in state
+    this.setState({
+      followingList: newFollowingList,
+      currentUserFollowingList: newCurrentUserFollowingList,
+    });
   };
 
   render() {

--- a/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
+++ b/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
@@ -166,11 +166,11 @@ describe("<UserSocialNetwork />", () => {
       });
 
       // initial state after first fetch
-      expect(instance.state.followingList).toEqual(["jack", "fnord"]);
+      expect(instance.state.currentUserFollowingList).toEqual(["jack", "fnord"]);
       await act(async () => {
         instance.updateFollowingList({ name: "Baldur" }, "follow");
       });
-      expect(instance.state.followingList).toEqual(["jack", "fnord", "Baldur"]);
+      expect(instance.state.currentUserFollowingList).toEqual(["jack", "fnord", "Baldur"]);
     });
 
     it("updates the state when called with action unfollow", async () => {
@@ -249,13 +249,13 @@ describe("<UserSocialNetwork />", () => {
       await act(async () => {
         instance.updateFollowingList({ name: "Baldur" }, "follow");
       });
-      expect(instance.state.followingList).toEqual(["jack", "fnord", "Baldur"]);
+      expect(instance.state.currentUserFollowingList).toEqual(["jack", "fnord", "Baldur"]);
 
       // Ensure we can't add a user twice
       await act(async () => {
         instance.updateFollowingList({ name: "Baldur" }, "follow");
       });
-      expect(instance.state.followingList).toEqual(["jack", "fnord", "Baldur"]);
+      expect(instance.state.currentUserFollowingList).toEqual(["jack", "fnord", "Baldur"]);
     });
 
     it("does nothing when trying to unfollow a user that is not followed", async () => {


### PR DESCRIPTION

# Problem

Follow button unable to correctly reflect the changes made to the following status of a user if followed from similar users pane and showing error if re-clicked.
https://tickets.metabrainz.org/browse/LB-1726 



# Solution

In updateFollowingList method, when a change was being made, it was only making a change in the followingList(the list used for similar users pane), but not the currentUserFollowingList which passed the old list to FollowersFollowingModal and hence the user following status was rendering from old list. So, i updated both currentUserFollowingList and followingList after a change is made.
Also, added verification if the current user.name is same to the profile user.name, and if it is same, then push or slice the usernames from following pane.

