### PR TITLE
Move created timestamp resolution reduction to postgres

### DIFF
--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -343,7 +343,7 @@ class DumpListenStore:
         -- setting multiple columns at once.
                 WITH listen_with_mbid AS (
                      SELECT l.listened_at
-                          , l.created
+                          , l.created::timestamp(3) with time zone AS created -- reduce timestamp resolution to ms
                           , l.user_id
                           , l.recording_msid
                           -- converting jsonb array to text array is non-trivial, so return a jsonb array not text


### PR DESCRIPTION
created column of the listen table and listen_created column in the listen_delete_metadata table are used in an anti join to filter deleted listens in the spark cluster. The rounding off done by pyarrow seems to be different from the rounding off done by spark/postgres due to which some of the rows miss the join by 1 ms. To ensure consistency in rounding and ensure that the created values match, do the resolution reduction for both cases in postgres.