### PR TITLE
Implement listen deletion in the spark cluster

### DIFF
--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -530,6 +530,12 @@ def request_troi_playlists():
     send_request_to_spark_cluster("tags.default")
 
 
+@cli.command(name="request_import_deleted_listens")
+def request_import_deleted_listens():
+    """ Send a request to spark cluster to import deleted listens from listenbrainz """
+    send_request_to_spark_cluster("import.deleted_listens")
+
+
 # Some useful commands to keep our crontabs manageable. These commands do not add new functionality
 # rather combine multiple commands related to a task so that they are always invoked in the correct order.
 

--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -236,5 +236,10 @@
     "name": "popularity.popularity",
     "description": "Calculate all popularity data from mlhd or listenbrainz data.",
     "params": ["mlhd", "entity", "type"]
+  },
+  "import.deleted_listens": {
+    "name": "import.deleted_listens",
+    "description": "Import deleted listens from ListenBrainz into spark cluster.",
+    "params": []
   }
 }

--- a/listenbrainz_spark/hdfs/upload.py
+++ b/listenbrainz_spark/hdfs/upload.py
@@ -4,10 +4,9 @@ import time
 import tarfile
 import tempfile
 import logging
-from typing import List
 
-from listenbrainz_spark import schema, path, utils, hdfs_connection
-from listenbrainz_spark.hdfs.utils import create_dir
+from listenbrainz_spark import path, utils, hdfs_connection
+from listenbrainz_spark.hdfs.utils import create_dir, move
 from listenbrainz_spark.hdfs.utils import delete_dir
 from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.hdfs.utils import upload_to_HDFS
@@ -96,22 +95,10 @@ class ListenbrainzDataUploader(ListenbrainzHDFSUploader):
         """
         src_path = self.upload_archive_to_temp(archive, ".parquet")
         dest_path = path.LISTENBRAINZ_NEW_DATA_DIRECTORY
-        # Delete existing dumps if any
-        if path_exists(dest_path):
-            logger.info(f'Removing {dest_path} from HDFS...')
-            delete_dir(dest_path, recursive=True)
-            logger.info('Done!')
 
-        logger.info(f"Moving the processed files from {src_path} to {dest_path}")
         t0 = time.monotonic()
-
-        # Check if parent directory exists, if not create a directory
-        dest_path_parent = str(Path(dest_path).parent)
-        if not path_exists(dest_path_parent):
-            create_dir(dest_path_parent)
-
-        rename(src_path, dest_path)
-        utils.logger.info(f"Done! Time taken: {time.monotonic() - t0:.2f}")
+        move(src_path, dest_path)
+        logger.info(f"Full dump uploaded! Time taken: {time.monotonic() - t0:.2f}")
 
     def upload_mlhd_dump_chunk(self, archive: str):
         """ Upload MLHD+ dump to HDFS """

--- a/listenbrainz_spark/hdfs/utils.py
+++ b/listenbrainz_spark/hdfs/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 from hdfs.util import HdfsError
 
@@ -111,3 +112,22 @@ def copy(hdfs_src_path: str, hdfs_dst_path: str, overwrite: bool = False):
             with hdfs_connection.client.read(src_file_path) as reader:
                 with hdfs_connection.client.write(dst_file_path, overwrite=overwrite) as writer:
                     writer.write(reader.read())
+
+
+def move(hdfs_src_path: str, hdfs_dest_path: str):
+    """ Move a file or folder in HDFS """
+    # Delete existing destination directory if any
+    if path_exists(hdfs_dest_path):
+        logger.info(f'Removing {hdfs_dest_path} from HDFS...')
+        delete_dir(hdfs_dest_path, recursive=True)
+        logger.info('Done!')
+
+    logger.info(f"Moving the processed files from {hdfs_src_path} to {hdfs_dest_path}")
+
+    # Check if parent directory exists, if not create a directory
+    dest_path_parent = str(Path(hdfs_dest_path).parent)
+    if not path_exists(dest_path_parent):
+        create_dir(dest_path_parent)
+
+    rename(hdfs_src_path, hdfs_dest_path)
+    logger.info(f"Done!")

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -22,6 +22,7 @@ INCREMENTAL_USERS_DF = os.path.join("/", "incremental-users")
 
 # path to save deleted listens
 DELETED_LISTENS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "delete.parquet")
+DELETED_USER_LISTEN_HISTORY_SAVE_PATH = os.path.join("/", "deleted-user-listen-history.parquet")
 
 # Directory containing RDD checkpoints to break lineage while using iterative algorithms.
 CHECKPOINT_DIR = os.path.join('/', 'checkpoint')

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -20,6 +20,9 @@ MLHD_PLUS_DATA_DIRECTORY = os.path.join("/", "mlhd")  # processed MLHD+ dump dat
 INCREMENTAL_DUMPS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "incremental.parquet")
 INCREMENTAL_USERS_DF = os.path.join("/", "incremental-users")
 
+# path to save deleted listens
+DELETED_LISTENS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "delete.parquet")
+
 # Directory containing RDD checkpoints to break lineage while using iterative algorithms.
 CHECKPOINT_DIR = os.path.join('/', 'checkpoint')
 

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -33,6 +33,7 @@ import listenbrainz_spark.mlhd.download
 import listenbrainz_spark.mlhd.similarity
 import listenbrainz_spark.popularity.main
 import listenbrainz_spark.echo.echo
+import listenbrainz_spark.request_consumer.jobs.delete_listens
 
 functions = {
     'echo.echo': listenbrainz_spark.echo.echo.handler,
@@ -82,6 +83,7 @@ functions = {
     'releases.fresh': listenbrainz_spark.fresh_releases.fresh_releases.main,
     'troi.playlists': listenbrainz_spark.troi.periodic_jams.main,
     'tags.default': listenbrainz_spark.tags.tags.main,
+    'import.deleted_listens': listenbrainz_spark.request_consumer.jobs.delete_listens.main,
 }
 
 

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -2,14 +2,13 @@ import uuid
 
 from listenbrainz_spark import config
 from listenbrainz_spark.hdfs.utils import move
-from listenbrainz_spark.path import DELETED_LISTENS_SAVE_PATH
+from listenbrainz_spark.path import DELETED_LISTENS_SAVE_PATH, DELETED_USER_LISTEN_HISTORY_SAVE_PATH
 from listenbrainz_spark.postgres.utils import load_from_db
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import read_files_from_HDFS
 
 
-def main():
-    """ Import deleted listens from timescale """
+def import_deleted_listens():
     query = """
         SELECT id
              , user_id
@@ -43,3 +42,36 @@ def main():
         .parquet(temp_df_path)
 
     move(temp_df_path, DELETED_LISTENS_SAVE_PATH)
+
+
+def import_deleted_user_listen_history():
+    query = """SELECT id, user_id, max_created FROM deleted_user_listen_history"""
+    new_deleted_history_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
+    existing_deleted_history_df = read_files_from_HDFS(DELETED_USER_LISTEN_HISTORY_SAVE_PATH)
+
+    new_deleted_history_df.createOrReplaceTempView("new_listen_history_to_delete")
+    existing_deleted_history_df.createOrReplaceTempView("existing_listen_history_to_delete")
+
+    all_deleted_history_df = run_query("""\
+        WITH intermediate AS (
+            SELECT user_id, max_created FROM new_listen_history_to_delete
+         UNION ALL
+            SELECT user_id, max_created FROM existing_listen_history_to_delete
+        )
+           SELECT user_id, max(max_created) AS max_created FROM intermediate GROUP BY user_id
+    """)
+
+    temp_df_path = f"/tmp/{str(uuid.uuid4())}"
+    all_deleted_history_df \
+        .repartition(1) \
+        .write \
+        .mode("overwrite") \
+        .parquet(temp_df_path)
+
+    move(temp_df_path, DELETED_USER_LISTEN_HISTORY_SAVE_PATH)
+
+
+def main():
+    """ Import deleted listens from timescale """
+    import_deleted_listens()
+    import_deleted_user_listen_history()

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -1,14 +1,45 @@
+import uuid
+
 from listenbrainz_spark import config
+from listenbrainz_spark.hdfs.utils import move
 from listenbrainz_spark.path import DELETED_LISTENS_SAVE_PATH
 from listenbrainz_spark.postgres.utils import load_from_db
+from listenbrainz_spark.stats import run_query
+from listenbrainz_spark.utils import read_files_from_HDFS
 
 
 def main():
-    """ Import deleted listens from  """
-    query = "SELECT id, user_id, listened_at, recording_msid, listen_created AS created FROM listen_delete_metadata WHERE deleted"
-    listens_to_delete_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
-    listens_to_delete_df \
+    """ Import deleted listens from timescale """
+    query = """
+        SELECT id
+             , user_id
+             , listened_at
+             , recording_msid
+             , listen_created::timestamp(3) with time zone AS created
+          FROM listen_delete_metadata
+         WHERE deleted
+    """
+    new_listens_to_delete_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
+    existing_listens_to_delete_df = read_files_from_HDFS(DELETED_LISTENS_SAVE_PATH)
+
+    new_listens_to_delete_df.createOrReplaceTempView("new_listens_to_delete")
+    existing_listens_to_delete_df.createOrReplaceTempView("existing_listens_to_delete")
+
+    columns = "id, user_id, listened_at, recording_msid, created"
+    all_listens_to_delete_df = run_query(f"""\
+        WITH intermediate AS (
+            SELECT {columns} FROM new_listens_to_delete
+             UNION ALL
+            SELECT {columns} FROM existing_listens_to_delete
+        )
+            SELECT {columns} FROM intermediate GROUP BY {columns}
+    """)
+
+    temp_df_path = f"/tmp/{str(uuid.uuid4())}"
+    all_listens_to_delete_df \
         .repartition(1) \
         .write \
-        .mode("append") \
-        .parquet(DELETED_LISTENS_SAVE_PATH)
+        .mode("overwrite") \
+        .parquet(temp_df_path)
+
+    move(temp_df_path, DELETED_LISTENS_SAVE_PATH)

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -8,13 +8,13 @@ from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import read_files_from_HDFS
 
 
-def combine_if_exists(new_df, save_path, combine_query_template):
+def combine_if_exists(new_df, save_path, combine_query_template, table_suffix):
     """ If a dataframe already exists at the save path, load it and combine it with the new dataframe using the provided
     query. Otherwise, save the new dataframe at the save path directly.
     """
     if hdfs_connection.client.status(save_path, strict=False):
-        existing_table = f"existing_df_{uuid.uuid4()}"
-        new_table = f"new_df_{uuid.uuid4()}"
+        existing_table = f"existing_{table_suffix}"
+        new_table = f"new_{table_suffix}"
         existing_df = read_files_from_HDFS(save_path)
         existing_df.createOrReplaceTempView(existing_table)
         new_df.createOrReplaceTempView(new_table)
@@ -58,7 +58,7 @@ def import_deleted_listens():
         )
             SELECT {columns} FROM intermediate GROUP BY {columns}
     """
-    combine_if_exists(new_listens_to_delete_df, DELETED_LISTENS_SAVE_PATH, query)
+    combine_if_exists(new_listens_to_delete_df, DELETED_LISTENS_SAVE_PATH, query, "listens_to_delete")
 
 
 def import_deleted_user_listen_history():
@@ -72,7 +72,7 @@ def import_deleted_user_listen_history():
         )
            SELECT user_id, max(max_created) AS max_created FROM intermediate GROUP BY user_id
     """
-    combine_if_exists(new_deleted_history_df, DELETED_USER_LISTEN_HISTORY_SAVE_PATH, query)
+    combine_if_exists(new_deleted_history_df, DELETED_USER_LISTEN_HISTORY_SAVE_PATH, query, "listen_history_to_delete")
 
 
 def main():

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -17,7 +17,7 @@ def main():
              , recording_msid
              , listen_created::timestamp(3) with time zone AS created
           FROM listen_delete_metadata
-         WHERE deleted
+         WHERE status = 'complete'::listen_delete_metadata_status_enum
     """
     new_listens_to_delete_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
     existing_listens_to_delete_df = read_files_from_HDFS(DELETED_LISTENS_SAVE_PATH)

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -1,11 +1,41 @@
 import uuid
 
-from listenbrainz_spark import config
+from listenbrainz_spark import config, hdfs_connection
 from listenbrainz_spark.hdfs.utils import move
 from listenbrainz_spark.path import DELETED_LISTENS_SAVE_PATH, DELETED_USER_LISTEN_HISTORY_SAVE_PATH
 from listenbrainz_spark.postgres.utils import load_from_db
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import read_files_from_HDFS
+
+
+def combine_if_exists(new_df, save_path, combine_query_template):
+    """ If a dataframe already exists at the save path, load it and combine it with the new dataframe using the provided
+    query. Otherwise, save the new dataframe at the save path directly.
+    """
+    if hdfs_connection.client.status(save_path, strict=False):
+        existing_table = f"existing_df_{uuid.uuid4()}"
+        new_table = f"new_df_{uuid.uuid4()}"
+        existing_df = read_files_from_HDFS(save_path)
+        existing_df.createOrReplaceTempView(existing_table)
+        new_df.createOrReplaceTempView(new_table)
+
+        query = combine_query_template.format(existing_table=existing_table, new_table=new_table)
+        combined_df = run_query(query)
+
+        temp_df_path = f"/tmp/{str(uuid.uuid4())}"
+        combined_df \
+            .repartition(1) \
+            .write \
+            .mode("overwrite") \
+            .parquet(temp_df_path)
+
+        move(temp_df_path, save_path)
+    else:
+        new_df \
+            .repartition(1) \
+            .write \
+            .mode("overwrite") \
+            .parquet(save_path)
 
 
 def import_deleted_listens():
@@ -19,56 +49,30 @@ def import_deleted_listens():
          WHERE status = 'complete'::listen_delete_metadata_status_enum
     """
     new_listens_to_delete_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
-    existing_listens_to_delete_df = read_files_from_HDFS(DELETED_LISTENS_SAVE_PATH)
-
-    new_listens_to_delete_df.createOrReplaceTempView("new_listens_to_delete")
-    existing_listens_to_delete_df.createOrReplaceTempView("existing_listens_to_delete")
-
     columns = "id, user_id, listened_at, recording_msid, created"
-    all_listens_to_delete_df = run_query(f"""\
+    query = f"""\
         WITH intermediate AS (
-            SELECT {columns} FROM new_listens_to_delete
+            SELECT {columns} FROM {{new_table}}
              UNION ALL
-            SELECT {columns} FROM existing_listens_to_delete
+            SELECT {columns} FROM {{existing_table}}
         )
             SELECT {columns} FROM intermediate GROUP BY {columns}
-    """)
-
-    temp_df_path = f"/tmp/{str(uuid.uuid4())}"
-    all_listens_to_delete_df \
-        .repartition(1) \
-        .write \
-        .mode("overwrite") \
-        .parquet(temp_df_path)
-
-    move(temp_df_path, DELETED_LISTENS_SAVE_PATH)
+    """
+    combine_if_exists(new_listens_to_delete_df, DELETED_LISTENS_SAVE_PATH, query)
 
 
 def import_deleted_user_listen_history():
     query = """SELECT id, user_id, max_created FROM deleted_user_listen_history"""
     new_deleted_history_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
-    existing_deleted_history_df = read_files_from_HDFS(DELETED_USER_LISTEN_HISTORY_SAVE_PATH)
-
-    new_deleted_history_df.createOrReplaceTempView("new_listen_history_to_delete")
-    existing_deleted_history_df.createOrReplaceTempView("existing_listen_history_to_delete")
-
-    all_deleted_history_df = run_query("""\
+    query = """\
         WITH intermediate AS (
-            SELECT user_id, max_created FROM new_listen_history_to_delete
+            SELECT user_id, max_created FROM {new_table}
          UNION ALL
-            SELECT user_id, max_created FROM existing_listen_history_to_delete
+            SELECT user_id, max_created FROM {existing_table}
         )
            SELECT user_id, max(max_created) AS max_created FROM intermediate GROUP BY user_id
-    """)
-
-    temp_df_path = f"/tmp/{str(uuid.uuid4())}"
-    all_deleted_history_df \
-        .repartition(1) \
-        .write \
-        .mode("overwrite") \
-        .parquet(temp_df_path)
-
-    move(temp_df_path, DELETED_USER_LISTEN_HISTORY_SAVE_PATH)
+    """
+    combine_if_exists(new_deleted_history_df, DELETED_USER_LISTEN_HISTORY_SAVE_PATH, query)
 
 
 def main():

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -1,0 +1,14 @@
+from listenbrainz_spark import config
+from listenbrainz_spark.path import DELETED_LISTENS_SAVE_PATH
+from listenbrainz_spark.postgres.utils import load_from_db
+
+
+def main():
+    """ Import deleted listens from  """
+    query = "SELECT id, user_id, listened_at, recording_msid, listen_created AS created FROM listen_delete_metadata WHERE deleted"
+    listens_to_delete_df = load_from_db(config.TS_JDBC_URI, config.TS_USER, config.TS_PASSWORD, query)
+    listens_to_delete_df \
+        .repartition(1) \
+        .write \
+        .mode("append") \
+        .parquet(DELETED_LISTENS_SAVE_PATH)

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -8,7 +8,9 @@ import listenbrainz_spark.request_consumer.jobs.utils as utils
 from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.dump.local import ListenbrainzLocalDumpLoader
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
+from listenbrainz_spark.hdfs import path_exists, delete_dir
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
+from listenbrainz_spark.path import DELETED_USER_LISTEN_HISTORY_SAVE_PATH
 from listenbrainz_spark.persisted import unpersist_incremental_df
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,8 @@ def import_full_dump_to_hdfs(dump_id: int = None, local: bool = False) -> str:
         uploader.process_full_listens_dump()
     utils.insert_dump_data(dump_id, DumpType.FULL, datetime.now(tz=timezone.utc))
     unpersist_incremental_df()
+    if path_exists(DELETED_USER_LISTEN_HISTORY_SAVE_PATH):
+        delete_dir(DELETED_USER_LISTEN_HISTORY_SAVE_PATH, recursive=True)
     return dump_name
 
 

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Tuple, Iterator, Dict
+from typing import Iterator, Dict
 
 from pandas import DataFrame
 from pyspark.errors import AnalysisException

--- a/listenbrainz_spark/utils/__init__.py
+++ b/listenbrainz_spark/utils/__init__.py
@@ -126,6 +126,8 @@ def get_listen_files_list() -> List[str]:
         if file == "incremental.parquet":
             has_incremental = True
             continue
+        if file == "delete.parquet":
+            continue
         if file.endswith(".parquet"):
             file_names.append(file)
 


### PR DESCRIPTION
As the first step to eliminate full dumps from the spark cluster pipeline, implement listen deletion by importing metadata about deleted individual listens and entire user listen histories from LB database. This metadata is stored in HDFS and the listens loaded for stats generation are filtered using the two metadata files to exclude listens that have been deleted from ListenBrainz.

Note that the actual listens are not removed from the Spark, they are just filtered out at stats generation time. Eventually the deleted listens and user listen histories will get cluttered up though and therefore a future PR will implement the logic to periodically remove the deleted listens from HDFS as well.