### PR TITLE
Refactor listen deletion status column

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -13,9 +13,9 @@ CREATE TABLE listen_delete_metadata (
     user_id             INTEGER                     NOT NULL,
     listened_at         TIMESTAMP WITH TIME ZONE    NOT NULL,
     recording_msid      UUID                        NOT NULL,
-    deleted             BOOLEAN                     NOT NULL DEFAULT FALSE,
+    status              listen_delete_metadata_status_enum NOT NULL DEFAULT 'pending',
     listen_created      TIMESTAMP WITH TIME ZONE
-    CHECK ( deleted IS FALSE OR (deleted IS TRUE AND listen_created IS NOT NULL) )
+    CHECK ( status = 'invalid' OR status = 'pending' OR (status = 'complete' AND listen_created IS NOT NULL) )
 );
 
 CREATE TABLE listen_user_metadata (

--- a/admin/timescale/create_types.sql
+++ b/admin/timescale/create_types.sql
@@ -2,5 +2,6 @@ BEGIN;
 
 CREATE TYPE mbid_mapping_match_type_enum AS ENUM('no_match', 'low_quality', 'med_quality', 'high_quality', 'exact_match');
 CREATE TYPE lb_tag_radio_source_type_enum AS ENUM ('recording', 'artist', 'release-group');
+CREATE TYPE listen_delete_metadata_status_enum AS ENUM ('pending', 'invalid', 'complete');
 
 COMMIT;

--- a/admin/timescale/updates/2025-02-19-change-listen-delete-metadata-status.sql
+++ b/admin/timescale/updates/2025-02-19-change-listen-delete-metadata-status.sql
@@ -1,0 +1,15 @@
+CREATE TYPE listen_delete_metadata_status_enum AS ENUM ('pending', 'invalid', 'complete');
+
+BEGIN;
+
+ALTER TABLE listen_delete_metadata ADD COLUMN status listen_delete_metadata_status_enum NOT NULL DEFAULT 'pending';
+ALTER TABLE listen_delete_metadata
+    ADD CONSTRAINT listen_delete_metadata_status_created_constraint
+    CHECK ( status = 'invalid' OR status = 'pending' OR (status = 'complete' AND listen_created IS NOT NULL) );
+
+UPDATE listen_delete_metadata SET status = CASE WHEN deleted IS TRUE 'complete' ELSE 'pending' END;
+
+ALTER TABLE listen_delete_metadata DROP CONSTRAINT listen_delete_metadata_deleted_created_constraint;
+ALTER TABLE listen_delete_metadata DROP COLUMN deleted;
+
+COMMIT;

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -555,6 +555,6 @@ class DumpListenStore:
         """ Cleanup listen delete metadata after spark full dump is complete """
         self.log.info("Cleaning up listen_delete_metadata")
         with timescale.engine.connect() as connection:
-            connection.execute(text("DELETE FROM listen_delete_metadata WHERE deleted"))
+            connection.execute(text("DELETE FROM listen_delete_metadata WHERE deleted != 'pending'"))
             connection.commit()
         self.log.info("Cleaning up listen_delete_metadata done!")

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -555,6 +555,6 @@ class DumpListenStore:
         """ Cleanup listen delete metadata after spark full dump is complete """
         self.log.info("Cleaning up listen_delete_metadata")
         with timescale.engine.connect() as connection:
-            connection.execute(text("DELETE FROM listen_delete_metadata WHERE deleted != 'pending'"))
+            connection.execute(text("DELETE FROM listen_delete_metadata WHERE status != 'pending'"))
             connection.commit()
         self.log.info("Cleaning up listen_delete_metadata done!")


### PR DESCRIPTION
Change boolean deleted column of listen_delete_metadata to status column which is an enum supporting pending, invalid and complete state. This helps mark duplicate listen delete requests and non existent listen delete requests as invalid and their subsequent cleanup after dumps finish. It's difficult to distinguish between a new listen deletion request and an invalid listen deletion request in the absence of an invalid.