### PR TITLE
Add missing filter on incremental listens during stats

### DIFF
--- a/listenbrainz_spark/persisted.py
+++ b/listenbrainz_spark/persisted.py
@@ -20,6 +20,10 @@ def unpersist_incremental_df():
 
 
 def get_incremental_listens_df() -> DataFrame:
+    """ Loads all listens imported from incremental dumps
+
+    Filter on listened_at after loading the dataframe to restrict on desired date range.
+    """
     global _incremental_listens_df
     if _incremental_listens_df is None:
         _incremental_listens_df = read_files_from_HDFS(INCREMENTAL_DUMPS_SAVE_PATH)

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -123,7 +123,12 @@ class IncrementalStatsEngine:
             DataFrame: The generated incremental aggregate DataFrame.
         """
         self.incremental_table = f"{self.provider.get_table_prefix()}_incremental_listens"
-        get_incremental_listens_df().createOrReplaceTempView(self.incremental_table)
+
+        inc_listens_df = get_incremental_listens_df()
+        inc_listens_df = inc_listens_df.where(f"listened_at >= to_timestamp('{self.provider.from_date}')")
+        inc_listens_df = inc_listens_df.where(f"listened_at <= to_timestamp('{self.provider.to_date}')")
+        inc_listens_df.createOrReplaceTempView(self.incremental_table)
+
         inc_query = self.provider.get_aggregate_query(self.incremental_table)
         return run_query(inc_query)
 


### PR DESCRIPTION
Recently when I added caching for incremental listens in Spark, I forgot to add filters on it using listened_at time range. As a result, all incremental dumps' listens were used in all stats irrespective of their listened_at timestamp and the date range of the stat. Fix it by adding back the filters.
