### PR TITLE
Add RTD status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 </h1>
 <h4 align="center">Server for the ListenBrainz project</h4>
 <p align="center">
+    <a href="https://app.readthedocs.org/projects/listenbrainz/">
+    <img src="https://readthedocs.org/projects/listenbrainz/badge/"
+         alt="Readthedocs status"></a>
     <a href="https://github.com/metabrainz/listenbrainz-server/commits/master">
     <img src="https://img.shields.io/github/last-commit/metabrainz/listenbrainz-server.svg?style=flat-square&logo=github&logoColor=white"
          alt="GitHub last commit"></a>


### PR DESCRIPTION
Since there's no monitoring for the documentation (that I'm aware of), adding this little badge should at least make it less hard to notice when it's broken