### PR TITLE
LB-1729: Flairs settings shows incorrect time remaining

### DIFF
--- a/frontend/js/src/settings/flairs/FlairsSettings.tsx
+++ b/frontend/js/src/settings/flairs/FlairsSettings.tsx
@@ -67,8 +67,8 @@ export default function FlairsSettings() {
           `https://metabrainz.org/donations/nag-check?editor=${name}`
         );
         const values = await response.text();
-        const [shouldNag, daysLeft] = values.split(",");
-        setFlairUnlocked(!Number(shouldNag));
+        // discard the "shouldNag" value
+        const [_, daysLeft] = values.split(",");
         setUnlockDaysLeft(Math.max(Number(daysLeft), 0));
       } catch (error) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION

# Problem


Flair section in settings page shows the invalid status of user's flair. It uses both LB API's endpoint (donors/all-flairs) and MB's endpoint(nag-check), MB's endpoint returns the user's donation data without setting the threshold (FLAIR_MONTHLY_DONATION_THRESHOLD = 5) and it overrides the flairUnlocked value.

    https://tickets.metabrainz.org/browse/LB-1729




# Solution

 By discarding the nag value returned by nag-checker and not setting flairUnlocked value to it, we can just use LB's endpoint to verify user's donation status and then use nag-checker's daysLeft value to show the time left.




