### PR TITLE
LB-1748: Add playlist cover art on the playlist overview page

### DIFF
--- a/frontend/css/playlists.less
+++ b/frontend/css/playlists.less
@@ -84,24 +84,6 @@
       width: 100%;
       background-color: @playlistBackgroundColor;
     }
-    @media (hover: hover) {
-      .info {
-        bottom: -60px;
-        transition: .3s ease-in-out;
-        transition-property: bottom, background-color;
-      }
-      &:hover .info {
-        bottom: 0;
-        background-color: @playlistBackgroundColorHover
-      }
-      .playlist-card-action-button {
-        transition: opacity .3s ease-in-out;
-        opacity: 0;
-      }
-       &:hover .playlist-card-action-button {
-        opacity: 1;
-      }
-    }
 
     .cover-art {
       position: absolute;
@@ -109,11 +91,36 @@
       left: 0;
       width: 100%;
       aspect-ratio: 1;
+      opacity: 0.75;
       > * {
         width: inherit;
         height: auto;
       }
     }
+    
+    @media (hover: hover) {
+      .info {
+        bottom: -65px;
+        transition: .3s ease-in-out;
+        transition-property: bottom, background-color;
+      }
+      .cover-art, .playlist-card-action-button  {
+        transition: opacity .3s ease-in-out;
+      }
+      .playlist-card-action-button {
+        opacity: 0;
+      }
+      &:hover {
+        .info {
+          bottom: 0;
+          background-color: @playlistBackgroundColorHover
+        }
+        .cover-art, .playlist-card-action-button {
+          opacity: 1;
+        }
+      }
+    }
+
   }
 
   .playlist-card-list-view {

--- a/frontend/css/playlists.less
+++ b/frontend/css/playlists.less
@@ -1,4 +1,5 @@
-@playlistBackgroundColor: #fafafa;
+@playlistBackgroundColor: #fafafaad;
+@playlistBackgroundColorHover: #fafafaeb;
 @descriptionLines: 3;
 
 #playlists-page .playlist-view-options {
@@ -48,7 +49,17 @@
     width: 15em;
     height: 15em !important;
     position: relative;
-    overflow: hidden;
+
+    > a {
+      // Making the inner link the overflow contaienr, otherwise the options menu is cut off
+      border-radius: 8px;
+      overflow: hidden;
+      width: inherit;
+      display: block;
+      height: inherit;
+      position: relative;
+      color: inherit;
+    }
 
     .playlist-card-action-dropdown {
       position: absolute;
@@ -59,23 +70,48 @@
     .playlist-card-action-button {
       position: absolute;
       bottom: 0;
+      right: 0;
       border: none;
       padding: 5px;
-      &:extend(.btn-block);
-      &:extend(.btn-info);
     }
 
     .info {
+      position: absolute;
+      bottom: 0;
+      left: 0;
       display: block;
-      padding: 1em;
-      height: 100%;
+      padding: 1em .5em;
       width: 100%;
       background-color: @playlistBackgroundColor;
+    }
+    @media (hover: hover) {
+      .info {
+        bottom: -60px;
+        transition: .3s ease-in-out;
+        transition-property: bottom, background-color;
+      }
+      &:hover .info {
+        bottom: 0;
+        background-color: @playlistBackgroundColorHover
+      }
+      .playlist-card-action-button {
+        transition: opacity .3s ease-in-out;
+        opacity: 0;
+      }
+       &:hover .playlist-card-action-button {
+        opacity: 1;
+      }
+    }
+
+    .cover-art {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      aspect-ratio: 1;
       > * {
-        margin: 0.5em 0;
-        &:first-child {
-          margin: 0;
-        }
+        width: inherit;
+        height: auto;
       }
     }
   }

--- a/frontend/js/src/user/playlists/components/PlaylistCard.tsx
+++ b/frontend/js/src/user/playlists/components/PlaylistCard.tsx
@@ -241,7 +241,7 @@ export default function PlaylistCard({
 
   return (
     <Card className="playlist" key={playlistId}>
-      <Link to={`/playlist/${sanitize(playlistId)}/`}>
+      <Link to={`/playlist/${sanitize(playlistId)}/`} title={playlist.title}>
         <div
           className="cover-art"
           // eslint-disable-next-line react/no-danger
@@ -286,7 +286,7 @@ export default function PlaylistCard({
             <FontAwesomeIcon
               icon={faCog as IconProp}
               fixedWidth
-              title="More options"
+              title="Options"
             />
           </button>
           <PlaylistMenu

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1,4 +1,11 @@
-import { isNil, isUndefined, kebabCase, lowerCase, omit } from "lodash";
+import {
+  isFinite,
+  isNil,
+  isUndefined,
+  kebabCase,
+  lowerCase,
+  omit,
+} from "lodash";
 import { TagActionType } from "../tags/TagComponent";
 import type { SortOption } from "../explore/fresh-releases/FreshReleases";
 import APIError from "./APIError";
@@ -986,6 +993,33 @@ export default class APIService {
     });
     await this.checkStatus(response);
     return response.status;
+  };
+
+  getPlaylistImage = async (
+    playlistId: string,
+    userToken: string,
+    dimension?: number,
+    layout?: number
+  ): Promise<string> => {
+    if (!playlistId) {
+      throw new SyntaxError("Playlist ID is missing");
+    }
+    if (!userToken) {
+      throw new SyntaxError("User token missing");
+    }
+    let url = `${this.APIBaseURI}/art/playlist/${playlistId}`;
+    if (isFinite(dimension) && isFinite(layout)) {
+      url += `/${dimension}/${layout}`;
+    }
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Token ${userToken}`,
+      },
+    });
+    await this.checkStatus(response);
+    const svgBody = await response.text();
+    return svgBody;
   };
 
   submitRecommendationFeedback = async (


### PR DESCRIPTION
With #3149 and the new art API endpoint to get playlist cover art images, we can now show the image on the playlists page.
On hover the title section at the bottom of the card expands and both it and the background image become more opaque.
I lowered the initial opacity because the was a bit overwhelming.

What do we think, is it still too busy?
![image](https://github.com/user-attachments/assets/d1b0a35f-edf1-4005-8af2-82b91b558e44)
