### PR TITLE
Playlist page: Prevent autofocus on add-track component

### DIFF
--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -77,6 +77,7 @@ export default function PlaylistPage() {
 
   // Ref
   const socketRef = React.useRef<Socket | null>(null);
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
 
   // States
   const [playlist, setPlaylist] = React.useState<JSPFPlaylist>(
@@ -459,6 +460,9 @@ export default function PlaylistPage() {
                 type="button"
                 href="#add-track"
                 style={{ marginBottom: "1em" }}
+                onClick={() => {
+                  searchInputRef.current?.focus();
+                }}
               >
                 <FontAwesomeIcon icon={faPlusCircle as IconProp} />
                 &nbsp;&nbsp;Add a track
@@ -498,6 +502,8 @@ export default function PlaylistPage() {
                   &nbsp;&nbsp;Add a track
                 </span>
                 <SearchTrackOrMBID
+                  ref={searchInputRef}
+                  autofocus={false}
                   onSelectRecording={addTrack}
                   expectedPayload="trackmetadata"
                 />

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -35,12 +35,18 @@ type ConditionalReturnValue =
     };
 
 type SearchTrackOrMBIDProps = {
+  autofocus?: boolean;
   defaultValue?: string;
   expectedPayload: PayloadType;
 } & ConditionalReturnValue;
 
 const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
-  { onSelectRecording, expectedPayload, defaultValue }: SearchTrackOrMBIDProps,
+  {
+    onSelectRecording,
+    expectedPayload,
+    defaultValue,
+    autofocus = true,
+  }: SearchTrackOrMBIDProps,
   inputRefForParent
 ) {
   const { APIService } = useContext(GlobalAppContext);
@@ -69,10 +75,12 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
 
   // Autofocus once on load
   useEffect(() => {
-    setTimeout(() => {
-      inputRefLocal?.current?.focus();
-    }, 500);
-  }, []);
+    if (autofocus) {
+      setTimeout(() => {
+        inputRefLocal?.current?.focus();
+      }, 500);
+    }
+  }, [autofocus]);
 
   const handleError = useCallback(
     (error: string | Error, title?: string): void => {


### PR DESCRIPTION
### Wait until #3149 is merged, will probably need rebasing after that

This focus-on-page-load had a good intent, but on the playlist page it scrolls to the bottom of the page automatically which is annoying.
In some components it is desirable, but not for the playlist page, so I added an autofocus option that defaults to true (keeps it the same for other components).

There is a button at the top that takes you to the add-track component, so I made that trigger focus on the input component instead.
