### PR TITLE
Add disambiguation to track search results

### DIFF
--- a/frontend/js/src/search/TrackSearch.tsx
+++ b/frontend/js/src/search/TrackSearch.tsx
@@ -85,6 +85,11 @@ export default function TrackSearch(props: TrackSearchProps) {
       return null;
     });
 
+    let trackNameWithDisambiguation = recording.title;
+    if (recording.disambiguation) {
+      trackNameWithDisambiguation = `${recording.title} (${recording.disambiguation})`;
+    }
+
     const listen = {
       listened_at: 0,
       track_metadata: {
@@ -98,12 +103,13 @@ export default function TrackSearch(props: TrackSearchProps) {
         artist_name: artistCredit
           .map((ac) => ac.name + (ac?.joinphrase ?? ""))
           .join(""),
-        track_name: recording.title,
+        track_name: trackNameWithDisambiguation,
         release_name:
           recording.releases?.length > 0 ? recording.releases[0].title : "",
         additional_info: {
           artist_mbids: artistMBIDs,
           recording_mbid: recording.id,
+          duration_ms: recording.length,
           release_mbid:
             recording.releases?.length > 0 ? recording.releases[0].id : "",
         },

--- a/frontend/js/src/search/types.d.ts
+++ b/frontend/js/src/search/types.d.ts
@@ -19,6 +19,8 @@ type TrackTypeSearchResult = {
   recordings: {
     id: string;
     title: string;
+    length: number;
+    disambiguation: string;
     "artist-credit": {
       name: string;
       joinphrase?: string;


### PR DESCRIPTION
Currently in the track search page, in some cases multiple recordings with the same name will be shown.
Without a disambiguation to look at and compare, this is very confusing.

This PR adds disambiguation (and track length, which was missing) next to the recording title to make it more useful.

Before:
![image](https://github.com/user-attachments/assets/87cb7ccf-e3ad-4962-b096-cb69f9fcce31)

After:
![image](https://github.com/user-attachments/assets/ef54f578-6837-4d3e-b72c-51a3409cee83)
