### PR TITLE
Link listens modal text cleanup

### DIFF
--- a/frontend/js/src/common/listens/MBIDMappingModal.tsx
+++ b/frontend/js/src/common/listens/MBIDMappingModal.tsx
@@ -166,15 +166,6 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
         aria-labelledby="MBIDMappingModalLabel"
       >
         <div className="modal-dialog" role="document">
-          <Tooltip id="musicbrainz-helptext" type="light" multiline>
-            Use the MusicBrainz search (musicbrainz.org/search) to search for
-            recordings (songs). When you have found the one that matches your
-            listen, copy its URL (link) into the field on this page.
-            <br />
-            You can also search for the album you listened to. When you have
-            found the album, click on the matching recording (song) in the track
-            listing, and copy its URL into the field on this page.
-          </Tooltip>
           <form className="modal-content" onSubmit={submitMBIDMapping}>
             <div className="modal-header">
               <button
@@ -186,30 +177,19 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
                 <span aria-hidden="true">&times;</span>
               </button>
               <h4 className="modal-title" id="MBIDMappingModalLabel">
-                Link this Listen with MusicBrainz
+                Link this listen with{" "}
+                <a href="https://musicbrainz.org/doc/About">MusicBrainz</a>
               </h4>
             </div>
             <div className="modal-body">
-              <p>
-                Sometimes ListenBrainz is unable to automatically link your
-                Listen with a MusicBrainz recording. Search by track and artist
-                name or paste a{" "}
-                <a href="https://musicbrainz.org/doc/About">MusicBrainz</a>{" "}
-                recording URL or MBID{" "}
-                <FontAwesomeIcon
-                  icon={faQuestionCircle}
-                  data-tip
-                  data-for="musicbrainz-helptext"
-                  size="sm"
-                />{" "}
-                below to link this Listen.
-              </p>
               <ListenCard
                 listen={listenToMap}
                 showTimestamp={false}
                 showUsername={false}
                 // eslint-disable-next-line react/jsx-no-useless-fragment
                 feedbackComponent={<></>}
+                // eslint-disable-next-line react/jsx-no-useless-fragment
+                customThumbnail={<></>}
                 compact
               />
 

--- a/frontend/js/src/settings/link-listens/LinkListens.tsx
+++ b/frontend/js/src/settings/link-listens/LinkListens.tsx
@@ -318,8 +318,9 @@ export default function LinkListensPage() {
       <h2 className="page-title">Link with MusicBrainz</h2>
       <ReactTooltip id="matching-tooltip" multiline>
         We automatically match listens with MusicBrainz recordings when
-        possible, which provides rich data like tags, album, artists, cover art,
-        and more.
+        possible,
+        <br />
+        which provides rich data like tags, album, artists, cover art, and more.
         <br />
         When a track can&apos;t be auto-matched you can manually link them on
         this page.


### PR DESCRIPTION
As discussed in LB-1722, after the changes in #3151 the modal looks a bit too busy.
Aerozol suggested removing the intro text and linking to MB in the title.

While in there I also fixed a couple of small details I noticed (capitalization in title, remove cover art for unlinked listen preview) as well as on the Link Listens page (formatting of help tooltip text)

Before:
![image](https://github.com/user-attachments/assets/dfe52e69-53ad-4eed-9b27-2bd7f57b783d)

After:
![image](https://github.com/user-attachments/assets/9b121071-1baf-46e5-b989-2219fcf61f3e)
