### PR TITLE
Cache incremental listens and metadata tables in Spark

### DIFF
--- a/listenbrainz_spark/hdfs/upload.py
+++ b/listenbrainz_spark/hdfs/upload.py
@@ -183,3 +183,15 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
 
         if path_exists(path.LISTENBRAINZ_BASE_STATS_DIRECTORY):
             hdfs_connection.client.delete(path.LISTENBRAINZ_BASE_STATS_DIRECTORY, recursive=True, skip_trash=True)
+
+    def process_incremental_listens_dump(self):
+        query = f"""
+            SELECT user_id
+                 , max(created) AS created
+              FROM parquet.`{path.INCREMENTAL_DUMPS_SAVE_PATH}`
+          GROUP BY user_id
+        """
+        run_query(query) \
+            .write \
+            .mode("overwrite") \
+            .parquet(path.INCREMENTAL_USERS_DF)

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -18,6 +18,7 @@ MLHD_PLUS_DATA_DIRECTORY = os.path.join("/", "mlhd")  # processed MLHD+ dump dat
 
 # path to save incremental dumps
 INCREMENTAL_DUMPS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "incremental.parquet")
+INCREMENTAL_USERS_DF = os.path.join("/", "incremental-users")
 
 # Directory containing RDD checkpoints to break lineage while using iterative algorithms.
 CHECKPOINT_DIR = os.path.join('/', 'checkpoint')

--- a/listenbrainz_spark/persisted.py
+++ b/listenbrainz_spark/persisted.py
@@ -2,17 +2,21 @@ from typing import Optional
 
 from pandas import DataFrame
 
-from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH
+from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH, INCREMENTAL_USERS_DF
 from listenbrainz_spark.utils import read_files_from_HDFS
 
 _incremental_listens_df: Optional[DataFrame] = None
+_incremental_users_df: Optional[DataFrame] = None
 
 
-def unpersist_incremental_listens_df():
-    global _incremental_listens_df
+def unpersist_incremental_df():
+    global _incremental_listens_df, _incremental_users_df
     if _incremental_listens_df is not None:
         _incremental_listens_df.unpersist()
         _incremental_listens_df = None
+    if _incremental_users_df is not None:
+        _incremental_users_df.unpersist()
+        _incremental_users_df = None
 
 
 def get_incremental_listens_df() -> DataFrame:
@@ -21,3 +25,11 @@ def get_incremental_listens_df() -> DataFrame:
         _incremental_listens_df = read_files_from_HDFS(INCREMENTAL_DUMPS_SAVE_PATH)
         _incremental_listens_df.persist()
     return _incremental_listens_df
+
+
+def get_incremental_users_df() -> DataFrame:
+    global _incremental_users_df
+    if _incremental_users_df is None:
+        _incremental_users_df = read_files_from_HDFS(INCREMENTAL_USERS_DF)
+        _incremental_users_df.persist()
+    return _incremental_users_df

--- a/listenbrainz_spark/persisted.py
+++ b/listenbrainz_spark/persisted.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from pandas import DataFrame
+
+from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH
+from listenbrainz_spark.utils import read_files_from_HDFS
+
+_incremental_listens_df: Optional[DataFrame] = None
+
+
+def unpersist_incremental_listens_df():
+    global _incremental_listens_df
+    if _incremental_listens_df is not None:
+        _incremental_listens_df.unpersist()
+        _incremental_listens_df = None
+
+
+def get_incremental_listens_df() -> DataFrame:
+    global _incremental_listens_df
+    if _incremental_listens_df is None:
+        _incremental_listens_df = read_files_from_HDFS(INCREMENTAL_DUMPS_SAVE_PATH)
+        _incremental_listens_df.persist()
+    return _incremental_listens_df

--- a/listenbrainz_spark/popularity/mlhd.py
+++ b/listenbrainz_spark/popularity/mlhd.py
@@ -21,16 +21,6 @@ class MlhdStatsEngine:
     def __init__(self, provider: QueryProvider, message_creator: MessageCreator):
         self.provider = provider
         self.message_creator = message_creator
-        self._cache_tables = []
-
-    def _setup_cache_tables(self):
-        """ Set up metadata cache tables by reading data from HDFS and creating temporary views. """
-        cache_tables = []
-        for idx, df_path in enumerate(self.provider.get_cache_tables()):
-            df_name = f"entity_data_cache_{idx}"
-            cache_tables.append(df_name)
-            read_files_from_HDFS(df_path).createOrReplaceTempView(df_name)
-        self._cache_tables = cache_tables
 
     def create_partial_aggregate(self) -> DataFrame:
         metadata_path = self.provider.get_bookkeeping_path()
@@ -41,7 +31,7 @@ class MlhdStatsEngine:
 
         logger.info("Creating partial aggregate from full dump listens")
         hdfs_connection.client.makedirs(Path(existing_aggregate_path).parent)
-        full_query = self.provider.get_aggregate_query(table, self._cache_tables)
+        full_query = self.provider.get_aggregate_query(table)
         full_df = run_query(full_query)
         full_df.write.mode("overwrite").parquet(existing_aggregate_path)
 
@@ -56,7 +46,6 @@ class MlhdStatsEngine:
         return full_df
 
     def generate_stats(self) -> DataFrame:
-        self._setup_cache_tables()
         prefix = self.provider.get_table_prefix()
         self.create_partial_aggregate()
 
@@ -64,7 +53,7 @@ class MlhdStatsEngine:
         partial_table = f"{prefix}_existing_aggregate"
         partial_df.createOrReplaceTempView(partial_table)
 
-        results_query = self.provider.get_stats_query(partial_table, self._cache_tables)
+        results_query = self.provider.get_stats_query(partial_table)
         results_df = run_query(results_query)
         return results_df
 

--- a/listenbrainz_spark/postgres/artist.py
+++ b/listenbrainz_spark/postgres/artist.py
@@ -86,4 +86,4 @@ def get_artist_country_cache():
         _artist_country_df = read_files_from_HDFS(ARTIST_COUNTRY_CODE_DATAFRAME)
         _artist_country_df.persist(StorageLevel.DISK_ONLY)
         _artist_country_df.createOrReplaceTempView(_ARTIST_COUNTRY_CACHE)
-    return _artist_country_df
+    return _ARTIST_COUNTRY_CACHE

--- a/listenbrainz_spark/postgres/artist.py
+++ b/listenbrainz_spark/postgres/artist.py
@@ -11,6 +11,7 @@ from listenbrainz_spark.postgres.utils import load_from_db
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import read_files_from_HDFS
 
+_ARTIST_COUNTRY_CACHE = "artist_country_cache"
 _artist_country_df: Optional[DataFrame] = None
 
 
@@ -77,9 +78,12 @@ def create_artist_country_cache():
         _artist_country_df = None
 
 
-def get_artist_country_df():
+def get_artist_country_cache():
+    """ Read the ARTIST_COUNTRY_CACHE parquet files from HDFS and create a spark SQL view
+     if one already doesn't exist """
     global _artist_country_df
     if _artist_country_df is None:
         _artist_country_df = read_files_from_HDFS(ARTIST_COUNTRY_CODE_DATAFRAME)
         _artist_country_df.persist(StorageLevel.DISK_ONLY)
+        _artist_country_df.createOrReplaceTempView(_ARTIST_COUNTRY_CACHE)
     return _artist_country_df

--- a/listenbrainz_spark/postgres/artist.py
+++ b/listenbrainz_spark/postgres/artist.py
@@ -25,7 +25,6 @@ def create_iso_country_codes_df():
     df.createOrReplaceTempView("iso_codes")
 
 
-
 def create_artist_country_cache():
     """ Import artist country from postgres to HDFS for use in artist map stats calculation. """
     query = """

--- a/listenbrainz_spark/postgres/artist.py
+++ b/listenbrainz_spark/postgres/artist.py
@@ -1,10 +1,17 @@
+from typing import Optional
+
 import pycountry
+from pyspark import StorageLevel
+from pyspark.sql import DataFrame
 
 import listenbrainz_spark
 from listenbrainz_spark import config
 from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
 from listenbrainz_spark.postgres.utils import load_from_db
 from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import read_files_from_HDFS
+
+_artist_country_df: Optional[DataFrame] = None
 
 
 def create_iso_country_codes_df():
@@ -64,3 +71,16 @@ def create_artist_country_cache():
         .write \
         .format("parquet") \
         .save(config.HDFS_CLUSTER_URI + ARTIST_COUNTRY_CODE_DATAFRAME, mode="overwrite")
+
+    global _artist_country_df
+    if _artist_country_df is not None:
+        _artist_country_df.unpersist()
+        _artist_country_df = None
+
+
+def get_artist_country_df():
+    global _artist_country_df
+    if _artist_country_df is None:
+        _artist_country_df: DataFrame = read_files_from_HDFS(ARTIST_COUNTRY_CODE_DATAFRAME)
+        _artist_country_df.persist(StorageLevel.DISK_ONLY)
+    return _artist_country_df

--- a/listenbrainz_spark/postgres/artist.py
+++ b/listenbrainz_spark/postgres/artist.py
@@ -81,6 +81,6 @@ def create_artist_country_cache():
 def get_artist_country_df():
     global _artist_country_df
     if _artist_country_df is None:
-        _artist_country_df: DataFrame = read_files_from_HDFS(ARTIST_COUNTRY_CODE_DATAFRAME)
+        _artist_country_df = read_files_from_HDFS(ARTIST_COUNTRY_CODE_DATAFRAME)
         _artist_country_df.persist(StorageLevel.DISK_ONLY)
     return _artist_country_df

--- a/listenbrainz_spark/postgres/recording.py
+++ b/listenbrainz_spark/postgres/recording.py
@@ -7,6 +7,7 @@ from listenbrainz_spark.path import RECORDING_LENGTH_DATAFRAME, RECORDING_ARTIST
 from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
 from listenbrainz_spark.utils import read_files_from_HDFS
 
+_RECORDING_ARTIST_CACHE = "recording_artist_cache"
 _recording_artist_df: Optional[DataFrame] = None
 
 
@@ -50,10 +51,13 @@ def create_recording_artist_cache():
         _recording_artist_df = None
 
 
-def get_recording_artist_df():
+def get_recording_artist_cache():
+    """ Read the RECORDING_ARTIST_CACHE parquet files from HDFS and create a spark SQL view
+     if one already doesn't exist """
     global _recording_artist_df
     if _recording_artist_df is None:
         _recording_artist_df = read_files_from_HDFS(RECORDING_ARTIST_DATAFRAME)
         _recording_artist_df.persist(StorageLevel.DISK_ONLY)
+        _recording_artist_df.createOrReplaceTempView(_RECORDING_ARTIST_CACHE)
     return _recording_artist_df
 

--- a/listenbrainz_spark/postgres/recording.py
+++ b/listenbrainz_spark/postgres/recording.py
@@ -59,5 +59,5 @@ def get_recording_artist_cache():
         _recording_artist_df = read_files_from_HDFS(RECORDING_ARTIST_DATAFRAME)
         _recording_artist_df.persist(StorageLevel.DISK_ONLY)
         _recording_artist_df.createOrReplaceTempView(_RECORDING_ARTIST_CACHE)
-    return _recording_artist_df
+    return _RECORDING_ARTIST_CACHE
 

--- a/listenbrainz_spark/postgres/recording.py
+++ b/listenbrainz_spark/postgres/recording.py
@@ -1,5 +1,13 @@
+from typing import Optional
+
+from pyspark import StorageLevel
+from pyspark.sql import DataFrame
+
 from listenbrainz_spark.path import RECORDING_LENGTH_DATAFRAME, RECORDING_ARTIST_DATAFRAME
 from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
+from listenbrainz_spark.utils import read_files_from_HDFS
+
+_recording_artist_df: Optional[DataFrame] = None
 
 
 def create_recording_length_cache():
@@ -35,3 +43,17 @@ def create_recording_artist_cache():
     """
 
     save_pg_table_to_hdfs(query, RECORDING_ARTIST_DATAFRAME, process_artists_column=True)
+
+    global _recording_artist_df
+    if _recording_artist_df is not None:
+        _recording_artist_df.unpersist()
+        _recording_artist_df = None
+
+
+def get_recording_artist_df():
+    global _recording_artist_df
+    if _recording_artist_df is None:
+        _recording_artist_df = read_files_from_HDFS(RECORDING_ARTIST_DATAFRAME)
+        _recording_artist_df.persist(StorageLevel.DISK_ONLY)
+    return _recording_artist_df
+

--- a/listenbrainz_spark/postgres/release.py
+++ b/listenbrainz_spark/postgres/release.py
@@ -7,6 +7,7 @@ from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
 from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
 from listenbrainz_spark.utils import read_files_from_HDFS
 
+_RELEASE_METADATA_CACHE = "release_metadata_cache"
 _release_metadata_df: Optional[DataFrame] = None
 
 
@@ -119,9 +120,12 @@ def create_release_metadata_cache():
         _release_metadata_df = None
 
 
-def get_release_metadata_df():
+def get_release_metadata_cache():
+    """ Read the RELEASE_METADATA_CACHE parquet files from HDFS and create a spark SQL view
+     if one already doesn't exist """
     global _release_metadata_df
     if _release_metadata_df is None:
         _release_metadata_df = read_files_from_HDFS(RELEASE_METADATA_CACHE_DATAFRAME)
         _release_metadata_df.persist(StorageLevel.DISK_ONLY)
-    return _release_metadata_df
+        _release_metadata_df.createOrReplaceTempView(_RELEASE_METADATA_CACHE)
+    return _RELEASE_METADATA_CACHE

--- a/listenbrainz_spark/postgres/release.py
+++ b/listenbrainz_spark/postgres/release.py
@@ -1,5 +1,13 @@
+from typing import Optional
+
+from pyspark import StorageLevel
+from pyspark.sql import DataFrame
+
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
 from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
+from listenbrainz_spark.utils import read_files_from_HDFS
+
+_release_metadata_df: Optional[DataFrame] = None
 
 
 def create_release_metadata_cache():
@@ -104,3 +112,16 @@ def create_release_metadata_cache():
     """
 
     save_pg_table_to_hdfs(query, RELEASE_METADATA_CACHE_DATAFRAME, process_artists_column=True)
+
+    global _release_metadata_df
+    if _release_metadata_df is not None:
+        _release_metadata_df.unpersist()
+        _release_metadata_df = None
+
+
+def get_release_metadata_df():
+    global _release_metadata_df
+    if _release_metadata_df is None:
+        _release_metadata_df = read_files_from_HDFS(RELEASE_METADATA_CACHE_DATAFRAME)
+        _release_metadata_df.persist(StorageLevel.DISK_ONLY)
+    return _release_metadata_df

--- a/listenbrainz_spark/postgres/release_group.py
+++ b/listenbrainz_spark/postgres/release_group.py
@@ -1,5 +1,13 @@
+from typing import Optional
+
+from pyspark import StorageLevel
+from pyspark.sql import DataFrame
+
 from listenbrainz_spark.path import RELEASE_GROUP_METADATA_CACHE_DATAFRAME
 from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
+from listenbrainz_spark.utils import read_files_from_HDFS
+
+_release_group_metadata_df: Optional[DataFrame] = None
 
 
 def create_release_group_metadata_cache():
@@ -72,3 +80,16 @@ def create_release_group_metadata_cache():
     """
 
     save_pg_table_to_hdfs(query, RELEASE_GROUP_METADATA_CACHE_DATAFRAME, process_artists_column=True)
+
+    global _release_group_metadata_df
+    if _release_group_metadata_df is not None:
+        _release_group_metadata_df.unpersist()
+        _release_group_metadata_df = None
+
+
+def get_release_group_metadata_df():
+    global _release_group_metadata_df
+    if _release_group_metadata_df is None:
+        _release_group_metadata_df = read_files_from_HDFS(RELEASE_GROUP_METADATA_CACHE_DATAFRAME)
+        _release_group_metadata_df.persist(StorageLevel.DISK_ONLY)
+    return _release_group_metadata_df

--- a/listenbrainz_spark/postgres/release_group.py
+++ b/listenbrainz_spark/postgres/release_group.py
@@ -7,6 +7,7 @@ from listenbrainz_spark.path import RELEASE_GROUP_METADATA_CACHE_DATAFRAME
 from listenbrainz_spark.postgres.utils import save_pg_table_to_hdfs
 from listenbrainz_spark.utils import read_files_from_HDFS
 
+_RELEASE_GROUP_METADATA_CACHE = "release_group_metadata_cache"
 _release_group_metadata_df: Optional[DataFrame] = None
 
 
@@ -87,9 +88,12 @@ def create_release_group_metadata_cache():
         _release_group_metadata_df = None
 
 
-def get_release_group_metadata_df():
+def get_release_group_metadata_cache():
+    """ Read the RELEASE_GROUP_METADATA_CACHE parquet files from HDFS and create a spark SQL view
+     if one already doesn't exist """
     global _release_group_metadata_df
     if _release_group_metadata_df is None:
         _release_group_metadata_df = read_files_from_HDFS(RELEASE_GROUP_METADATA_CACHE_DATAFRAME)
         _release_group_metadata_df.persist(StorageLevel.DISK_ONLY)
-    return _release_group_metadata_df
+        _release_group_metadata_df.createOrReplaceTempView(_RELEASE_GROUP_METADATA_CACHE)
+    return _RELEASE_GROUP_METADATA_CACHE

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -4,13 +4,14 @@ import logging
 import shutil
 import tempfile
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import listenbrainz_spark.request_consumer.jobs.utils as utils
 from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.dump.local import ListenbrainzLocalDumpLoader
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
+from listenbrainz_spark.persisted import unpersist_incremental_listens_df
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,8 @@ def import_full_dump_to_hdfs(dump_id: int = None, local: bool = False) -> str:
         uploader = ListenbrainzDataUploader()
         uploader.upload_new_listens_full_dump(src)
         uploader.process_full_listens_dump()
-    utils.insert_dump_data(dump_id, DumpType.FULL, datetime.utcnow())
+    utils.insert_dump_data(dump_id, DumpType.FULL, datetime.now(tz=timezone.utc))
+    unpersist_incremental_listens_df()
     return dump_name
 
 
@@ -69,7 +71,8 @@ def import_incremental_dump_to_hdfs(dump_id: int = None, local: bool = False) ->
         # is a bit non-intuitive.
         # FIXME in future to make initializing of spark session more explicit?
         ListenbrainzDataUploader().upload_new_listens_incremental_dump(src)
-    utils.insert_dump_data(dump_id, DumpType.INCREMENTAL, datetime.utcnow())
+    utils.insert_dump_data(dump_id, DumpType.INCREMENTAL, datetime.now(tz=timezone.utc))
+    unpersist_incremental_listens_df()
     return dump_name
 
 

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -10,6 +10,7 @@ import listenbrainz_spark
 from listenbrainz_spark import hdfs_connection
 from listenbrainz_spark.config import HDFS_CLUSTER_URI
 from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH
+from listenbrainz_spark.persisted import get_incremental_listens_df
 from listenbrainz_spark.schema import BOOKKEEPING_SCHEMA, INCREMENTAL_BOOKKEEPING_SCHEMA
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats.incremental.message_creator import MessageCreator
@@ -132,8 +133,7 @@ class IncrementalStatsEngine:
             DataFrame: The generated incremental aggregate DataFrame.
         """
         self.incremental_table = f"{self.provider.get_table_prefix()}_incremental_listens"
-        read_files_from_HDFS(INCREMENTAL_DUMPS_SAVE_PATH) \
-            .createOrReplaceTempView(self.incremental_table)
+        get_incremental_listens_df().createOrReplaceTempView(self.incremental_table)
         inc_query = self.provider.get_aggregate_query(self.incremental_table, self._cache_tables)
         return run_query(inc_query)
 

--- a/listenbrainz_spark/stats/incremental/listener/release_group.py
+++ b/listenbrainz_spark/stats/incremental/listener/release_group.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from typing import List
 
-from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME, \
-    RELEASE_GROUP_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.release import get_release_metadata_cache
+from listenbrainz_spark.postgres.release_group import get_release_group_metadata_cache
 from listenbrainz_spark.stats.incremental.listener.entity import EntityListenerStatsQueryProvider
 
 
@@ -13,15 +13,12 @@ class ReleaseGroupEntityListenerStatsQuery(EntityListenerStatsQueryProvider):
     def entity(self):
         return "release_groups"
 
-    def get_cache_tables(self) -> List[str]:
-        return [RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME]
-
     def get_entity_id(self):
         return "release_group_mbid"
 
-    def get_aggregate_query(self, table, cache_tables):
-        rel_cache_table = cache_tables[0]
-        rg_cache_table = cache_tables[1]
+    def get_aggregate_query(self, table):
+        rel_cache_table = get_release_metadata_cache()
+        rg_cache_table = get_release_group_metadata_cache()
         return f"""
             WITH gather_release_data AS (
                 SELECT user_id
@@ -98,7 +95,7 @@ class ReleaseGroupEntityListenerStatsQuery(EntityListenerStatsQueryProvider):
                      , user_id
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count as (
             SELECT release_group_mbid
@@ -156,9 +153,8 @@ class ReleaseGroupEntityListenerStatsQuery(EntityListenerStatsQueryProvider):
              USING (release_group_mbid)
         """
 
-    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime,
-                                   cache_tables: List[str]) -> str:
-        rel_cache_table = cache_tables[0]
+    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime) -> str:
+        rel_cache_table = get_release_metadata_cache()
         return f"""
             WITH incremental_release_groups AS (
                 SELECT DISTINCT rel.release_group_mbid

--- a/listenbrainz_spark/stats/incremental/query_provider.py
+++ b/listenbrainz_spark/stats/incremental/query_provider.py
@@ -14,7 +14,6 @@ class QueryProvider(abc.ABC):
             selector: ListenRangeSelector to provide dates and stats range for listens to choose stat from
         """
         self.stats_range, self.from_date, self.to_date = selector.get_dates()
-        self._cache_tables = []
 
     @property
     @abc.abstractmethod
@@ -25,11 +24,6 @@ class QueryProvider(abc.ABC):
     @abc.abstractmethod
     def get_table_prefix(self) -> str:
         """ Get the prefix for table names based on the stat type, entity and stats range. """
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def get_cache_tables(self) -> List[str]:
-        """ Returns the list of HDFS paths for the metadata cache tables required by the statistic. """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -46,13 +40,12 @@ class QueryProvider(abc.ABC):
         return f"{self.get_base_path()}/bookkeeping/{self.entity}/{self.stats_range}"
 
     @abc.abstractmethod
-    def get_aggregate_query(self, table: str, cache_tables: List[str]) -> str:
+    def get_aggregate_query(self, table: str) -> str:
         """
         Returns the query to create (partial) aggregates from the given listens.
 
         Args:
             table: The listen table to aggregation.
-            cache_tables: List of metadata cache tables.
         """
         raise NotImplementedError()
 
@@ -69,8 +62,7 @@ class QueryProvider(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime,
-                                   cache_tables: List[str]) -> str:
+    def get_filter_aggregate_query(self, aggregate: str, inc_listens_table: str, existing_created: datetime) -> str:
         """
         Return the query to filter the aggregate based on the listens submitted since existing created timestamp.
 
@@ -82,7 +74,7 @@ class QueryProvider(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_stats_query(self, final_aggregate: str, cache_tables: List[str]) -> str:
+    def get_stats_query(self, final_aggregate: str) -> str:
         """ Return the query to generate final statistics from final aggregate. """
         raise NotImplementedError()
 

--- a/listenbrainz_spark/stats/incremental/sitewide/artist.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/artist.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
+from listenbrainz_spark.postgres.artist import get_artist_country_cache
 from listenbrainz_spark.stats.incremental.sitewide.entity import SitewideEntityStatsQueryProvider
 
 
@@ -10,12 +10,9 @@ class AritstSitewideEntity(SitewideEntityStatsQueryProvider):
     def entity(self):
         return "artists"
 
-    def get_cache_tables(self) -> List[str]:
-        return [ARTIST_COUNTRY_CODE_DATAFRAME]
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         user_listen_count_limit = self.get_listen_count_limit()
-        cache_table = cache_tables[0]
+        cache_table = get_artist_country_cache()
         return f"""
             WITH exploded_listens AS (
                 SELECT user_id
@@ -68,7 +65,7 @@ class AritstSitewideEntity(SitewideEntityStatsQueryProvider):
                      , artist_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT count(*) AS total_count

--- a/listenbrainz_spark/stats/incremental/sitewide/artist_map.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/artist_map.py
@@ -2,6 +2,7 @@ from typing import List, Iterator, Dict
 
 from pyspark.sql import DataFrame
 
+from listenbrainz_spark.postgres.artist import get_artist_country_cache
 from listenbrainz_spark.stats.incremental.message_creator import StatsMessageCreator
 from listenbrainz_spark.stats.incremental.sitewide.artist import AritstSitewideEntity
 
@@ -9,8 +10,8 @@ from listenbrainz_spark.stats.incremental.sitewide.artist import AritstSitewideE
 class ArtistMapSitewideEntity(AritstSitewideEntity):
     """ See base class QueryProvider for details. """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
-        cache_table = cache_tables[0]
+    def get_stats_query(self, final_aggregate):
+        cache_table = get_artist_country_cache()
         return f"""
             WITH ranked_stats AS (
                 SELECT artist_name

--- a/listenbrainz_spark/stats/incremental/sitewide/entity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/entity.py
@@ -36,7 +36,7 @@ class SitewideStatsQueryProvider(QueryProvider, abc.ABC):
         return f"sitewide_{self.entity}_{self.stats_range}"
 
     def get_filter_aggregate_query(self, existing_aggregate: str, incremental_aggregate: str,
-                                   existed_created: Optional[datetime], cache_tables: List[str]) -> str:
+                                   existed_created: Optional[datetime]) -> str:
         return f"SELECT * FROM {existing_aggregate}"
 
 

--- a/listenbrainz_spark/stats/incremental/sitewide/listening_activity.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/listening_activity.py
@@ -20,10 +20,7 @@ class ListeningActivitySitewideStatsQuery(SitewideStatsQueryProvider):
     def entity(self):
         return "listening_activity"
 
-    def get_cache_tables(self) -> List[str]:
-        return []
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         return f"""
             SELECT date_format(listened_at, '{self.spark_date_format}') AS time_range
                  , count(listened_at) AS listen_count
@@ -48,7 +45,7 @@ class ListeningActivitySitewideStatsQuery(SitewideStatsQueryProvider):
               GROUP BY time_range
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
              SELECT sort_array(
                        collect_list(

--- a/listenbrainz_spark/stats/incremental/sitewide/recording.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/recording.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from listenbrainz_spark.postgres.release import get_release_metadata_cache
 from listenbrainz_spark.stats.incremental.sitewide.entity import SitewideEntityStatsQueryProvider
 

--- a/listenbrainz_spark/stats/incremental/sitewide/recording.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/recording.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.release import get_release_metadata_cache
 from listenbrainz_spark.stats.incremental.sitewide.entity import SitewideEntityStatsQueryProvider
 
 
@@ -11,12 +11,9 @@ class RecordingSitewideEntity(SitewideEntityStatsQueryProvider):
     def entity(self):
         return "recordings"
 
-    def get_cache_tables(self) -> List[str]:
-        return [RELEASE_METADATA_CACHE_DATAFRAME]
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         user_listen_count_limit = self.get_listen_count_limit()
-        cache_table = cache_tables[0]
+        rel_cache_table = get_release_metadata_cache()
         return f"""
         WITH user_counts as (
             SELECT user_id
@@ -30,7 +27,7 @@ class RecordingSitewideEntity(SitewideEntityStatsQueryProvider):
                  , rel.caa_release_mbid
                  , LEAST(count(*), {user_listen_count_limit}) as listen_count
               FROM {table} l
-         LEFT JOIN {cache_table} rel
+         LEFT JOIN {rel_cache_table} rel
                 ON rel.release_mbid = l.release_mbid
           GROUP BY l.user_id
                  , lower(l.recording_name)
@@ -107,7 +104,7 @@ class RecordingSitewideEntity(SitewideEntityStatsQueryProvider):
                      , caa_release_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT count(*) AS total_count

--- a/listenbrainz_spark/stats/incremental/sitewide/release.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/release.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.release import get_release_metadata_cache
 from listenbrainz_spark.stats.incremental.sitewide.entity import SitewideEntityStatsQueryProvider
 
 
@@ -11,12 +11,9 @@ class ReleaseSitewideEntity(SitewideEntityStatsQueryProvider):
     def entity(self):
         return "releases"
 
-    def get_cache_tables(self) -> List[str]:
-        return [RELEASE_METADATA_CACHE_DATAFRAME]
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         user_listen_count_limit = self.get_listen_count_limit()
-        cache_table = cache_tables[0]
+        rel_cache_table = get_release_metadata_cache()
         return f"""
            WITH gather_release_data AS (
                 SELECT user_id
@@ -27,7 +24,7 @@ class ReleaseSitewideEntity(SitewideEntityStatsQueryProvider):
                      , rel.caa_id
                      , rel.caa_release_mbid
                   FROM {table} l
-             LEFT JOIN {cache_table} rel
+             LEFT JOIN {rel_cache_table} rel
                     ON rel.release_mbid = l.release_mbid
             ), user_counts AS (
                 SELECT user_id
@@ -102,7 +99,7 @@ class ReleaseSitewideEntity(SitewideEntityStatsQueryProvider):
                      , caa_release_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT count(*) AS total_count

--- a/listenbrainz_spark/stats/incremental/sitewide/release_group.py
+++ b/listenbrainz_spark/stats/incremental/sitewide/release_group.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.release import get_release_metadata_cache
+from listenbrainz_spark.postgres.release_group import get_release_group_metadata_cache
 from listenbrainz_spark.stats.incremental.sitewide.entity import SitewideEntityStatsQueryProvider
 
 
@@ -11,13 +12,10 @@ class ReleaseGroupSitewideEntity(SitewideEntityStatsQueryProvider):
     def entity(self):
         return "release_groups"
 
-    def get_cache_tables(self) -> List[str]:
-        return [RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME]
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         user_listen_count_limit = self.get_listen_count_limit()
-        rel_cache_table = cache_tables[0]
-        rg_cache_table = cache_tables[1]
+        rel_cache_table = get_release_metadata_cache()
+        rg_cache_table = get_release_group_metadata_cache()
         return f"""
         WITH gather_release_group_data AS (
             SELECT l.user_id
@@ -107,7 +105,7 @@ class ReleaseGroupSitewideEntity(SitewideEntityStatsQueryProvider):
                      , caa_release_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT count(*) AS total_count

--- a/listenbrainz_spark/stats/incremental/user/artist.py
+++ b/listenbrainz_spark/stats/incremental/user/artist.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
+from listenbrainz_spark.postgres.artist import get_artist_country_df
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
@@ -16,10 +17,11 @@ class ArtistUserEntity(UserEntityStatsQueryProvider):
         return "artists"
 
     def get_cache_tables(self) -> List[str]:
-        return [ARTIST_COUNTRY_CODE_DATAFRAME]
+        return []
 
     def get_aggregate_query(self, table, cache_tables):
-        cache_table = cache_tables[0]
+        get_artist_country_df().createOrReplaceTempView("artist_country_code")
+        cache_table = "artist_country_code"
         return f"""
             WITH exploded_listens AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/artist.py
+++ b/listenbrainz_spark/stats/incremental/user/artist.py
@@ -1,7 +1,6 @@
 from typing import List
 
-from listenbrainz_spark.path import ARTIST_COUNTRY_CODE_DATAFRAME
-from listenbrainz_spark.postgres.artist import get_artist_country_df
+from listenbrainz_spark.postgres.artist import get_artist_country_cache
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
@@ -16,12 +15,8 @@ class ArtistUserEntity(UserEntityStatsQueryProvider):
     def entity(self):
         return "artists"
 
-    def get_cache_tables(self) -> List[str]:
-        return []
-
-    def get_aggregate_query(self, table, cache_tables):
-        get_artist_country_df().createOrReplaceTempView("artist_country_code")
-        cache_table = "artist_country_code"
+    def get_aggregate_query(self, table):
+        cache_table = get_artist_country_cache()
         return f"""
             WITH exploded_listens AS (
                 SELECT user_id
@@ -77,7 +72,7 @@ class ArtistUserEntity(UserEntityStatsQueryProvider):
                      , artist_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/artist_map.py
+++ b/listenbrainz_spark/stats/incremental/user/artist_map.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from listenbrainz_spark.postgres.artist import get_artist_country_df
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
 from listenbrainz_spark.stats.incremental.user.artist import ArtistUserEntity
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsMessageCreator
@@ -12,7 +13,8 @@ class ArtistMapUserEntity(ArtistUserEntity):
         super().__init__(selector=selector, top_entity_limit=top_entity_limit)
 
     def get_stats_query(self, final_aggregate, cache_tables: List[str]):
-        cache_table = cache_tables[0]
+        get_artist_country_df().createOrReplaceTempView("artist_country_code")
+        cache_table = "artist_country_code"
         return f"""
             WITH ranked_stats AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/artist_map.py
+++ b/listenbrainz_spark/stats/incremental/user/artist_map.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from listenbrainz_spark.postgres.artist import get_artist_country_df
+from listenbrainz_spark.postgres.artist import get_artist_country_cache
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
 from listenbrainz_spark.stats.incremental.user.artist import ArtistUserEntity
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsMessageCreator
@@ -12,9 +12,8 @@ class ArtistMapUserEntity(ArtistUserEntity):
     def __init__(self, selector: ListenRangeSelector, top_entity_limit: int):
         super().__init__(selector=selector, top_entity_limit=top_entity_limit)
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
-        get_artist_country_df().createOrReplaceTempView("artist_country_code")
-        cache_table = "artist_country_code"
+    def get_stats_query(self, final_aggregate):
+        cache_table = get_artist_country_cache()
         return f"""
             WITH ranked_stats AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/daily_activity.py
+++ b/listenbrainz_spark/stats/incremental/user/daily_activity.py
@@ -33,10 +33,7 @@ class DailyActivityUserStatsQueryEntity(UserStatsQueryProvider):
         time_range_df = listenbrainz_spark.session.createDataFrame(time_range, schema=["day", "hour"])
         time_range_df.createOrReplaceTempView("time_range")
 
-    def get_cache_tables(self) -> List[str]:
-        return []
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         return f"""
             SELECT user_id
                  , date_format(listened_at, 'EEEE') as day
@@ -73,7 +70,7 @@ class DailyActivityUserStatsQueryEntity(UserStatsQueryProvider):
                      , hour
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
              SELECT user_id
                   , sort_array(

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -36,7 +36,7 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
     def get_table_prefix(self) -> str:
         return f"user_{self.entity}_{self.stats_range}"
 
-    def get_filter_aggregate_query(self, aggregate, inc_listens_table, existing_created, cache_tables: List[str]):
+    def get_filter_aggregate_query(self, aggregate, inc_listens_table, existing_created):
         """ Filter listens from existing aggregate to only include listens for entities having listens in the
         incremental dumps.
         """

--- a/listenbrainz_spark/stats/incremental/user/entity.py
+++ b/listenbrainz_spark/stats/incremental/user/entity.py
@@ -11,6 +11,7 @@ from data.model.user_recording_stat import RecordingRecord
 from data.model.user_release_group_stat import ReleaseGroupRecord
 from data.model.user_release_stat import ReleaseRecord
 from listenbrainz_spark.path import LISTENBRAINZ_USER_STATS_DIRECTORY
+from listenbrainz_spark.persisted import get_incremental_users_df
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats.incremental.message_creator import StatsMessageCreator
 from listenbrainz_spark.stats.incremental.query_provider import QueryProvider
@@ -39,10 +40,12 @@ class UserStatsQueryProvider(QueryProvider, abc.ABC):
         """ Filter listens from existing aggregate to only include listens for entities having listens in the
         incremental dumps.
         """
+        inc_users_df = get_incremental_users_df()
+        inc_users_df.createOrReplaceTempView("inc_users_table")
         return f"""
               WITH incremental_users AS (
-            SELECT DISTINCT user_id
-              FROM {inc_listens_table}
+            SELECT user_id
+              FROM inc_users_table
              WHERE created >= to_timestamp('{existing_created}')
             )
             SELECT *

--- a/listenbrainz_spark/stats/incremental/user/listening_activity.py
+++ b/listenbrainz_spark/stats/incremental/user/listening_activity.py
@@ -24,10 +24,7 @@ class ListeningActivityUserStatsQueryEntity(UserStatsQueryProvider):
     def entity(self):
         return "listening_activity"
 
-    def get_cache_tables(self) -> List[str]:
-        return []
-
-    def get_aggregate_query(self, table, cache_tables):
+    def get_aggregate_query(self, table):
         return f"""
             SELECT user_id
                  , date_format(listened_at, '{self.spark_date_format}') AS time_range
@@ -58,7 +55,7 @@ class ListeningActivityUserStatsQueryEntity(UserStatsQueryProvider):
                      , time_range
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         # calculates the number of listens in each time range for each user, count(listen.listened_at) so that
         # group without listens are counted as 0, count(*) gives 1.
         # use cross join to create all time range rows for all users (otherwise ranges in which user was inactive

--- a/listenbrainz_spark/stats/incremental/user/recording.py
+++ b/listenbrainz_spark/stats/incremental/user/recording.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from listenbrainz_spark.path import RECORDING_ARTIST_DATAFRAME, RELEASE_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.recording import get_recording_artist_df
+from listenbrainz_spark.postgres.release import get_release_metadata_df
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
 
@@ -12,11 +13,13 @@ class RecordingUserEntity(UserEntityStatsQueryProvider):
         return "recordings"
 
     def get_cache_tables(self) -> List[str]:
-        return [RECORDING_ARTIST_DATAFRAME, RELEASE_METADATA_CACHE_DATAFRAME]
+        return []
 
     def get_aggregate_query(self, table, cache_tables):
-        rec_cache_table = cache_tables[0]
-        rel_cache_table = cache_tables[1]
+        rec_cache_table = "recording_artist_cache_df"
+        get_recording_artist_df().createOrReplaceTempView(rec_cache_table)
+        rel_cache_table = "release_metadata_cache_df"
+        get_release_metadata_df().createOrReplaceTempView(rel_cache_table)
         return f"""
             SELECT user_id
                  , first(l.recording_name) AS recording_name

--- a/listenbrainz_spark/stats/incremental/user/release.py
+++ b/listenbrainz_spark/stats/incremental/user/release.py
@@ -1,7 +1,6 @@
 from typing import List
 
-from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
-from listenbrainz_spark.postgres.release import get_release_metadata_df
+from listenbrainz_spark.postgres.release import get_release_metadata_cache
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
 
@@ -12,12 +11,8 @@ class ReleaseUserEntity(UserEntityStatsQueryProvider):
     def entity(self):
         return "releases"
 
-    def get_cache_tables(self) -> List[str]:
-        return []
-
-    def get_aggregate_query(self, table, cache_tables):
-        cache_table = "release_metadata_cache_df"
-        get_release_metadata_df().createOrReplaceTempView(cache_table)
+    def get_aggregate_query(self, table):
+        cache_table = get_release_metadata_cache()
         return f"""
             WITH gather_release_data AS (
                 SELECT user_id
@@ -99,7 +94,7 @@ class ReleaseUserEntity(UserEntityStatsQueryProvider):
                      , caa_release_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/release.py
+++ b/listenbrainz_spark/stats/incremental/user/release.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.release import get_release_metadata_df
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
 
@@ -12,10 +13,11 @@ class ReleaseUserEntity(UserEntityStatsQueryProvider):
         return "releases"
 
     def get_cache_tables(self) -> List[str]:
-        return [RELEASE_METADATA_CACHE_DATAFRAME]
+        return []
 
     def get_aggregate_query(self, table, cache_tables):
-        cache_table = cache_tables[0]
+        cache_table = "release_metadata_cache_df"
+        get_release_metadata_df().createOrReplaceTempView(cache_table)
         return f"""
             WITH gather_release_data AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/release_group.py
+++ b/listenbrainz_spark/stats/incremental/user/release_group.py
@@ -1,8 +1,7 @@
 from typing import List
 
-from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME
-from listenbrainz_spark.postgres.release import get_release_metadata_df
-from listenbrainz_spark.postgres.release_group import get_release_group_metadata_df
+from listenbrainz_spark.postgres.release import get_release_metadata_cache
+from listenbrainz_spark.postgres.release_group import get_release_group_metadata_cache
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
 
@@ -13,14 +12,9 @@ class ReleaseGroupUserEntity(UserEntityStatsQueryProvider):
     def entity(self):
         return "release_groups"
 
-    def get_cache_tables(self) -> List[str]:
-        return []
-
-    def get_aggregate_query(self, table, cache_tables):
-        rel_cache_table = "release_metadata_cache_df"
-        get_release_metadata_df().createOrReplaceTempView(rel_cache_table)
-        rg_cache_table = "release_group_metadata_cache_df"
-        get_release_group_metadata_df().createOrReplaceTempView(rg_cache_table)
+    def get_aggregate_query(self, table):
+        rel_cache_table = get_release_metadata_cache()
+        rg_cache_table = get_release_group_metadata_cache()
         return f"""
             WITH gather_release_data AS (
                 SELECT user_id
@@ -106,7 +100,7 @@ class ReleaseGroupUserEntity(UserEntityStatsQueryProvider):
                      , caa_release_mbid
         """
 
-    def get_stats_query(self, final_aggregate, cache_tables: List[str]):
+    def get_stats_query(self, final_aggregate):
         return f"""
             WITH entity_count AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/release_group.py
+++ b/listenbrainz_spark/stats/incremental/user/release_group.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME
+from listenbrainz_spark.postgres.release import get_release_metadata_df
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
 
@@ -12,11 +13,13 @@ class ReleaseGroupUserEntity(UserEntityStatsQueryProvider):
         return "release_groups"
 
     def get_cache_tables(self) -> List[str]:
-        return [RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME]
+        return []
 
     def get_aggregate_query(self, table, cache_tables):
-        rel_cache_table = cache_tables[0]
-        rg_cache_table = cache_tables[1]
+        rel_cache_table = "release_metadata_cache_df"
+        get_release_metadata_df().createOrReplaceTempView(rel_cache_table)
+        rg_cache_table = "release_group_metadata_cache_df"
+        get_release_metadata_df().createOrReplaceTempView(rg_cache_table)
         return f"""
             WITH gather_release_data AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/incremental/user/release_group.py
+++ b/listenbrainz_spark/stats/incremental/user/release_group.py
@@ -2,6 +2,7 @@ from typing import List
 
 from listenbrainz_spark.path import RELEASE_METADATA_CACHE_DATAFRAME, RELEASE_GROUP_METADATA_CACHE_DATAFRAME
 from listenbrainz_spark.postgres.release import get_release_metadata_df
+from listenbrainz_spark.postgres.release_group import get_release_group_metadata_df
 from listenbrainz_spark.stats.incremental.user.entity import UserEntityStatsQueryProvider
 
 
@@ -19,7 +20,7 @@ class ReleaseGroupUserEntity(UserEntityStatsQueryProvider):
         rel_cache_table = "release_metadata_cache_df"
         get_release_metadata_df().createOrReplaceTempView(rel_cache_table)
         rg_cache_table = "release_group_metadata_cache_df"
-        get_release_metadata_df().createOrReplaceTempView(rg_cache_table)
+        get_release_group_metadata_df().createOrReplaceTempView(rg_cache_table)
         return f"""
             WITH gather_release_data AS (
                 SELECT user_id

--- a/listenbrainz_spark/stats/sitewide/entity.py
+++ b/listenbrainz_spark/stats/sitewide/entity.py
@@ -37,7 +37,7 @@ def get_entity_stats(entity: str, stats_range: str) -> Iterator[Dict]:
 
         artist_map_entity = ArtistMapSitewideEntity(selector, SITEWIDE_STATS_ENTITY_LIMIT)
         artist_map_message_creator = ArtistMapSitewideStatsMessageCreator(selector)
-        artist_map_query = artist_map_entity.get_stats_query(engine._final_table, engine._cache_tables)
+        artist_map_query = artist_map_entity.get_stats_query(engine._final_table)
         artist_map_results = run_query(artist_map_query)
         yield from engine.create_messages(artist_map_results, engine._only_inc, artist_map_message_creator)
     else:

--- a/listenbrainz_spark/stats/user/entity.py
+++ b/listenbrainz_spark/stats/user/entity.py
@@ -37,7 +37,7 @@ def get_entity_stats(entity: str, stats_range: str, database: str = None) -> Ite
         artist_map_database = database.replace("artists", "artist_map") if database else None
         artist_map_entity = ArtistMapUserEntity(selector, NUMBER_OF_TOP_ENTITIES)
         artist_map_message_creator = ArtistMapStatsMessageCreator("artist_map", "user_entity", selector, artist_map_database)
-        artist_map_query = artist_map_entity.get_stats_query(engine._final_table, engine._cache_tables)
+        artist_map_query = artist_map_entity.get_stats_query(engine._final_table)
         artist_map_results = run_query(artist_map_query)
         yield from engine.create_messages(artist_map_results, engine._only_inc, artist_map_message_creator)
     else:

--- a/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
+++ b/listenbrainz_spark/year_in_music/new_releases_of_top_artists.py
@@ -2,11 +2,10 @@ from datetime import datetime, date, time
 
 from more_itertools import chunked
 
-from listenbrainz_spark.path import RELEASE_GROUP_METADATA_CACHE_DATAFRAME
-from listenbrainz_spark.postgres.release_group import create_release_group_metadata_cache
+from listenbrainz_spark.postgres.release_group import create_release_group_metadata_cache, get_release_group_metadata_cache
 
 from listenbrainz_spark.stats import run_query
-from listenbrainz_spark.utils import get_listens_from_dump, read_files_from_HDFS
+from listenbrainz_spark.utils import get_listens_from_dump
 
 
 USERS_PER_MESSAGE = 500
@@ -18,7 +17,7 @@ def get_new_releases_of_top_artists(year):
     get_listens_from_dump(from_date, to_date).createOrReplaceTempView("listens")
 
     create_release_group_metadata_cache()
-    read_files_from_HDFS(RELEASE_GROUP_METADATA_CACHE_DATAFRAME).createOrReplaceTempView("release_groups_all")
+    get_release_group_metadata_cache().createOrReplaceTempView("release_groups_all")
 
     new_releases = run_query(_get_new_releases_of_top_artists(year))
 

--- a/listenbrainz_spark/year_in_music/top_stats.py
+++ b/listenbrainz_spark/year_in_music/top_stats.py
@@ -51,7 +51,7 @@ def calculate_top_entity_stats(year):
         if entity == "artists":
             artist_map_entity = ArtistMapUserEntity(selector, NUMBER_OF_YIM_ENTITIES)
             artist_map_message_creator = YIMArtistMapMessageCreator(selector)
-            artist_map_query = artist_map_entity.get_stats_query(engine._final_table, engine._cache_tables)
+            artist_map_query = artist_map_entity.get_stats_query(engine._final_table)
             artist_map_results = run_query(artist_map_query)
             for message in engine.create_messages(artist_map_results, engine._only_inc, artist_map_message_creator):
                 if message["type"] == "couchdb_data_start" or message["type"] == "couchdb_data_end":


### PR DESCRIPTION
Persisting these not so big and commonly used datasets with Spark creates a copy of them in each node's memory and/or disk which speeds up processing of stats.