### PR TITLE
Update this_(week/month/year) time ranges

### DIFF
--- a/listenbrainz_spark/stats/__init__.py
+++ b/listenbrainz_spark/stats/__init__.py
@@ -168,35 +168,31 @@ def get_dates_for_stats_range(stats_range: str) -> Tuple[datetime, datetime]:
     # in spark and so that instead of no stats, outdated stats are calculated.
     latest_listen_date = latest_listen_ts.date()
 
+    # from_offset: this is applied to the latest_listen_date to get from_date
+    # to_offset: this is applied to from_date to get to_date
+
     # "this" time ranges, these count stats for the ongoing time period till date
-    if stats_range.startswith("this"):
-        if stats_range == "this_week":
-            # if today is a monday then from_offset is monday of last week
-            # otherwise from_offset is monday of this week
-            from_offset = relativedelta(days=-1, weekday=MO(-1))
-        elif stats_range == "this_month":
-            # if today is 1st then 1st of last month otherwise the 1st of this month
-            from_offset = relativedelta(months=-1) if latest_listen_date.day == 1 else relativedelta(day=1)
+    if stats_range == "this_week":
+        # if today is a monday then from_offset is monday of last week
+        # otherwise from_offset is monday of this week
+        from_offset = relativedelta(days=-1, weekday=MO(-1))
+        to_offset = relativedelta(weeks=+1)
+    elif stats_range == "this_month":
+        # if today is 1st then 1st of last month otherwise the 1st of this month
+        from_offset = relativedelta(months=-1) if latest_listen_date.day == 1 else relativedelta(day=1)
+        to_offset = relativedelta(months=+1)
+    elif stats_range == "this_year":
+        # if today is the 1st of the year, then still show last year stats
+        if latest_listen_date.day == 1 and latest_listen_date.month == 1:
+            from_offset = relativedelta(years=-1)
         else:
-            # if today is the 1st of the year, then still show last year stats
-            if latest_listen_date.day == 1 and latest_listen_date.month == 1:
-                from_offset = relativedelta(years=-1)
-            else:
-                from_offset = relativedelta(month=1, day=1)
-
-        from_date = latest_listen_date + from_offset
-
-        # set time to 00:00
-        from_date = datetime.combine(from_date, time.min)
-        to_date = datetime.combine(latest_listen_date, time.min)
-        return from_date, to_date
+            from_offset = relativedelta(month=1, day=1)
+        to_offset = relativedelta(years=+1)
 
     # following are "last" week/month/year stats, here we want the stats of the
     # previous week/month/year and *not* from 7 days ago to today so on.
 
-    # from_offset: this is applied to the latest_listen_date to get from_date
-    # to_offset: this is applied to from_date to get to_date
-    if stats_range == "week":
+    elif stats_range == "week":
         from_offset = relativedelta(weeks=-1, weekday=MO(-1))  # monday of previous week
         to_offset = relativedelta(weeks=+1)
     elif stats_range == "month":

--- a/listenbrainz_spark/stats/tests/test_init.py
+++ b/listenbrainz_spark/stats/tests/test_init.py
@@ -83,7 +83,7 @@ class InitTestCase(SparkNewTestCase):
         self.assertEqual((periods[1], periods[2]), stats.get_dates_for_stats_range("half_yearly"))
 
         mock_get_latest_listen_ts.return_value = datetime(2021, 11, 24, 2, 3, 0)
-        self.assertEqual((datetime(2021, 11, 22), datetime(2021, 11, 24)), stats.get_dates_for_stats_range("this_week"))
+        self.assertEqual((datetime(2021, 11, 22), datetime(2021, 11, 29)), stats.get_dates_for_stats_range("this_week"))
 
         mock_get_latest_listen_ts.return_value = datetime(2021, 11, 22, 3, 0, 0)
         self.assertEqual((datetime(2021, 11, 15), datetime(2021, 11, 22)), stats.get_dates_for_stats_range("this_week"))
@@ -95,7 +95,7 @@ class InitTestCase(SparkNewTestCase):
         self.assertEqual((datetime(2021, 11, 15), datetime(2021, 11, 22)), stats.get_dates_for_stats_range("week"))
 
         mock_get_latest_listen_ts.return_value = datetime(2021, 11, 21, 2, 3, 0)
-        self.assertEqual((datetime(2021, 11, 1), datetime(2021, 11, 21)), stats.get_dates_for_stats_range("this_month"))
+        self.assertEqual((datetime(2021, 11, 1), datetime(2021, 12, 1)), stats.get_dates_for_stats_range("this_month"))
 
         mock_get_latest_listen_ts.return_value = datetime(2021, 11, 1, 3, 0, 0)
         self.assertEqual((datetime(2021, 10, 1), datetime(2021, 11, 1)), stats.get_dates_for_stats_range("this_month"))
@@ -116,4 +116,4 @@ class InitTestCase(SparkNewTestCase):
         self.assertEqual((datetime(2020, 1, 1), datetime(2021, 1, 1)), stats.get_dates_for_stats_range("this_year"))
 
         mock_get_latest_listen_ts.return_value = datetime(2021, 11, 1, 3, 0, 0)
-        self.assertEqual((datetime(2021, 1, 1), datetime(2021, 11, 1)), stats.get_dates_for_stats_range("this_year"))
+        self.assertEqual((datetime(2021, 1, 1), datetime(2022, 1, 1)), stats.get_dates_for_stats_range("this_year"))


### PR DESCRIPTION
Consider this_week range and the example of week Feb 17 - Feb 24. If today is Feb 20, currently this_week range resolves to Feb 17 - Feb 20 midnight. Note that this range is used to filter listens using listened_at timestamp.

Imagine the two listens:

|          | listened_at         | created             |
|----------|---------------------|---------------------|
| Listen 1 | 2025-02-20 12:00:04 | 2025-02-20 12:01:55 |
| Listen 2 | 2025-02-18 09:00:00 | 2025-02-20 12:02:05 |

The second listen will be selected in the filter but not the first. The incremental stats run records the max created during in bookkeeping and uses this timestamp as the minimum created timestamp for the next incremental stats run. As a result Listen 1 will not be included in any stats run. To fix this, relax the this_week timestamp filters to the full week. this_week range will now resolve to Feb 17 - Feb 24.

Similar logic applies to this_month and this_year.
