### PR TITLE
Alerts dismissal without states

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -412,7 +412,10 @@ export default function MusicServices() {
               Connect to your Last.FM account to import your entire listening
               history and automatically add your new scrobbles to ListenBrainz.
             </p>
-            <p className="alert alert-warning">
+            <div
+              className="alert alert-warning alert-dismissible fade in"
+              role="alert"
+            >
               You must first disable the &#34;Hide recent listening
               information&#34; setting in your Last.fm{" "}
               <a
@@ -423,7 +426,15 @@ export default function MusicServices() {
                 privacy settings
               </a>
               .
-            </p>
+              <button
+                type="button"
+                className="close"
+                data-dismiss="alert"
+                aria-label="Close"
+              >
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
             <form onSubmit={handleConnectToLaftFM}>
               <div className="flex flex-wrap" style={{ gap: "1em" }}>
                 <div>


### PR DESCRIPTION
#Problem

The alert wasnt dismissable and it felt like it reflected the status of user's last.fm connection.
https://tickets.metabrainz.org/browse/LB-1728

#Solution

Added a button which onclick disables the visibility of alert.

(This is #3154 's continuation because i pushed an old branch and that pr got closed)


