### PR TITLE
Make the /feed routes protected, requiring login

### DIFF
--- a/frontend/js/src/routes/index.tsx
+++ b/frontend/js/src/routes/index.tsx
@@ -149,29 +149,6 @@ const getIndexRoutes = (): RouteObject[] => {
           ],
         },
         {
-          path: "feed/",
-          lazy: async () => {
-            const UserFeedLayout = await import("../user-feed/UserFeedLayout");
-            return { Component: UserFeedLayout.default };
-          },
-          children: [
-            {
-              index: true,
-              lazy: async () => {
-                const UserFeed = await import("../user-feed/UserFeed");
-                return { Component: UserFeed.default };
-              },
-            },
-            {
-              path: ":mode/",
-              lazy: async () => {
-                const NetworkFeed = await import("../user-feed/NetworkFeed");
-                return { Component: NetworkFeed.default };
-              },
-            },
-          ],
-        },
-        {
           path: "recent/",
           lazy: async () => {
             const UserFeedLayout = await import("../user-feed/UserFeedLayout");

--- a/frontend/js/src/routes/routes.tsx
+++ b/frontend/js/src/routes/routes.tsx
@@ -10,6 +10,7 @@ import getRedirectRoutes from "./redirectRoutes";
 import getEntityPages from "./EntityPages";
 import Layout from "../layout";
 import ErrorBoundary from "../error/ErrorBoundary";
+import getFeedRoutes from "../user-feed/routes";
 import getSettingsRoutes from "../settings/routes";
 import getSettingsRedirectRoutes from "../settings/routes/redirectRoutes";
 import getPlayerRoutes from "../player/routes";
@@ -24,6 +25,7 @@ const getRoutes = (musicbrainzID?: string): RouteObject[] => {
   const aboutRedirectRoutes = getRedirectRoutes();
   const entityPages = getEntityPages();
   const indexRoutes = getIndexRoutes();
+  const feedRoutes = getFeedRoutes();
   const settingsRoutes = getSettingsRoutes();
   const settingsRedirectRoutes = getSettingsRedirectRoutes();
   const playerRoutes = getPlayerRoutes();
@@ -59,6 +61,7 @@ const getRoutes = (musicbrainzID?: string): RouteObject[] => {
         </Layout>
       ),
       children: [
+        ...feedRoutes,
         ...settingsRoutes,
         ...settingsRedirectRoutes,
         ...playingNowRoutes,

--- a/frontend/js/src/user-feed/UserFeedLayout.tsx
+++ b/frontend/js/src/user-feed/UserFeedLayout.tsx
@@ -44,13 +44,17 @@ function UserFeedLayout() {
         <ul className="nav nav-tabs" role="tablist">
           <NavItem
             label="My Feed"
-            url={loggedIn ? "/feed/" : "#"}
+            url={loggedIn ? "/feed/" : `/login/?next=/feed/`}
             isActive={activeSection === "feed"}
             isDisabled={!loggedIn}
           />
           <NavItem
             label="My Network"
-            url={loggedIn ? `/feed/${FeedModes.Follows}/` : "#"}
+            url={
+              loggedIn
+                ? `/feed/${FeedModes.Follows}/`
+                : `/login/?next=/feed/${FeedModes.Follows}/`
+            }
             isActive={
               activeSection === FeedModes.Follows ||
               activeSection === FeedModes.Similar

--- a/frontend/js/src/user-feed/routes/index.tsx
+++ b/frontend/js/src/user-feed/routes/index.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import type { RouteObject } from "react-router-dom";
+import ErrorBoundary from "../../error/ErrorBoundary";
+
+const getFeedRoutes = (): RouteObject[] => {
+  const routes = [
+    {
+      path: "feed/",
+      lazy: async () => {
+        const UserFeedLayout = await import("../UserFeedLayout");
+        return { Component: UserFeedLayout.default };
+      },
+      errorElement: <ErrorBoundary />,
+      children: [
+        {
+          index: true,
+          lazy: async () => {
+            const UserFeed = await import("../UserFeed");
+            return { Component: UserFeed.default };
+          },
+        },
+        {
+          path: ":mode/",
+          lazy: async () => {
+            const NetworkFeed = await import("../NetworkFeed");
+            return { Component: NetworkFeed.default };
+          },
+        },
+      ],
+    },
+  ];
+  return routes;
+};
+
+export default getFeedRoutes;

--- a/frontend/js/src/user-feed/routes/index.tsx
+++ b/frontend/js/src/user-feed/routes/index.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import type { RouteObject } from "react-router-dom";
-import ErrorBoundary from "../../error/ErrorBoundary";
 
 const getFeedRoutes = (): RouteObject[] => {
   const routes = [
@@ -10,7 +9,6 @@ const getFeedRoutes = (): RouteObject[] => {
         const UserFeedLayout = await import("../UserFeedLayout");
         return { Component: UserFeedLayout.default };
       },
-      errorElement: <ErrorBoundary />,
       children: [
         {
           index: true,

--- a/frontend/js/tests/user-feed/NetworkFeed.test.tsx
+++ b/frontend/js/tests/user-feed/NetworkFeed.test.tsx
@@ -29,7 +29,7 @@ import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import * as timelineProps from "../__mocks__/listensTimelineProps.json";
 
 import { renderWithProviders } from "../test-utils/rtl-test-utils";
-import getIndexRoutes from "../../src/routes";
+import getFeedRoutes from "../../src/user-feed/routes";
 
 jest.unmock("react-toastify");
 
@@ -46,7 +46,7 @@ const reactQueryWrapper = ({ children }: any) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-const routes = getIndexRoutes();
+const routes = getFeedRoutes();
 const router = createMemoryRouter(routes, {
   initialEntries: ["/feed/follows"],
 });


### PR DESCRIPTION
The feed pages require users to be logged in.
Currently, if not logged in, users _can_ access the feed pages but get an empty page with error messages instead of being redirected to the login page.

![image](https://github.com/user-attachments/assets/ad132b61-ec31-4e3d-9322-be547cfcf318)

Also changes the feed tabs links to redirect to the login page then back to the appropriate page after successful login.
Even though disabled in style, the tabs are still clickable, hence should redirect to login for a better UX.

