### PR TITLE
Incremental Stats deployment fixes

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -4,6 +4,7 @@ from datetime import date
 
 import click
 import orjson
+from dateutil.relativedelta import relativedelta, MO
 from kombu import Connection
 from kombu.entity import PERSISTENT_DELIVERY_MODE, Exchange
 
@@ -87,7 +88,7 @@ def send_request_to_spark_cluster(query, **params):
 
 
 @cli.command(name="request_user_stats")
-@click.option("--type", 'type_', type=click.Choice(['entity', 'listening_activity', 'daily_activity', 'listeners']),
+@click.option("--type", 'type_', type=click.Choice(['entity', 'listening_activity', 'daily_activity']),
               help="Type of statistics to calculate", required=True)
 @click.option("--range", 'range_', type=click.Choice(ALLOWED_STATISTICS_RANGE),
               help="Time range of statistics to calculate", required=True)
@@ -95,24 +96,13 @@ def send_request_to_spark_cluster(query, **params):
               help="Entity for which statistics should be calculated")
 @click.option("--database", type=str, help="Name of the couchdb database to store data in")
 def request_user_stats(type_, range_, entity, database):
-    """ Send a user stats request to the spark cluster
-    """
+    """ Send a user stats request to the spark cluster """
     params = {
-        "stats_range": range_
+        "stats_range": range_,
+        "database": database
     }
-    if type_ in ["entity", "listener"] and entity:
+    if type_ == "entity" and entity:
         params["entity"] = entity
-
-    if not database and type_ != "entity":
-        today = date.today().strftime("%Y%m%d")
-        if type_ == "listeners":
-            prefix = f"{entity}_listeners"
-        else:
-            prefix = type_
-        database = f"{prefix}_{range_}_{today}"
-
-    params["database"] = database
-
     send_request_to_spark_cluster(f"stats.user.{type_}", **params)
 
 
@@ -146,15 +136,9 @@ def request_entity_stats(type_, range_, entity, database):
     """ Send an entity stats request to the spark cluster """
     params = {
         "stats_range": range_,
-        "entity": entity
+        "entity": entity,
+        "database": database
     }
-
-    if not database and type_ != "listeners":
-        today = date.today().strftime("%Y%m%d")
-        database = f"{type_}_{range_}_{today}"
-
-    params["database"] = database
-
     send_request_to_spark_cluster(f"stats.entity.{type_}", **params)
 
 

--- a/listenbrainz/spark/spark_dataset.py
+++ b/listenbrainz/spark/spark_dataset.py
@@ -136,7 +136,10 @@ class _StatsDataset(SparkDataset):
             )
 
     def handle_insert(self, message):
-        database = message["database"]
+        if "database_prefix" in message:
+            database = couchdb.list_databases(message["database_prefix"])[0]
+        else:
+            database = message["database"]
         stats_range = message["stats_range"]
         from_ts = message["from_ts"]
         to_ts = message["to_ts"]

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -179,8 +179,7 @@ class IncrementalStatsEngine:
         results = self.generate_stats()
         if not self.only_inc:
             yield self.message_creator.create_start_message()
-        for message in self.message_creator.create_messages(results):
-            message["only_inc"] = self.only_inc
+        for message in self.message_creator.create_messages(results, self.only_inc):
             yield message
         if not self.only_inc:
             yield self.message_creator.create_end_message()

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -81,7 +81,7 @@ class IncrementalStatsEngine:
             existing_from_date, existing_to_date = metadata["from_date"], metadata["to_date"]
             existing_aggregate_fresh = existing_from_date.date() == self.provider.from_date.date() \
                 and existing_to_date.date() <= self.provider.to_date.date()
-        except AnalysisException:
+        except (AnalysisException, IndexError):
             existing_aggregate_fresh = False
 
         existing_aggregate_exists = hdfs_connection.client.status(existing_aggregate_path, strict=False)

--- a/listenbrainz_spark/stats/incremental/listener/entity.py
+++ b/listenbrainz_spark/stats/incremental/listener/entity.py
@@ -11,7 +11,7 @@ class EntityListenerStatsQueryProvider(UserEntityStatsQueryProvider, abc.ABC):
     """ See base class QueryProvider for details. """
 
     def get_table_prefix(self) -> str:
-        return f"{self.entity}_listener_{self.stats_range}"
+        return f"{self.entity}_listeners_{self.stats_range}"
 
     def get_base_path(self) -> str:
         return LISTENBRAINZ_LISTENER_STATS_DIRECTORY
@@ -24,3 +24,7 @@ class EntityListenerStatsMessageCreator(UserStatsMessageCreator):
 
     def items_per_message(self):
         return 10000
+
+    @property
+    def default_database_prefix(self):
+        return f"{self.entity}_listeners_{self.stats_range}"

--- a/listenbrainz_spark/stats/incremental/sitewide/entity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/entity.py
@@ -62,7 +62,10 @@ class SitewideEntityStatsMessageCreator(StatsMessageCreator):
     def __init__(self, entity, selector):
         super().__init__(entity, "sitewide_entity", selector)
 
-    def create_messages(self, results: DataFrame) -> Iterator[Dict]:
+    def default_database_prefix(self):
+        return ""
+
+    def create_messages(self, results: DataFrame, only_inc: bool) -> Iterator[Dict]:
         message = {
             "type": self.message_type,
             "stats_range": self.stats_range,

--- a/listenbrainz_spark/stats/incremental/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/listening_activity.py
@@ -71,7 +71,10 @@ class ListeningActivitySitewideMessageCreator(StatsMessageCreator):
     def __init__(self, selector, database=None):
         super().__init__("listening_activty", "sitewide_listening_activity", selector, database)
 
-    def create_messages(self, results: DataFrame) -> Iterator[Dict]:
+    def default_database_prefix(self):
+        return ""
+
+    def create_messages(self, results: DataFrame, only_inc: bool) -> Iterator[Dict]:
         message = {
             "type": self.message_type,
             "stats_range": self.stats_range,

--- a/listenbrainz_spark/stats/incremental/user/daily_activity.py
+++ b/listenbrainz_spark/stats/incremental/user/daily_activity.py
@@ -97,6 +97,10 @@ class DailyActivityUserMessageCreator(UserStatsMessageCreator):
     def __init__(self, message_type: str, selector: StatsRangeListenRangeSelector, database=None):
         super().__init__("daily_activity", message_type, selector, database)
 
+    @property
+    def default_database_prefix(self):
+        return f"{self.entity}_{self.stats_range}"
+
     def parse_row(self, entry: dict):
         try:
             UserStatRecords[DailyActivityRecord](

--- a/listenbrainz_spark/stats/incremental/user/listening_activity.py
+++ b/listenbrainz_spark/stats/incremental/user/listening_activity.py
@@ -83,6 +83,10 @@ class ListeningActivityUserMessageCreator(UserStatsMessageCreator):
     def __init__(self, message_type: str, selector: ListeningActivityListenRangeSelector, database=None):
         super().__init__("listening_activity", message_type, selector, database)
 
+    @property
+    def default_database_prefix(self):
+        return f"{self.entity}_{self.stats_range}"
+
     def parse_row(self, row):
         try:
             UserStatRecords[ListeningActivityRecord](

--- a/listenbrainz_spark/stats/incremental/user/listening_activity.py
+++ b/listenbrainz_spark/stats/incremental/user/listening_activity.py
@@ -59,22 +59,31 @@ class ListeningActivityUserStatsQueryEntity(UserStatsQueryProvider):
         """
 
     def get_stats_query(self, final_aggregate):
+        # calculates the number of listens in each time range for each user, count(listen.listened_at) so that
+        # group without listens are counted as 0, count(*) gives 1.
+        # use cross join to create all time range rows for all users (otherwise ranges in which user was inactive
+        # would be missing from final output)
         return f"""
-             SELECT user_id
-                  , sort_array(
-                       collect_list(
+           WITH dist_user_id AS (
+               SELECT DISTINCT user_id FROM {final_aggregate}
+           )
+               SELECT d.user_id AS user_id
+                    , sort_array(
+                        collect_list(
                             struct(
-                                  to_unix_timestamp(start) AS from_ts
-                                , to_unix_timestamp(end) AS to_ts
-                                , time_range
-                                , COALESCE(listen_count, 0) AS listen_count
+                                  to_unix_timestamp(tr.start) AS from_ts
+                                , to_unix_timestamp(tr.end) AS to_ts
+                                , tr.time_range AS time_range
+                                , COALESCE(fa.listen_count, 0) AS listen_count
                             )
                         )
-                    ) AS listening_activity
-               FROM time_range
-          LEFT JOIN {final_aggregate}
-              USING (time_range)
-           GROUP BY user_id
+                      ) AS listening_activity
+                 FROM dist_user_id d
+           CROSS JOIN time_range tr
+            LEFT JOIN {final_aggregate} fa
+                   ON fa.time_range = tr.time_range
+                  AND fa.user_id = d.user_id
+             GROUP BY d.user_id
         """
 
 

--- a/listenbrainz_spark/stats/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/sitewide/listening_activity.py
@@ -23,4 +23,4 @@ def get_listening_activity(stats_range: str) -> Iterator[Optional[Dict]]:
     entity_obj = ListeningActivitySitewideStatsQuery(selector)
     message_creator = ListeningActivitySitewideMessageCreator(selector)
     engine = IncrementalStatsEngine(entity_obj, message_creator)
-    return aggregator.run()
+    return engine.run()

--- a/listenbrainz_spark/year_in_music/top_stats.py
+++ b/listenbrainz_spark/year_in_music/top_stats.py
@@ -8,6 +8,13 @@ from listenbrainz_spark.stats.user.entity import incremental_entity_map
 NUMBER_OF_YIM_ENTITIES = 50
 
 
+class YIMStatsMessageCreator(UserStatsMessageCreator):
+
+    @property
+    def default_database_prefix(self):
+        return f"{self.entity}_year_in_music"
+
+
 def calculate_top_entity_stats(year):
     from_date = datetime(year, 1, 1)
     to_date = datetime.combine(date(year, 12, 31), time.max)
@@ -16,9 +23,9 @@ def calculate_top_entity_stats(year):
     for entity in ["artists", "recordings", "release_groups"]:
         entity_cls = incremental_entity_map[entity]
         entity_obj = entity_cls(selector, NUMBER_OF_YIM_ENTITIES)
-        message_creator = UserStatsMessageCreator(entity, "year_in_music_top_stats", selector, "")
+        message_creator = YIMStatsMessageCreator(entity, "year_in_music_top_stats", selector, "")
         engine = IncrementalStatsEngine(entity_obj, message_creator)
-        for message in aggregator.run():
+        for message in engine.run():
             # yim stats are stored in postgres instead of couchdb so drop those messages for yim
             if message["type"] == "couchdb_data_start" or message["type"] == "couchdb_data_end":
                 continue


### PR DESCRIPTION
Currently, the database for each stat is generated and the previous database for the same stat is deleted daily. However, incremental stats generates messages only for users with listens in incremental dumps, assuming stats for users without new listens are already available on the LB server. To maintain this assumption, each stats database must have a fixed name. Therefore, avoid sending the database name from the LB server to Spark in stat generation requests. During stats generation, Spark determines whether it's a full or incremental generation. For full stats, a new database name is created and sent; for incremental stats, a database prefix is sent for the LB server to look up the existing database and insert the stats accordingly.