### PR TITLE
Fix incremental listener stats

### DIFF
--- a/listenbrainz_spark/popularity/listens.py
+++ b/listenbrainz_spark/popularity/listens.py
@@ -25,7 +25,7 @@ class PopularityProvider(QueryProvider):
         return LISTENBRAINZ_POPULARITY_DIRECTORY
 
     def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                          existing_created: Optional[datetime]) -> str:
+                                          existing_created: Optional[datetime], cache_tables: List[str]) -> str:
         inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()
         return f"""
@@ -95,7 +95,7 @@ class TopPerArtistPopularityProvider(QueryProvider):
         return LISTENBRAINZ_POPULARITY_DIRECTORY
 
     def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                          existing_created: Optional[datetime]) -> str:
+                                          existing_created: Optional[datetime], cache_tables: List[str]) -> str:
         inc_where_clause = f"WHERE created >= to_timestamp('{existing_created}')" if existing_created else ""
         entity_id = self.get_entity_id()
         return f"""

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -184,7 +184,8 @@ class IncrementalStatsEngine:
                 filter_existing_query = self.provider.get_filter_aggregate_query(
                     partial_table,
                     self.incremental_table,
-                    existing_created
+                    existing_created,
+                    self._cache_tables
                 )
                 filtered_existing_aggregate_df = run_query(filter_existing_query)
                 filtered_existing_table = f"{prefix}_filtered_existing_aggregate"
@@ -193,7 +194,8 @@ class IncrementalStatsEngine:
                 filter_incremental_query = self.provider.get_filter_aggregate_query(
                     inc_table,
                     self.incremental_table,
-                    existing_created
+                    existing_created,
+                    self._cache_tables
                 )
                 filtered_incremental_aggregate_df = run_query(filter_incremental_query)
                 filtered_incremental_table = f"{prefix}_filtered_incremental_aggregate"

--- a/listenbrainz_spark/stats/incremental/listener/entity.py
+++ b/listenbrainz_spark/stats/incremental/listener/entity.py
@@ -2,22 +2,25 @@ import abc
 import logging
 
 from listenbrainz_spark.path import LISTENBRAINZ_LISTENER_STATS_DIRECTORY
-from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider, UserStatsMessageCreator
+from listenbrainz_spark.stats.incremental.query_provider import QueryProvider
+from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
+from listenbrainz_spark.stats.incremental.user.entity import UserStatsMessageCreator
 
 logger = logging.getLogger(__name__)
 
 
-class EntityListenerStatsQueryProvider(UserEntityStatsQueryProvider, abc.ABC):
+class EntityListenerStatsQueryProvider(QueryProvider, abc.ABC):
     """ See base class QueryProvider for details. """
+
+    def __init__(self, selector: ListenRangeSelector, top_entity_limit: int):
+        super().__init__(selector)
+        self.top_entity_limit = top_entity_limit
 
     def get_table_prefix(self) -> str:
         return f"{self.entity}_listeners_{self.stats_range}"
 
     def get_base_path(self) -> str:
         return LISTENBRAINZ_LISTENER_STATS_DIRECTORY
-
-    def get_entity_id(self):
-        raise NotImplementedError()
 
 
 class EntityListenerStatsMessageCreator(UserStatsMessageCreator):

--- a/listenbrainz_spark/stats/incremental/listener/release_group.py
+++ b/listenbrainz_spark/stats/incremental/listener/release_group.py
@@ -158,6 +158,7 @@ class ReleaseGroupEntityListenerStatsQuery(EntityListenerStatsQueryProvider):
 
     def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime,
                                    cache_tables: List[str]) -> str:
+        rel_cache_table = cache_tables[0]
         return f"""
             WITH incremental_release_groups AS (
                 SELECT DISTINCT rel.release_group_mbid

--- a/listenbrainz_spark/stats/incremental/listener/release_group.py
+++ b/listenbrainz_spark/stats/incremental/listener/release_group.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME, \
@@ -154,3 +155,19 @@ class ReleaseGroupEntityListenerStatsQuery(EntityListenerStatsQueryProvider):
               JOIN entity_count
              USING (release_group_mbid)
         """
+
+    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime,
+                                   cache_tables: List[str]) -> str:
+        return f"""
+            WITH incremental_release_groups AS (
+                SELECT DISTINCT rel.release_group_mbid
+                  FROM {inc_listens_table} l
+             LEFT JOIN {rel_cache_table} rel
+                    ON rel.release_mbid = l.release_mbid
+                 WHERE created >= to_timestamp('{existing_created}')
+            )
+                SELECT *
+                  FROM {aggregate} ea
+                 WHERE EXISTS(SELECT 1 FROM incremental_release_groups irg WHERE irg.release_group_mbid = ea.release_group_mbid)
+        """
+

--- a/listenbrainz_spark/stats/incremental/query_provider.py
+++ b/listenbrainz_spark/stats/incremental/query_provider.py
@@ -69,7 +69,8 @@ class QueryProvider(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime) -> str:
+    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime,
+                                   cache_tables: List[str]) -> str:
         """
         Return the query to filter the aggregate based on the listens submitted since existing created timestamp.
 

--- a/listenbrainz_spark/stats/incremental/sitewide/entity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/entity.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from datetime import datetime
-from typing import Iterator, Dict, Optional
+from typing import Iterator, Dict, Optional, List
 
 from pydantic import ValidationError
 from pyspark.sql import DataFrame
@@ -36,7 +36,7 @@ class SitewideStatsQueryProvider(QueryProvider, abc.ABC):
         return f"sitewide_{self.entity}_{self.stats_range}"
 
     def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   existed_created: Optional[datetime]) -> str:
+                                   existed_created: Optional[datetime], cache_tables: List[str]) -> str:
         return f"SELECT * FROM {existing_aggregate}"
 
 


### PR DESCRIPTION
The latest iteration of incremental stats filters listens based on created timestamp instead of using the entire incremental aggregate, hence the filtering queries used for user stats are no longer valid for entity stats and need to be updated.