### PR TITLE
LB-1222 Add option to enable or disable brainzplayer

### DIFF
--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -86,6 +86,10 @@ function BrainzPlayerSettings() {
       defaultDataSourcesPriority
   );
 
+  const [brainzplayerEnabled, setBrainzplayerEnabled] = React.useState(
+    userPreferences?.brainzplayer?.brainzplayerEnabled ?? true
+  );
+
   const moveDataSource = (evt: any) => {
     const { newIndex, oldIndex } = evt;
     const newPriority = [...dataSourcesPriority];
@@ -120,6 +124,7 @@ function BrainzPlayerSettings() {
         spotifyEnabled,
         soundcloudEnabled,
         appleMusicEnabled,
+        brainzplayerEnabled,
         dataSourcesPriority,
       });
       toast.success("Saved your preferences successfully");
@@ -132,6 +137,7 @@ function BrainzPlayerSettings() {
           spotifyEnabled,
           soundcloudEnabled,
           appleMusicEnabled,
+          brainzplayerEnabled,
           dataSourcesPriority,
         };
       }
@@ -154,6 +160,7 @@ function BrainzPlayerSettings() {
     spotifyEnabled,
     soundcloudEnabled,
     appleMusicEnabled,
+    brainzplayerEnabled,
     dataSourcesPriority,
     APIService,
     currentUser?.auth_token,
@@ -166,6 +173,19 @@ function BrainzPlayerSettings() {
         <title>BrainzPlayer Settings</title>
       </Helmet>
       <h2 className="page-title">BrainzPlayer settings</h2>
+      <Switch
+        id="enable-brainzplayer"
+        value="brainzplayer"
+        checked={brainzplayerEnabled}
+        onChange={(e) => setBrainzplayerEnabled(!brainzplayerEnabled)}
+        switchLabel={
+          <span
+            className={`text-brand ${!brainzplayerEnabled ? "text-muted" : ""}`}
+          >
+            <span>&nbsp;Brainzplayer</span>
+          </span>
+        }
+      />
       <p>Choose which music services to use for playback in ListenBrainz.</p>
 
       <p>

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -658,6 +658,7 @@ declare type BrainzPlayerSettings = {
   spotifyEnabled?: boolean;
   soundcloudEnabled?: boolean;
   appleMusicEnabled?: boolean;
+  brainzplayerEnabled?: boolean;
   dataSourcesPriority?: Array<
     "spotify" | "youtube" | "soundcloud" | "appleMusic"
   >;

--- a/listenbrainz/db/model/user_timeline_event.py
+++ b/listenbrainz/db/model/user_timeline_event.py
@@ -35,6 +35,7 @@ class UserTimelineEventType(Enum):
     RECORDING_PIN = 'recording_pin'
     CRITIQUEBRAINZ_REVIEW = 'critiquebrainz_review'
     PERSONAL_RECORDING_RECOMMENDATION = 'personal_recording_recommendation'
+    THANKS = 'thanks'
 
 
 class RecordingRecommendationMetadata(MsidMbidModel):
@@ -57,6 +58,13 @@ class PersonalRecordingRecommendationMetadata(MsidMbidModel):
 class NotificationMetadata(BaseModel):
     creator: constr(min_length=1)
     message: constr(min_length=1)
+
+
+class ThanksMetadata(MsidMbidModel):
+    original_event_id: NonNegativeInt
+    original_event_type: UserTimelineEventType
+    blurb_content: Optional[str]
+
 
 
 UserTimelineEventMetadata = Union[CBReviewTimelineMetadata, PersonalRecordingRecommendationMetadata,

--- a/listenbrainz/db/user_timeline_event.py
+++ b/listenbrainz/db/user_timeline_event.py
@@ -27,6 +27,7 @@ from listenbrainz.db.model.user_timeline_event import (
     UserTimelineEvent,
     UserTimelineEventType,
     UserTimelineEventMetadata,
+    ThanksMetadata,
     RecordingRecommendationMetadata,
     NotificationMetadata,
     HiddenUserTimelineEvent,
@@ -83,6 +84,17 @@ def create_user_notification_event(db_conn, user_id: int, metadata: Notification
         user_id=user_id,
         event_type=UserTimelineEventType.NOTIFICATION,
         metadata=metadata
+    )
+
+
+def create_thanks_event(db_conn, user_id: int, metadata: ThanksMetadata) -> UserTimelineEvent:
+    """ Creates a thanks event in the database and returns it.
+    """
+    return create_user_timeline_event(
+        db_conn,
+        user_id=user_id,
+        event_type=UserTimelineEventType.THANKS,
+        metadata=metadata,
     )
 
 
@@ -144,6 +156,38 @@ def create_personal_recommendation_event(db_conn, user_id: int, metadata: WriteP
                 'recording_mbid': metadata.recording_mbid,
                 'recording_msid': metadata.recording_msid,
                 'users': metadata.users,
+                'blurb_content': metadata.blurb_content
+            }
+        )
+        db_conn.commit()
+        return UserTimelineEvent(**result.mappings().first())
+    except Exception as e:
+        raise DatabaseException(str(e))
+
+
+def create_thanks_event(db_conn, user_id: int, metadata: ThanksMetadata)\
+        -> UserTimelineEvent:
+    """ Creates a thanks event in the database and returns it.
+        The User ID in the table is the person thanking meanwhile the original_event_id and original_event_type refer to
+        the event id and type being thanked respectively.
+    """
+    try:
+        result = db_conn.execute(text("""
+            INSERT INTO user_timeline_event (user_id, event_type, metadata)
+                VALUES (
+                    :user_id,
+                    'thanks',
+                    jsonb_build_object(
+                        'original_event_id', :original_event_id,
+                        'original_event_type', :original_event_type,
+                        'blurb_content', :blurb_content
+                    )
+                )
+            RETURNING id, user_id, event_type, metadata, created
+            """), {
+                'user_id': user_id,
+                'original_event_id': metadata.original_event_id,
+                'original_event_type': metadata.original_event_type,
                 'blurb_content': metadata.blurb_content
             }
         )

--- a/listenbrainz/webserver/views/user_settings_api.py
+++ b/listenbrainz/webserver/views/user_settings_api.py
@@ -125,6 +125,7 @@ brainzplayer_preferences_schema = {
         "spotifyEnabled": {"type": "boolean"},
         "soundcloudEnabled": {"type": "boolean"},
         "appleMusicEnabled": {"type": "boolean"},
+        "brainzplayerEnabled": {"type": "boolean"},
         "dataSourcesPriority": {"type": "array", "items": {"type": "string"}},
     },
     "additionalProperties": False,


### PR DESCRIPTION
# Problem

Right now, Brainzplayer occupies space in the bottom section of the screen which is unnecessary for people who don't want to use it. This feature allows users to disable Brainzplayer from the settings page so that it doesn't occupy space in the bottom and feel less cluttered.

Feature request ticket: [LB-1222](https://tickets.metabrainz.org/browse/LB-1222)

# Solution

Work in progress as of now!