### PR TITLE
Add a table to record listen history deletion

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -28,6 +28,12 @@ CREATE TABLE listen_user_metadata (
 
 SELECT create_hypertable('listen', 'listened_at', chunk_time_interval => INTERVAL '30 days');
 
+CREATE TABLE deleted_user_listen_history (
+    id                          INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    user_id                     INTEGER NOT NULL,
+    max_created                 TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
 -- Playlists
 
 CREATE TABLE playlist.playlist (

--- a/admin/timescale/updates/2025-02-19-add-user-listen-history-delete.sql
+++ b/admin/timescale/updates/2025-02-19-add-user-listen-history-delete.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE TABLE deleted_user_listen_history (
+    id                          INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    user_id                     INTEGER NOT NULL,
+    max_created                 TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+COMMIT;

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -556,5 +556,6 @@ class DumpListenStore:
         self.log.info("Cleaning up listen_delete_metadata")
         with timescale.engine.connect() as connection:
             connection.execute(text("DELETE FROM listen_delete_metadata WHERE status != 'pending'"))
+            connection.execute(text("DELETE FROM deleted_user_listen_history"))
             connection.commit()
         self.log.info("Cleaning up listen_delete_metadata done!")

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -668,9 +668,11 @@ class TimescaleListenStore:
              WHERE user_id = :user_id
         """
         query2 = """DELETE FROM listen WHERE user_id = :user_id AND created <= :created"""
+        query3 = """INSERT INTO deleted_user_listen_history (user_id, created) VALUES (:user_id, :created)"""
         try:
             ts_conn.execute(sqlalchemy.text(query1), {"user_id": user_id})
             ts_conn.execute(sqlalchemy.text(query2), {"user_id": user_id, "created": created})
+            ts_conn.execute(sqlalchemy.text(query3), {"user_id": user_id, "created": created})
             ts_conn.commit()
         except psycopg2.OperationalError as e:
             self.log.error("Cannot delete listens for user: %s" % str(e))

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -668,7 +668,7 @@ class TimescaleListenStore:
              WHERE user_id = :user_id
         """
         query2 = """DELETE FROM listen WHERE user_id = :user_id AND created <= :created"""
-        query3 = """INSERT INTO deleted_user_listen_history (user_id, created) VALUES (:user_id, :created)"""
+        query3 = """INSERT INTO deleted_user_listen_history (user_id, max_created) VALUES (:user_id, :created)"""
         try:
             ts_conn.execute(sqlalchemy.text(query1), {"user_id": user_id})
             ts_conn.execute(sqlalchemy.text(query2), {"user_id": user_id, "created": created})


### PR DESCRIPTION
It is possible for users' to delete their entire listen history in one command, instead of individually deleting every listen. To handle this spark, record the user_id and the max created value until which listens have been deleted.