### PR TITLE
LB-1735: Rework recording/album search regular expressions

### DIFF
--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -15,11 +15,14 @@ import { toast } from "react-toastify";
 import { ToastMsg } from "../notifications/Notifications";
 import GlobalAppContext from "./GlobalAppContext";
 import DropdownRef from "./Dropdown";
-import { RECORDING_MBID_REGEXP } from "./SearchTrackOrMBID";
+import {
+  LB_ALBUM_MBID_REGEXP,
+  RELEASE_GROUP_MBID_REGEXP,
+  RELEASE_MBID_REGEXP,
+  RECORDING_MBID_REGEXP,
+  UUID_REGEXP,
+} from "./constants";
 
-export const RELEASE_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/release\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
-export const RELEASE_GROUP_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?musicbrainz\.org\/release-group\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
-export const LB_ALBUM_MBID_REGEXP = /^(https?:\/\/(?:beta\.)?listenbrainz\.org\/album\/)?([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})/i;
 const THROTTLE_MILLISECONDS = 1500;
 
 type SearchTrackOrMBIDProps = {
@@ -97,12 +100,12 @@ const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
     () =>
       throttle(
         async (input: string) => {
-          const newReleaseMBID = RELEASE_MBID_REGEXP.exec(
-            input
-          )?.[2].toLowerCase();
+          const newReleaseMBID =
+            RELEASE_MBID_REGEXP.exec(input)?.[1] ??
+            UUID_REGEXP.exec(input)?.[0];
           const newReleaseGroupMBID =
-            RELEASE_GROUP_MBID_REGEXP.exec(input)?.[2].toLowerCase() ||
-            LB_ALBUM_MBID_REGEXP.exec(input)?.[2].toLowerCase();
+            RELEASE_GROUP_MBID_REGEXP.exec(input)?.[1].toLowerCase() ??
+            LB_ALBUM_MBID_REGEXP.exec(input)?.[1].toLowerCase();
           try {
             if (newReleaseMBID) {
               onSelectAlbum(newReleaseMBID);
@@ -157,6 +160,7 @@ const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
       return;
     }
     setLoading(true);
+    const isValidUUID = UUID_REGEXP.test(inputValue);
     const isValidAlbumUUID =
       RELEASE_MBID_REGEXP.test(inputValue) ||
       RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
@@ -166,7 +170,7 @@ const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
       switchMode(inputValue);
       return;
     }
-    if (isValidAlbumUUID) {
+    if (isValidUUID || isValidAlbumUUID) {
       throttledHandleValidMBID(inputValue);
     } else {
       throttledSearchRelease(inputValue);

--- a/frontend/js/src/utils/constants.ts
+++ b/frontend/js/src/utils/constants.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 export const COLOR_WHITE = "#fff";
 export const COLOR_BLACK = "#000";
 export const COLOR_LB_ASPHALT = "#46433a";
@@ -32,3 +33,15 @@ export enum FlairEnum {
 export type FlairName = keyof typeof FlairEnum;
 // A union type for the flair css strings, based on the enum values above 
 export type Flair = `${FlairEnum}`; 
+
+// Note: This UUID regexp has a capturing group but no start or end of string character to make it reusable
+const uuid = "([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})"
+// Note: These website URL regexps have a start of string character (^) but no end of string ($)
+const musicbrainz_website_regex = "^(?:https?:\/\/)?(?:beta\.)?musicbrainz\.org"
+const listenbrainz_website_regex = "^(?:https?:\/\/)?(?:beta\.)?listenbrainz\.org"
+// Note: adding a start-of-string and end-of-string character for UUID_REGEXP
+export const UUID_REGEXP = new RegExp(`^${uuid}$`,"i");
+export const RECORDING_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/recording\/${uuid}\/?`, "i");
+export const RELEASE_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/release\/${uuid}\/?`, "i");
+export const RELEASE_GROUP_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/release-group\/${uuid}\/?`, "i");
+export const LB_ALBUM_MBID_REGEXP = new RegExp(`${listenbrainz_website_regex}\/album\/${uuid}\/?`, "i");


### PR DESCRIPTION
My previous changes in #3179 broke the ability to paste only an MBID (as opposed to the whole MB URL) into the search track/ search album component (used in the add listens modal for example).

I refactored (and vigorously testes this time) the various regular expressions we have to detect and validate user inputs so as to separate MBID-only inputs from whole URLs.

Also moved said regexps to the constants file and made them more reusable / reduce error-prone repetitions.


One (small) caveat is the if pasting only an MBID, this is straightforward for recordings, but for the "add album" component we accept release, release-group, and LB album (~same as RG) MBIDs.
So currently, pasting only an MBID assumes it is a release MBID, and will fail if pasting a release-group MBID, for example.

We could potentially do an API call to check if the pasted MBID has a corresponding release, then fallback to assuming it is a release group MBID if not.
However that will significantly complicate the code for questionable results.
IMO since selecting a RG shows a dropdown to manually select a specific release, I think assuming MBIDs are release MBIDs is probably in line with the current component logic.