### PR TITLE
LB-1735: Automatically switch search type depending on pasted MB URL

### DIFF
--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -31,6 +31,8 @@ import {
 
 interface AddAlbumListensProps {
   onPayloadChange: (listens: Listen[]) => void;
+  switchMode: (text: string) => void;
+  initialText?: string;
 }
 
 export type MBReleaseWithMetadata = MusicBrainzRelease &
@@ -95,6 +97,8 @@ export function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
 
 export default function AddAlbumListens({
   onPayloadChange,
+  switchMode,
+  initialText,
 }: AddAlbumListensProps) {
   const { APIService } = useContext(GlobalAppContext);
   const { lookupMBRelease } = APIService;
@@ -103,6 +107,22 @@ export default function AddAlbumListens({
   const [selectedTracks, setSelectedTracks] = useState<Array<MBTrackWithAC>>(
     []
   );
+  const searchInputRef = useRef<{
+    focus(): void;
+    triggerSearch(newText: string): void;
+  }>(null);
+
+  const initialTextRef = useRef(initialText);
+  React.useEffect(() => {
+    // Trigger search manually if auto-switching from album to recording search
+    if (initialText && initialTextRef.current !== initialText) {
+      searchInputRef.current?.triggerSearch(initialText);
+      initialTextRef.current = initialText;
+    }
+    return () => {
+      initialTextRef.current = undefined;
+    };
+  }, [initialText]);
 
   // No need to store that one in the state
   const lastChecked = useRef<MBTrackWithAC>();
@@ -230,6 +250,8 @@ export default function AddAlbumListens({
         onSelectAlbum={(newSelectedAlbumId?: string) => {
           setSelectedAlbumMBID(newSelectedAlbumId);
         }}
+        switchMode={switchMode}
+        ref={searchInputRef}
       />
       <div className="track-info">
         {selectedAlbum && (

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -101,6 +101,8 @@ export default NiceModal.create(() => {
   const [customTimestamp, setCustomTimestamp] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [invertOrder, setInvertOrder] = useState(false);
+  // Used for the automatic switching and search trigger if pasting URL for another entity type
+  const [textToSearch, setTextToSearch] = useState<string>();
 
   const closeModal = useCallback(() => {
     modal.hide();
@@ -211,6 +213,26 @@ export default NiceModal.create(() => {
     handleError,
   ]);
 
+  const switchMode = React.useCallback(
+    (pastedURL: string) => {
+      if (listenOption === SubmitListenType.track) {
+        setListenOption(SubmitListenType.album);
+      } else if (listenOption === SubmitListenType.album) {
+        setListenOption(SubmitListenType.track);
+      }
+      setTimeout(() => {
+        // Trigger search in the inner (grandchild) search input component by modifying the textToSearch prop in child component
+        // Give it some time to allow re-render and trigger search in the correct child component
+        setTextToSearch(pastedURL);
+      }, 200);
+      setTimeout(() => {
+        // Reset text trigger
+        setTextToSearch("");
+      }, 500);
+    },
+    [listenOption]
+  );
+
   const userLocale = navigator.languages?.length
     ? navigator.languages[0]
     : navigator.language;
@@ -262,10 +284,18 @@ export default NiceModal.create(() => {
               </Pill>
             </div>
             {listenOption === SubmitListenType.track && (
-              <AddSingleListen onPayloadChange={setSelectedListens} />
+              <AddSingleListen
+                onPayloadChange={setSelectedListens}
+                switchMode={switchMode}
+                initialText={textToSearch}
+              />
             )}
             {listenOption === SubmitListenType.album && (
-              <AddAlbumListens onPayloadChange={setSelectedListens} />
+              <AddAlbumListens
+                onPayloadChange={setSelectedListens}
+                switchMode={switchMode}
+                initialText={textToSearch}
+              />
             )}
             <hr />
             <div className="timestamp">

--- a/frontend/js/src/user/components/AddSingleListen.tsx
+++ b/frontend/js/src/user/components/AddSingleListen.tsx
@@ -12,10 +12,14 @@ import ReleaseCard from "../../explore/fresh-releases/components/ReleaseCard";
 
 interface AddSingleListenProps {
   onPayloadChange: (listens: Listen[]) => void;
+  switchMode: (text: string) => void;
+  initialText?: string;
 }
 
 export default function AddSingleListen({
   onPayloadChange,
+  switchMode,
+  initialText,
 }: AddSingleListenProps) {
   const [selectedRecordings, setSelectedRecordings] = useState<
     MusicBrainzRecordingWithReleasesAndRGs[]
@@ -26,7 +30,22 @@ export default function AddSingleListen({
       | undefined;
   }>({});
 
-  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchInputRef = useRef<{
+    focus(): void;
+    triggerSearch(newText: string): void;
+  }>(null);
+
+  const initialTextRef = useRef(initialText);
+  React.useEffect(() => {
+    // Trigger search manually if auto-switching from album to recording search
+    if (initialText && initialTextRef.current !== initialText) {
+      searchInputRef.current?.triggerSearch(initialText);
+      initialTextRef.current = initialText;
+    }
+    return () => {
+      initialTextRef.current = undefined;
+    };
+  }, [initialText]);
 
   const removeRecording = (recordingMBID: string) => {
     setSelectedRecordings((prevRecordings) =>
@@ -77,6 +96,7 @@ export default function AddSingleListen({
         ref={searchInputRef}
         expectedPayload="recording"
         onSelectRecording={selectRecording}
+        switchMode={switchMode}
       />
       <div className="track-info">
         <div className="content">

--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -1,10 +1,12 @@
 import { faSpinner, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { throttle } from "lodash";
+import { isFunction, throttle } from "lodash";
 import React, {
+  forwardRef,
   useCallback,
   useContext,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -13,21 +15,23 @@ import { toast } from "react-toastify";
 import { ToastMsg } from "../notifications/Notifications";
 import GlobalAppContext from "./GlobalAppContext";
 import DropdownRef from "./Dropdown";
+import { RECORDING_MBID_REGEXP } from "./SearchTrackOrMBID";
 
-const RELEASE_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/release\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
-const RELEASE_GROUP_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/release-group\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
-const LB_ALBUM_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?listenbrainz\.org\/album\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
+export const RELEASE_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/release\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
+export const RELEASE_GROUP_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/release-group\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
+export const LB_ALBUM_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?listenbrainz\.org\/album\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
 const THROTTLE_MILLISECONDS = 1500;
 
 type SearchTrackOrMBIDProps = {
   onSelectAlbum: (releaseMBID?: string) => void;
   defaultValue?: string;
+  switchMode?: (text: string) => void;
 };
 
-export default function SearchAlbumOrMBID({
-  onSelectAlbum,
-  defaultValue,
-}: SearchTrackOrMBIDProps) {
+const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
+  { onSelectAlbum, defaultValue, switchMode }: SearchTrackOrMBIDProps,
+  inputRefForParent
+) {
   const { APIService } = useContext(GlobalAppContext);
   const { lookupMBReleaseGroup, searchMBRelease } = APIService;
   const dropdownRef = DropdownRef();
@@ -37,6 +41,23 @@ export default function SearchAlbumOrMBID({
   const [searchResults, setSearchResults] = useState<
     Array<MusicBrainzRelease & Partial<WithMedia> & WithArtistCredits>
   >([]);
+
+  // Allow parents to focus on input and trigger search
+  useImperativeHandle(
+    inputRefForParent,
+    () => {
+      return {
+        focus() {
+          searchInputRef?.current?.focus();
+        },
+        triggerSearch(newText: string) {
+          setInputValue(newText);
+        },
+      };
+    },
+    []
+  );
+
   const handleError = useCallback(
     (error: string | Error, title?: string): void => {
       if (!error) {
@@ -136,16 +157,26 @@ export default function SearchAlbumOrMBID({
       return;
     }
     setLoading(true);
-    const isValidUUID =
+    const isValidAlbumUUID =
       RELEASE_MBID_REGEXP.test(inputValue) ||
       RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
       LB_ALBUM_MBID_REGEXP.test(inputValue);
-    if (isValidUUID) {
+    const isValidRecordingUUID = RECORDING_MBID_REGEXP.test(inputValue);
+    if (isValidRecordingUUID && isFunction(switchMode)) {
+      switchMode(inputValue);
+      return;
+    }
+    if (isValidAlbumUUID) {
       throttledHandleValidMBID(inputValue);
     } else {
       throttledSearchRelease(inputValue);
     }
-  }, [inputValue, throttledHandleValidMBID, throttledSearchRelease]);
+  }, [
+    inputValue,
+    throttledHandleValidMBID,
+    throttledSearchRelease,
+    switchMode,
+  ]);
 
   // Autofocus once on load
   useEffect(() => {
@@ -198,9 +229,9 @@ export default function SearchAlbumOrMBID({
               let releaseInfoString = `(${release.media
                 ?.map((medium) => medium.format)
                 .join(" + ")}) 
-              ${
-                release.country === "XE" ? "Worldwide" : release.country ?? ""
-              } ${release.date ?? ""}`;
+                ${
+                  release.country === "XE" ? "Worldwide" : release.country ?? ""
+                } ${release.date ?? ""}`;
               if (release["label-info"]?.length) {
                 const labelNames = release["label-info"]
                   ?.map((li) => li.label?.name)
@@ -243,4 +274,6 @@ export default function SearchAlbumOrMBID({
       </div>
     </div>
   );
-}
+});
+
+export default SearchAlbumOrMBID;

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -1,6 +1,6 @@
 import { faSpinner, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { throttle } from "lodash";
+import { isFunction, throttle } from "lodash";
 import React, {
   forwardRef,
   useCallback,
@@ -15,8 +15,13 @@ import { toast } from "react-toastify";
 import { ToastMsg } from "../notifications/Notifications";
 import GlobalAppContext from "./GlobalAppContext";
 import DropdownRef from "./Dropdown";
+import {
+  LB_ALBUM_MBID_REGEXP,
+  RELEASE_GROUP_MBID_REGEXP,
+  RELEASE_MBID_REGEXP,
+} from "./SearchAlbumOrMBID";
 
-const RECORDING_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/recording\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
+export const RECORDING_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/recording\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
 const THROTTLE_MILLISECONDS = 1500;
 
 type PayloadType = "trackmetadata" | "recording";
@@ -38,6 +43,7 @@ type SearchTrackOrMBIDProps = {
   autofocus?: boolean;
   defaultValue?: string;
   expectedPayload: PayloadType;
+  switchMode?: (text: string) => void;
 } & ConditionalReturnValue;
 
 const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
@@ -46,6 +52,7 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
     expectedPayload,
     defaultValue,
     autofocus = true,
+    switchMode,
   }: SearchTrackOrMBIDProps,
   inputRefForParent
 ) {
@@ -67,6 +74,9 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
       return {
         focus() {
           inputRefLocal?.current?.focus();
+        },
+        triggerSearch(newText: string) {
+          setInputValue(newText);
         },
       };
     },
@@ -223,8 +233,16 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
       return;
     }
     setLoading(true);
-    const isValidUUID = RECORDING_MBID_REGEXP.test(inputValue);
-    if (isValidUUID) {
+    const isValidRecordingUUID = RECORDING_MBID_REGEXP.test(inputValue);
+    const isValidAlbumUUID =
+      RELEASE_MBID_REGEXP.test(inputValue) ||
+      RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
+      LB_ALBUM_MBID_REGEXP.test(inputValue);
+    if (isValidAlbumUUID && isFunction(switchMode)) {
+      switchMode(inputValue);
+      return;
+    }
+    if (isValidRecordingUUID) {
       throttledHandleValidMBID(inputValue);
     } else {
       throttledSearchTrack(inputValue);


### PR DESCRIPTION
Automatically switches between components to add a recording and add a release if the pasted MusicBrainz URL is of the other entity type.
So for example if you paste a release or release group MBID in the single track search, it will automatically switch to the "Add album" mode, copying the pasted URL over and triggering the search.

The components are so split up (to allow re-usability across the codebase) that this requires a bit of extra fuckery to shoehorn this feature in (requires both switching components and triggering actions on said un-rendered component, requiring delays before triggers etc.)