### PR TITLE
Refactor listen_delete_metadata

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -12,7 +12,10 @@ CREATE TABLE listen_delete_metadata (
     id                  SERIAL                      NOT NULL,
     user_id             INTEGER                     NOT NULL,
     listened_at         TIMESTAMP WITH TIME ZONE    NOT NULL,
-    recording_msid      UUID                        NOT NULL
+    recording_msid      UUID                        NOT NULL,
+    deleted             BOOLEAN                     NOT NULL DEFAULT FALSE,
+    listen_created      TIMESTAMP WITH TIME ZONE
+    CHECK ( deleted IS FALSE OR (deleted IS TRUE AND listen_created IS NOT NULL) )
 );
 
 CREATE TABLE listen_user_metadata (

--- a/admin/timescale/updates/2025-02-18-add-listen-delete-metadata.sql
+++ b/admin/timescale/updates/2025-02-18-add-listen-delete-metadata.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE listen_delete_metadata ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE listen_delete_metadata ADD COLUMN listen_created TIMESTAMP WITH TIME ZONE;
+ALTER TABLE listen_delete_metadata
+    ADD CONSTRAINT listen_delete_metadata_deleted_created_constraint
+    CHECK ( deleted IS FALSE OR (deleted IS TRUE AND listen_created IS NOT NULL) );
+
+COMMIT;

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -222,6 +222,9 @@ def create_full(location: str, location_private: str, threads: int, dump_id: int
             with open(os.path.join(private_dump_path, "DUMP_ID.txt"), "w") as f:
                 f.write("%s %s full\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
+        if do_spark_dump:
+            ls.cleanup_listen_delete_metadata()
+
         sys.exit(0)
 
 

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -15,6 +15,7 @@ import sqlalchemy
 import tempfile
 import orjson
 from psycopg2.extras import execute_values
+from sqlalchemy import text
 
 from listenbrainz import DUMP_LICENSE_FILE_PATH, db
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
@@ -549,3 +550,11 @@ class DumpListenStore:
         self.log.info('ListenBrainz spark listen dump done!')
         self.log.info('Dump present at %s!', archive_path)
         return archive_path
+
+    def cleanup_listen_delete_metadata(self):
+        """ Cleanup listen delete metadata after spark full dump is complete """
+        self.log.info("Cleaning up listen_delete_metadata")
+        with timescale.engine.connect() as connection:
+            connection.execute(text("DELETE FROM listen_delete_metadata WHERE deleted"))
+            connection.commit()
+        self.log.info("Cleaning up listen_delete_metadata done!")

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -106,19 +106,24 @@ def delete_listens():
                AND l.user_id = ldm.user_id
                AND l.listened_at = ldm.listened_at
                AND l.recording_msid = ldm.recording_msid
-         RETURNING l.user_id, l.created
+               AND NOT ldm.deleted
+         RETURNING ldm.id, l.user_id, l.created
         ), update_counts AS (
-            SELECT user_id
-                 , count(*) AS deleted_count
-              FROM deleted_listens dl
-              JOIN listen_user_metadata lm
-             USING (user_id)
-          GROUP BY user_id
-        ) 
             UPDATE listen_user_metadata lm
                SET count = count - deleted_count
-              FROM update_counts uc
+              FROM (
+                        SELECT user_id
+                             , count(*) AS deleted_count
+                          FROM deleted_listens dl
+                      GROUP BY user_id
+                   ) uc
              WHERE lm.user_id = uc.user_id
+        )
+            UPDATE listen_delete_metadata ldm
+               SET deleted = 't'
+                 , listen_created = dl.created
+              FROM deleted_listens dl
+             WHERE ldm.id = dl.id
     """
 
     # check for which users the listen of minimum listened_at was deleted, for those users
@@ -188,7 +193,6 @@ def delete_listens():
               FROM calculate_new_ts mt
              WHERE lm.user_id = mt.user_id
     """
-    delete_user_metadata = "DELETE FROM listen_delete_metadata WHERE id <= :max_id"
 
     with timescale.engine.begin() as connection:
         result = connection.execute(text(select_max_id))
@@ -209,9 +213,6 @@ def delete_listens():
 
         logger.info("Update maximum listen timestamp affected by deleted listens")
         connection.execute(text(update_listen_max_ts), {"max_id": max_id})
-
-        logger.info("Clean up listen delete metadata table")
-        connection.execute(text(delete_user_metadata), {"max_id": max_id})
 
         logger.info("Completed deleting listens and updating affected metadata")
 


### PR DESCRIPTION
To directly import deleted listens in the spark cluster, do not remove deleted listens from listen_delete_metadata until a full dump is produced. The listen created field is useful for cases where the same listens is been deleted and later reimported. Hence, store the deleted listen's created back in the delete metadata for spark to query later.