### PR TITLE
More granular incremental stats

### DIFF
--- a/listenbrainz_spark/popularity/listens.py
+++ b/listenbrainz_spark/popularity/listens.py
@@ -24,8 +24,8 @@ class PopularityProvider(QueryProvider):
     def get_base_path(self) -> str:
         return LISTENBRAINZ_POPULARITY_DIRECTORY
 
-    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   existing_created: Optional[datetime]) -> str:
+    def get_filter_aggregate_query_coarse(self, existing_aggregate: str, incremental_aggregate: str,
+                                          existing_created: Optional[datetime]) -> str:
         inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()
         return f"""
@@ -94,8 +94,8 @@ class TopPerArtistPopularityProvider(QueryProvider):
     def get_base_path(self) -> str:
         return LISTENBRAINZ_POPULARITY_DIRECTORY
 
-    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   existing_created: Optional[datetime]) -> str:
+    def get_filter_aggregate_query_coarse(self, existing_aggregate: str, incremental_aggregate: str,
+                                          existing_created: Optional[datetime]) -> str:
         inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()
         return f"""

--- a/listenbrainz_spark/popularity/listens.py
+++ b/listenbrainz_spark/popularity/listens.py
@@ -24,7 +24,7 @@ class PopularityProvider(QueryProvider):
     def get_base_path(self) -> str:
         return LISTENBRAINZ_POPULARITY_DIRECTORY
 
-    def get_filter_aggregate_query_coarse(self, existing_aggregate: str, incremental_aggregate: str,
+    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
                                           existing_created: Optional[datetime]) -> str:
         inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()
@@ -94,7 +94,7 @@ class TopPerArtistPopularityProvider(QueryProvider):
     def get_base_path(self) -> str:
         return LISTENBRAINZ_POPULARITY_DIRECTORY
 
-    def get_filter_aggregate_query_coarse(self, existing_aggregate: str, incremental_aggregate: str,
+    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
                                           existing_created: Optional[datetime]) -> str:
         inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -10,7 +10,12 @@ from pyspark.sql.types import StructField, StructType, ArrayType, StringType, Ti
 BOOKKEEPING_SCHEMA = StructType([
     StructField('from_date', TimestampType(), nullable=False),
     StructField('to_date', TimestampType(), nullable=False),
+    StructField('updated_at', TimestampType(), nullable=False),
+])
+
+INCREMENTAL_BOOKKEEPING_SCHEMA = StructType([
     StructField('created', TimestampType(), nullable=False),
+    StructField('updated_at', TimestampType(), nullable=False),
 ])
 
 mlhd_schema = StructType([

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -180,16 +180,29 @@ class IncrementalStatsEngine:
 
             if self._only_inc:
                 existing_created = self.get_incremental_dumps_existing_created()
-                filter_query = self.provider.get_filter_aggregate_query(
-                    partial_table, inc_table, self.incremental_table, existing_created
-                )
-                filtered_aggregate_df = run_query(filter_query)
-                filtered_table = f"{prefix}_filtered_aggregate"
-                filtered_aggregate_df.createOrReplaceTempView(filtered_table)
-            else:
-                filtered_table = partial_table
 
-            final_query = self.provider.get_combine_aggregates_query(filtered_table, inc_table)
+                filter_existing_query = self.provider.get_filter_aggregate_query(
+                    partial_table,
+                    self.incremental_table,
+                    existing_created
+                )
+                filtered_existing_aggregate_df = run_query(filter_existing_query)
+                filtered_existing_table = f"{prefix}_filtered_existing_aggregate"
+                filtered_existing_aggregate_df.createOrReplaceTempView(filtered_existing_table)
+
+                filter_incremental_query = self.provider.get_filter_aggregate_query(
+                    inc_table,
+                    self.incremental_table,
+                    existing_created
+                )
+                filtered_incremental_aggregate_df = run_query(filter_incremental_query)
+                filtered_incremental_table = f"{prefix}_filtered_incremental_aggregate"
+                filtered_incremental_aggregate_df.createOrReplaceTempView(filtered_incremental_table)
+            else:
+                filtered_existing_table = partial_table
+                filtered_incremental_table = inc_table
+
+            final_query = self.provider.get_combine_aggregates_query(filtered_existing_table, filtered_incremental_table)
             final_df = run_query(final_query)
         else:
             final_df = partial_df

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -69,7 +69,7 @@ class IncrementalStatsEngine:
 
     def partial_aggregate_usable(self) -> bool:
         """ Checks whether a partial aggregate exists and is fresh to generate the required stats. """
-        metadata_path = Path(self.provider.get_bookkeeping_path()) / "full"
+        metadata_path = f"{self.provider.get_bookkeeping_path()}/full"
         existing_aggregate_path = self.provider.get_existing_aggregate_path()
 
         try:
@@ -96,7 +96,7 @@ class IncrementalStatsEngine:
         Returns:
             DataFrame: The generated partial aggregate DataFrame.
         """
-        metadata_path = Path(self.provider.get_bookkeeping_path()) / "full"
+        metadata_path = f"{self.provider.get_bookkeeping_path()}/full"
         existing_aggregate_path = self.provider.get_existing_aggregate_path()
 
         table = f"{self.provider.get_table_prefix()}_full_listens"
@@ -137,7 +137,7 @@ class IncrementalStatsEngine:
         return run_query(inc_query)
 
     def bookkeep_incremental_aggregate(self):
-        metadata_path = Path(self.provider.get_bookkeeping_path()) / "incremental"
+        metadata_path = f"{self.provider.get_bookkeeping_path()}/incremental"
         query = f"SELECT max(created) AS latest_created_at FROM {self.incremental_table}"
         latest_created_at = run_query(query).collect()[0]["latest_created_at"]
         metadata_df = listenbrainz_spark.session.createDataFrame(
@@ -147,7 +147,7 @@ class IncrementalStatsEngine:
         metadata_df.write.mode("overwrite").json(metadata_path)
 
     def get_incremental_dumps_existing_created(self):
-        metadata_path = Path(self.provider.get_bookkeeping_path()) / "incremental"
+        metadata_path = f"{self.provider.get_bookkeeping_path()}/incremental"
         try:
             metadata = listenbrainz_spark \
                 .session \

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -180,7 +180,9 @@ class IncrementalStatsEngine:
 
             if self._only_inc:
                 existing_created = self.get_incremental_dumps_existing_created()
-                filter_query = self.provider.get_filter_aggregate_query(partial_table, inc_table, existing_created)
+                filter_query = self.provider.get_filter_aggregate_query(
+                    partial_table, inc_table, self.incremental_table, existing_created
+                )
                 filtered_aggregate_df = run_query(filter_query)
                 filtered_table = f"{prefix}_filtered_aggregate"
                 filtered_aggregate_df.createOrReplaceTempView(filtered_table)

--- a/listenbrainz_spark/stats/incremental/query_provider.py
+++ b/listenbrainz_spark/stats/incremental/query_provider.py
@@ -70,7 +70,7 @@ class QueryProvider(abc.ABC):
 
     @abc.abstractmethod
     def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   existing_created: Optional[datetime]) -> str:
+                                   inc_listens_table: str, existing_created: Optional[datetime]) -> str:
         """
         Return the query to filter the existing aggregate based on the listens present in incremental
         aggregate.
@@ -78,6 +78,8 @@ class QueryProvider(abc.ABC):
         Args:
             existing_aggregate: The table name for existing aggregate.
             incremental_aggregate: The table name for incremental aggregate.
+            inc_listens_table: The table name for incremental listens.
+            existing_created: The max listen created value last time incremental stats for this query was run.
         """
         raise NotImplementedError()
 

--- a/listenbrainz_spark/stats/incremental/query_provider.py
+++ b/listenbrainz_spark/stats/incremental/query_provider.py
@@ -1,5 +1,6 @@
 import abc
-from typing import List
+from datetime import datetime
+from typing import List, Optional
 
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
 
@@ -41,7 +42,7 @@ class QueryProvider(abc.ABC):
         return f"{self.get_base_path()}/aggregates/{self.entity}/{self.stats_range}"
 
     def get_bookkeeping_path(self) -> str:
-        """ Returns the HDFS path for bookkeeping metadata. """
+        """ Returns the HDFS path for bookkeeping metadata directory. """
         return f"{self.get_base_path()}/bookkeeping/{self.entity}/{self.stats_range}"
 
     @abc.abstractmethod
@@ -68,7 +69,8 @@ class QueryProvider(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str) -> str:
+    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
+                                   existing_created: Optional[datetime]) -> str:
         """
         Return the query to filter the existing aggregate based on the listens present in incremental
         aggregate.

--- a/listenbrainz_spark/stats/incremental/query_provider.py
+++ b/listenbrainz_spark/stats/incremental/query_provider.py
@@ -69,15 +69,12 @@ class QueryProvider(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   inc_listens_table: str, existing_created: Optional[datetime]) -> str:
+    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime) -> str:
         """
-        Return the query to filter the existing aggregate based on the listens present in incremental
-        aggregate.
+        Return the query to filter the aggregate based on the listens submitted since existing created timestamp.
 
         Args:
-            existing_aggregate: The table name for existing aggregate.
-            incremental_aggregate: The table name for incremental aggregate.
+            aggregate: The table name for the aggregate to filter
             inc_listens_table: The table name for incremental listens.
             existing_created: The max listen created value last time incremental stats for this query was run.
         """

--- a/listenbrainz_spark/stats/incremental/sitewide/entity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/entity.py
@@ -1,6 +1,7 @@
 import abc
 import logging
-from typing import Iterator, Dict
+from datetime import datetime
+from typing import Iterator, Dict, Optional
 
 from pydantic import ValidationError
 from pyspark.sql import DataFrame
@@ -34,7 +35,8 @@ class SitewideStatsQueryProvider(QueryProvider, abc.ABC):
     def get_table_prefix(self) -> str:
         return f"sitewide_{self.entity}_{self.stats_range}"
 
-    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str) -> str:
+    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
+                                   existed_created: Optional[datetime]) -> str:
         return f"SELECT * FROM {existing_aggregate}"
 
 

--- a/listenbrainz_spark/stats/incremental/sitewide/entity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/entity.py
@@ -35,8 +35,8 @@ class SitewideStatsQueryProvider(QueryProvider, abc.ABC):
     def get_table_prefix(self) -> str:
         return f"sitewide_{self.entity}_{self.stats_range}"
 
-    def get_filter_aggregate_query_coarse(self, existing_aggregate: str, incremental_aggregate: str,
-                                          existed_created: Optional[datetime]) -> str:
+    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
+                                   existed_created: Optional[datetime]) -> str:
         return f"SELECT * FROM {existing_aggregate}"
 
 

--- a/listenbrainz_spark/stats/incremental/sitewide/entity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/entity.py
@@ -35,8 +35,8 @@ class SitewideStatsQueryProvider(QueryProvider, abc.ABC):
     def get_table_prefix(self) -> str:
         return f"sitewide_{self.entity}_{self.stats_range}"
 
-    def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   existed_created: Optional[datetime]) -> str:
+    def get_filter_aggregate_query_coarse(self, existing_aggregate: str, incremental_aggregate: str,
+                                          existed_created: Optional[datetime]) -> str:
         return f"SELECT * FROM {existing_aggregate}"
 
 

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -38,7 +38,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
     def get_entity_id(self):
         return "user_id"
 
-    def get_filter_aggregate_query_coarse(self, existing_aggregate, incremental_aggregate, inc_listens_table, existing_created):
+    def get_filter_aggregate_query(self, existing_aggregate, incremental_aggregate, inc_listens_table, existing_created):
         """ Filter listens from existing aggregate to only include listens for entities having listens in the
         incremental dumps.
         """

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -38,7 +38,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
     def get_entity_id(self):
         return "user_id"
 
-    def get_filter_aggregate_query(self, existing_aggregate, incremental_aggregate, inc_listens_table, existing_created):
+    def get_filter_aggregate_query_coarse(self, existing_aggregate, incremental_aggregate, inc_listens_table, existing_created):
         """ Filter listens from existing aggregate to only include listens for entities having listens in the
         incremental dumps.
         """

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -37,7 +37,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
     def get_entity_id(self):
         return "user_id"
 
-    def get_filter_aggregate_query(self, existing_aggregate, incremental_aggregate, existing_created):
+    def get_filter_aggregate_query(self, existing_aggregate, incremental_aggregate, inc_listens_table, existing_created):
         """ Filter listens from existing aggregate to only include listens for entities having listens in the
         incremental dumps.
         """
@@ -45,7 +45,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
         entity_id = self.get_entity_id()
         return f"""
             WITH incremental_users AS (
-                SELECT DISTINCT {entity_id} FROM {incremental_aggregate} {inc_where_clause}
+                SELECT DISTINCT {entity_id} FROM {inc_listens_table} {inc_where_clause}
             )
             SELECT *
               FROM {existing_aggregate} ea

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -11,6 +11,7 @@ from data.model.user_recording_stat import RecordingRecord
 from data.model.user_release_group_stat import ReleaseGroupRecord
 from data.model.user_release_stat import ReleaseRecord
 from listenbrainz_spark.path import LISTENBRAINZ_USER_STATS_DIRECTORY
+from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats.incremental.message_creator import StatsMessageCreator
 from listenbrainz_spark.stats.incremental.query_provider import QueryProvider
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
@@ -51,6 +52,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
         else:
             inc_clause = f"SELECT DISTINCT {entity_id} FROM {incremental_aggregate}"
         logger.info("Query: %s", inc_clause)
+        logger.info("RESULTS: %s", run_query(inc_clause).collect())
         return f"""
             WITH incremental_users AS (
                 {inc_clause}

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -37,14 +37,15 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
     def get_entity_id(self):
         return "user_id"
 
-    def get_filter_aggregate_query(self, existing_aggregate, incremental_aggregate):
+    def get_filter_aggregate_query(self, existing_aggregate, incremental_aggregate, existing_created):
         """ Filter listens from existing aggregate to only include listens for entities having listens in the
         incremental dumps.
         """
+        inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()
         return f"""
             WITH incremental_users AS (
-                SELECT DISTINCT {entity_id} FROM {incremental_aggregate}
+                SELECT DISTINCT {entity_id} FROM {incremental_aggregate} {inc_where_clause}
             )
             SELECT *
               FROM {existing_aggregate} ea

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -50,7 +50,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
             """
         else:
             inc_clause = f"SELECT DISTINCT {entity_id} FROM {incremental_aggregate}"
-
+        logger.info("Query: %s", inc_clause)
         return f"""
             WITH incremental_users AS (
                 {inc_clause}


### PR DESCRIPTION
Currently, the entirety of incremental dumps is checked to filter entities whose stats/popularity needs to be recomputed. This can be further optimized by storing the latest created timestamp of the listens in incremental dumps when a stat is
run. The next time a stat is run, only listens with a higher created value (added through newer incremental dumps) are considered for the filter.

Note that the incremental aggregate is still computed from all of incremental listens dump, only the filter is made more granular.