### PR TITLE
Fix: Add missing <ul> element to the template.

### DIFF
--- a/listenbrainz/webserver/templates/atom/top_artists.html
+++ b/listenbrainz/webserver/templates/atom/top_artists.html
@@ -1,4 +1,5 @@
 <p>
+  <ul>
     {% for artist in (artists or []) %}
         <li>
             {% if artist.artist_mbid %}
@@ -9,4 +10,5 @@
             {{ artist.listen_count }} listens
         </li>
     {% endfor %}
+  </ul>
 </p>


### PR DESCRIPTION
# Problem

The Top Artists feed HTML was missing the `<ul>` element to wrap all the generated `<li>` elements.

# Solution

I've added the missing `<ul>` element to the template.

