### PR TITLE
Change dumps sequencing and misc test improvements

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -46,7 +46,8 @@ ALTER TABLE api_compat.token ADD CONSTRAINT token_token_uniq UNIQUE (token);
 
 CREATE TABLE data_dump (
   id          SERIAL,
-  created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+  created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  dump_type   data_dump_type_type
 );
 
 CREATE TABLE missing_musicbrainz_data (

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -24,3 +24,5 @@ CREATE TYPE background_tasks_type AS ENUM ('delete_listens', 'delete_user', 'exp
 CREATE TYPE user_data_export_status_type AS ENUM ('in_progress', 'waiting', 'completed', 'failed');
 
 CREATE TYPE user_data_export_type_type AS ENUM ('export_all_user_data');
+
+CREATE TYPE data_dump_type_type AS ENUM ('incremental', 'full');

--- a/admin/sql/updates/2025-02-21-add-data-dump-type.sql
+++ b/admin/sql/updates/2025-02-21-add-data-dump-type.sql
@@ -1,0 +1,7 @@
+CREATE TYPE data_dump_type_type AS ENUM ('incremental', 'full');
+
+BEGIN;
+
+ALTER TABLE data_dump ADD COLUMN dump_type data_dump_type_type;
+
+COMMIT;

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -2,7 +2,7 @@ import os.path
 import shutil
 import tempfile
 import zipfile
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, date, time, timedelta, timezone
 from pathlib import Path
 
 import orjson
@@ -48,8 +48,8 @@ def get_time_ranges_for_listens(min_dt: datetime, max_dt: datetime):
             end_date = start_date + relativedelta(months=1, days=-1)
             months.append({
                 "month": month,
-                "start": datetime.combine(start_date, time.min),
-                "end": datetime.combine(end_date, time.max)
+                "start": datetime.combine(start_date, time.min, tzinfo=timezone.utc),
+                "end": datetime.combine(end_date, time.max, tzinfo=timezone.utc),
             })
         years.append({
             "year": year,

--- a/listenbrainz/db/dump.py
+++ b/listenbrainz/db/dump.py
@@ -658,23 +658,23 @@ def copy_table(cursor, location, columns, table_name):
         cursor.copy_expert(query, f)
 
 
-def add_dump_entry(timestamp):
+def add_dump_entry(timestamp, dump_type):
     """ Adds an entry to the data_dump table with specified time.
 
         Args:
-            timestamp: the unix timestamp to be added
+            timestamp: the datetime to be added
 
         Returns:
             id (int): the id of the new entry added
     """
-
     with db.engine.begin() as connection:
         result = connection.execute(sqlalchemy.text("""
-                INSERT INTO data_dump (created)
-                     VALUES (TO_TIMESTAMP(:ts))
+                INSERT INTO data_dump (created, dump_type)
+                     VALUES (:ts, :dump_type)
                   RETURNING id
             """), {
             'ts': timestamp,
+            'dump_type': dump_type
         })
         return result.fetchone().id
 
@@ -685,7 +685,7 @@ def get_dump_entries():
 
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-                SELECT id, created
+                SELECT id, created, dump_type
                   FROM data_dump
               ORDER BY created DESC
             """))
@@ -693,29 +693,48 @@ def get_dump_entries():
         return result.mappings().all()
 
 
-def get_dump_entry(dump_id):
+def get_dump_entry(dump_id, dump_type=None):
+    filters = ["id = :dump_id"]
+    args = {"dump_id": dump_id}
+
+    if dump_type is not None:
+        filters.append("dump_type = :dump_type")
+        args["dump_type"] = dump_type
+
+    where_clause = " AND ".join(filters)
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT id, created
+            SELECT id, created, dump_type
               FROM data_dump
-             WHERE id = :dump_id
-        """), {
-            'dump_id': dump_id,
-        })
+             WHERE """ + where_clause), args)
         return result.mappings().first()
 
 
-def get_previous_dump_entry(dump_id):
-    """ Get the id of the dump that is one before the given dump id.
+def get_latest_incremental_dump():
+    """ Get the latest incremental dump"""
+    with db.engine.connect() as connection:
+        result = connection.execute(sqlalchemy.text("""
+            SELECT id, created, dump_type
+              FROM data_dump
+             WHERE dump_type = 'incremental'
+          ORDER BY id DESC
+             LIMIT 1
+        """))
+        return result.mappings().first()
+
+
+def get_previous_incremental_dump(dump_id):
+    """ Get the id of the incremental dump that is one before the given dump id.
 
     Cannot just do dump_id - 1 because SERIAL/IDENTITY columns in postgres can skip values in some
     cases (for instance master/standby switchover).
     """
     with db.engine.connect() as connection:
         result = connection.execute(sqlalchemy.text("""
-            SELECT id, created
+            SELECT id, created, dump_type
               FROM data_dump
              WHERE id < :dump_id
+               AND dump_type = 'incremental'
           ORDER BY id DESC
              LIMIT 1
         """), {"dump_id": dump_id})

--- a/listenbrainz/db/dump_manager.py
+++ b/listenbrainz/db/dump_manager.py
@@ -22,7 +22,7 @@ from pathlib import PurePath
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import click
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 import re
 import shutil
@@ -35,11 +35,11 @@ from brainzutils.mail import send_mail
 import listenbrainz.db.dump as db_dump
 from listenbrainz.db import mapping_dump
 from listenbrainz.db import DUMP_DEFAULT_THREAD_COUNT
+from listenbrainz.listenstore import LISTEN_MINIMUM_DATE
 from listenbrainz.listenstore.dump_listenstore import DumpListenStore
 from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app
 from listenbrainz.db.dump import check_ftp_dump_ages
-
 
 NUMBER_OF_FULL_DUMPS_TO_KEEP = 2
 NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP = 30
@@ -153,15 +153,20 @@ def create_full(location: str, location_private: str, threads: int, dump_id: int
             sys.exit(-1)
         ls = DumpListenStore(app)
         if dump_id is None:
-            end_time = datetime.now()
-            dump_id = db_dump.add_dump_entry(int(end_time.strftime('%s')))
+            latest_inc_dump = db_dump.get_latest_incremental_dump()
+            if latest_inc_dump is not None:
+                end_time = latest_inc_dump['created']
+            else:
+                end_time = datetime.now(tz=timezone.utc)
+            dump_id = db_dump.add_dump_entry(end_time, "full")
         else:
-            dump_entry = db_dump.get_dump_entry(dump_id)
+            dump_entry = db_dump.get_dump_entry(dump_id, "full")
             if dump_entry is None:
-                current_app.logger.error("No dump with ID %d found", dump_id)
+                current_app.logger.error("No full dump with ID %d found", dump_id)
                 sys.exit(-1)
             end_time = dump_entry['created']
 
+        start_time = LISTEN_MINIMUM_DATE
         dump_name = f'listenbrainz-dump-{dump_id}-{end_time.strftime("%Y%m%d-%H%M%S")}-full'
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
@@ -182,10 +187,14 @@ def create_full(location: str, location_private: str, threads: int, dump_id: int
             expected_num_dumps += 1
             expected_num_private_dumps += 1
         if do_listen_dump:
-            ls.dump_listens(dump_path, dump_id=dump_id, end_time=end_time, threads=threads)
+            ls.dump_listens(
+                dump_path, dump_id=dump_id, start_time=start_time,
+                end_time=end_time, dump_type="full", threads=threads
+            )
             expected_num_dumps += 1
         if do_spark_dump:
-            ls.dump_listens_for_spark(dump_path, dump_id=dump_id, dump_type="full", end_time=end_time)
+            ls.dump_listens_for_spark(dump_path, dump_id=dump_id, dump_type="full",
+                                      start_time=start_time, end_time=end_time)
             expected_num_dumps += 1
         if do_stats_dump:
             db_dump.create_statistics_dump(dump_path, end_time, threads)
@@ -237,27 +246,28 @@ def create_incremental(location, threads, dump_id):
     with app.app_context():
         ls = DumpListenStore(app)
         if dump_id is None:
-            end_time = datetime.now()
-            dump_id = db_dump.add_dump_entry(int(end_time.strftime('%s')))
+            end_time = datetime.now(tz=timezone.utc)
+            dump_id = db_dump.add_dump_entry(end_time, "incremental")
         else:
-            dump_entry = db_dump.get_dump_entry(dump_id)
+            dump_entry = db_dump.get_dump_entry(dump_id, "incremental")
             if dump_entry is None:
-                current_app.logger.error("No dump with ID %d found, exiting!", dump_id)
+                current_app.logger.error("No incremental dump with ID %d found, exiting!", dump_id)
                 sys.exit(-1)
             end_time = dump_entry['created']
 
-        prev_dump_entry = db_dump.get_previous_dump_entry(dump_id)
+        prev_dump_entry = db_dump.get_previous_incremental_dump(dump_id)
         if prev_dump_entry is None:  # incremental dumps must have a previous dump in the series
-            current_app.logger.error("Invalid dump ID %d, could not find previous dump", dump_id)
+            current_app.logger.error("Invalid dump ID %d, could not find previous incrmental dump", dump_id)
             sys.exit(-1)
-        start_time = prev_dump_entry['created']
+        start_time = prev_dump_entry["created"]
         current_app.logger.info("Dumping data from %s to %s", start_time, end_time)
 
         dump_name = f'listenbrainz-dump-{dump_id}-{end_time.strftime("%Y%m%d-%H%M%S")}-incremental'
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
 
-        ls.dump_listens(dump_path, dump_id=dump_id, start_time=start_time, end_time=end_time, threads=threads)
+        ls.dump_listens(dump_path, dump_id=dump_id, start_time=start_time, end_time=end_time,
+                        dump_type="incremental", threads=threads)
         ls.dump_listens_for_spark(dump_path, dump_id=dump_id, dump_type="incremental",
                                   start_time=start_time, end_time=end_time)
 

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -102,12 +102,12 @@ class DumpTestCase(DatabaseTestCase):
 
     def test_add_dump_entry(self):
         prev_dumps = db_dump.get_dump_entries()
-        db_dump.add_dump_entry(datetime.today().strftime('%s'))
+        db_dump.add_dump_entry(datetime.today(), "incremental")
         now_dumps = db_dump.get_dump_entries()
         self.assertEqual(len(now_dumps), len(prev_dumps) + 1)
 
     def test_copy_table(self):
-        db_dump.add_dump_entry(datetime.today().strftime('%s'))
+        db_dump.add_dump_entry(datetime.today(), "incremental")
         with db.engine.connect() as connection:
             db_dump.copy_table(
                 cursor=connection.connection.cursor(),

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -21,8 +21,10 @@
 
 import os
 import shutil
+import tarfile
 import tempfile
 import time
+from datetime import datetime, timezone, timedelta
 
 import pytest
 from click.testing import CliRunner
@@ -34,16 +36,17 @@ import listenbrainz.db.user as db_user
 from listenbrainz.db import dump_manager
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.db.model.recommendation_feedback import RecommendationFeedbackSubmit
-from listenbrainz.db.testing import DatabaseTestCase
+from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 from listenbrainz.listenstore.tests.util import generate_data
 from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app, timescale_connection
 
 
-class DumpManagerTestCase(DatabaseTestCase):
+class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def setUp(self):
-        super().setUp()
+        DatabaseTestCase.setUp(self)
+        TimescaleTestCase.setUp(self)
         self.app = create_app()
         self.tempdir = tempfile.mkdtemp()
         self.tempdir_private = tempfile.mkdtemp()
@@ -53,7 +56,8 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.user_name = db_user.get(self.db_conn, self.user_id)['musicbrainz_id']
 
     def tearDown(self):
-        super().tearDown()
+        DatabaseTestCase.tearDown(self)
+        TimescaleTestCase.tearDown(self)
         shutil.rmtree(self.tempdir)
 
     @pytest.fixture(autouse=True)
@@ -172,7 +176,7 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.assertEqual(len(os.listdir(self.tempdir)), 0)
 
         # now, add a dump entry to the database and create a dump with that specific dump id
-        dump_id = db_dump.add_dump_entry(int(time.time()))
+        dump_id = db_dump.add_dump_entry(datetime.now(tz=timezone.utc), "full")
         result = self.runner.invoke(dump_manager.create_full, [
             '--location',
             self.tempdir,
@@ -238,7 +242,7 @@ class DumpManagerTestCase(DatabaseTestCase):
             self.tempdir,
             '--no-db',
             '--no-timescale'
-        ])
+        ], catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)
 
     def test_create_incremental(self):
@@ -249,18 +253,24 @@ class DumpManagerTestCase(DatabaseTestCase):
         self.assertEqual(result.exit_code, -1)
         self.assertEqual(len(os.listdir(self.tempdir)), 0)
 
-        base = int(time.time())
-        dump_id = db_dump.add_dump_entry(base - 60)
-        print("%d dump id" % dump_id)
-        self.listenstore.insert(generate_data(1, self.user_name, base - 30, 5))
-        result = self.runner.invoke(dump_manager.create_incremental, [
-                                    '--location', self.tempdir])
+        base = datetime.now()
+        dump_id = db_dump.add_dump_entry(base  - timedelta(seconds=60), "incremental")
+        self.listenstore.insert(generate_data(
+            1,
+            self.user_name,
+            int((base - timedelta(seconds=30)).timestamp()),
+            5
+        ))
+        result = self.runner.invoke(
+            dump_manager.create_incremental,
+            ['--location', self.tempdir],
+            catch_exceptions=False
+        )
         self.assertEqual(len(os.listdir(self.tempdir)), 1)
         dump_name = os.listdir(self.tempdir)[0]
 
         # created dump ID should be one greater than previous dump's ID
         created_dump_id = int(dump_name.split('-')[2])
-        print("%d created dump id" % created_dump_id)
         self.assertEqual(created_dump_id, dump_id + 1)
 
         # make sure that the dump contains a full listens and spark dump
@@ -270,20 +280,68 @@ class DumpManagerTestCase(DatabaseTestCase):
                 archive_count += 1
         self.assertEqual(archive_count, 2)
 
-    def test_create_incremental_dump_with_id(self):
+    def test_create_full_when_incremental_exists(self):
+        """ Test that creating a full dump uses the latest incremental dump's created timestamp for
+        end time if an incremental dump exists.
+        """
+        listened_at = int((datetime.now() - timedelta(hours=3)).timestamp())
+        self.listenstore.insert(generate_data(self.user_id, self.user_name, listened_at,5))
+        self.assertEqual(db_dump.get_dump_entries(), [])
+        inc_dump_created = datetime.now(tz=timezone.utc)
+        db_dump.add_dump_entry(inc_dump_created, "incremental")
 
+        # dumps filter on created timestamp and not listened_at which is auto-generated on insert
+        # hence actual sleep is needed for the timestamp value to elapse
+        time.sleep(1)
+        self.listenstore.insert(generate_data(self.user_id, self.user_name, listened_at, 3))
+
+        # the dump filters use exclusive ranges on datetime, hence let a second elapse before requesting a
+        # dump else the dump will be empty
+        time.sleep(1)
+
+        # passing a created value for start timestamp makes it work fine
+        self.runner.invoke(dump_manager.create_full, [
+            "--location", self.tempdir,
+            "--no-db", "--no-timescale", "--no-stats"
+        ], catch_exceptions=False)
+
+        self.assertEqual(len(os.listdir(self.tempdir)), 1)
+        dump_name = os.listdir(self.tempdir)[0]
+        dump_id = int(dump_name.split('-')[2])
+
+        full_dump = db_dump.get_dump_entry(dump_id, "full")
+        self.assertEqual(full_dump["created"], inc_dump_created)
+
+        # make sure that the dump contains a full listens and spark dump
+        archive_count = 0
+        for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
+            if file_name.endswith(".tar.xz") or file_name.endswith(".tar"):
+                archive_count += 1
+        self.assertEqual(archive_count, 2)
+
+        dump_file_name = dump_name.replace("dump", "listens-dump") + ".tar.xz"
+        listens_dump_file = os.path.join(self.tempdir, dump_name, dump_file_name)
+        with tarfile.open(listens_dump_file, "r:xz") as f:
+            for member in f.getmembers():
+                if member.name.endswith(".listens"):
+                    lines = f.extractfile(member).readlines()
+                    # five listens were dumped as expected as only five listens were created until the
+                    # the incremental dump's timestamp and the full dump dumped listens until the same
+                    # the three created after were excluded.
+                    self.assertEqual(len(lines), 5)
+
+    def test_create_incremental_dump_with_id(self):
         # if the dump ID does not exist, it should exit with a -1
         result = self.runner.invoke(dump_manager.create_incremental, [
                                     '--location', self.tempdir, '--dump-id', 1000])
         self.assertEqual(result.exit_code, -1)
 
         # create a base dump entry
-        t = int(time.time())
-        db_dump.add_dump_entry(t)
+        db_dump.add_dump_entry(datetime.now(tz=timezone.utc), "incremental")
         self.listenstore.insert(generate_data(1, self.user_name, 1500000000, 5))
 
         # create a new dump ID to recreate later
-        dump_id = db_dump.add_dump_entry(int(time.time()))
+        dump_id = db_dump.add_dump_entry(datetime.now(tz=timezone.utc), "incremental")
         # now, create a dump with that specific dump id
         result = self.runner.invoke(dump_manager.create_incremental, [
                                     '--location', self.tempdir, '--dump-id', dump_id])

--- a/listenbrainz/db/tests/test_feedback.py
+++ b/listenbrainz/db/tests/test_feedback.py
@@ -3,7 +3,6 @@ import sqlalchemy
 from listenbrainz.db.model.feedback import Feedback
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.user as db_user
-from listenbrainz.db import timescale as ts
 from listenbrainz import messybrainz as msb_db
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 

--- a/listenbrainz/db/tests/test_lastfm_user.py
+++ b/listenbrainz/db/tests/test_lastfm_user.py
@@ -5,11 +5,8 @@ from datetime import datetime, time
 
 import listenbrainz.db.user as db_user
 from listenbrainz.db.lastfm_user import User
-from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.listen import Listen
-from listenbrainz.listenstore import TimescaleListenStore
 from listenbrainz.tests.integration import IntegrationTestCase
-from listenbrainz.tests.utils import generate_data
 from listenbrainz.webserver import timescale_connection
 
 

--- a/listenbrainz/db/tests/test_playlist.py
+++ b/listenbrainz/db/tests/test_playlist.py
@@ -17,8 +17,9 @@ class PlaylistTestCase(IntegrationTestCase):
         self.ts_conn = timescale.engine.connect()
 
     def tearDown(self):
-        timescale.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))
+        super(PlaylistTestCase, self).tearDown()
         self.ts_conn.close()
+        timescale.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))
 
     def test_create(self):
         playlist_1 = WritablePlaylist(

--- a/listenbrainz/db/tests/test_similar_users.py
+++ b/listenbrainz/db/tests/test_similar_users.py
@@ -3,7 +3,6 @@ import json
 import listenbrainz.db.user as db_user
 import sqlalchemy
 
-from listenbrainz import db
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.db.similar_users import get_top_similar_users
 

--- a/listenbrainz/db/tests/test_stats.py
+++ b/listenbrainz/db/tests/test_stats.py
@@ -14,6 +14,7 @@ class StatsDatabaseTestCase(DatabaseTestCase):
         super(StatsDatabaseTestCase, self).setUp()
 
     def tearDown(self):
+        super(StatsDatabaseTestCase, self).tearDown()
         delete_all_couch_databases()
 
     def _test_one_stat(self, entity, range_, data_file, model, exclude_count=False):

--- a/listenbrainz/listenstore/__init__.py
+++ b/listenbrainz/listenstore/__init__.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 ORDER_DESC = 0
 ORDER_ASC = 1
@@ -9,7 +9,7 @@ DEFAULT_LISTENS_PER_FETCH = 25
 # when the format of the json document in the public dumps changes
 LISTENS_DUMP_SCHEMA_VERSION = 1
 
-LISTEN_MINIMUM_DATE = datetime(2002, 10, 1)
+LISTEN_MINIMUM_DATE = datetime(2002, 10, 1, tzinfo=timezone.utc)
 # October 2002 is date before which most Last.FM data is rubbish
 #: The minimum acceptable value for listened_at field
 LISTEN_MINIMUM_TS = int(LISTEN_MINIMUM_DATE.timestamp())

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import time
 
 import sqlalchemy
@@ -83,22 +83,22 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_insert_timescale(self):
         count = self._create_test_data(self.testuser_name, self.testuser_id)
-        from_ts = datetime.utcfromtimestamp(1399999999)
+        from_ts = datetime.fromtimestamp(1399999999, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), count)
 
     def test_fetch_listens_0(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        from_ts = datetime.utcfromtimestamp(1400000000)
+        from_ts = datetime.fromtimestamp(1400000000, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].ts_since_epoch, 1400000050)
-        self.assertEqual(min_ts, datetime.utcfromtimestamp(1400000000))
-        self.assertEqual(max_ts, datetime.utcfromtimestamp(1400000200))
+        self.assertEqual(min_ts, datetime.fromtimestamp(1400000000, timezone.utc))
+        self.assertEqual(max_ts, datetime.fromtimestamp(1400000200, timezone.utc))
 
     def test_fetch_listens_1(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        from_ts = datetime.utcfromtimestamp(1400000000)
+        from_ts = datetime.fromtimestamp(1400000000, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -108,7 +108,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_fetch_listens_2(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        from_ts = datetime.utcfromtimestamp(1400000100)
+        from_ts = datetime.fromtimestamp(1400000100, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -116,7 +116,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_fetch_listens_3(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        to_ts = datetime.utcfromtimestamp(1400000300)
+        to_ts = datetime.fromtimestamp(1400000300, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -127,8 +127,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_fetch_listens_4(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        from_ts = datetime.utcfromtimestamp(1400000049)
-        to_ts = datetime.utcfromtimestamp(1400000101)
+        from_ts = datetime.fromtimestamp(1400000049, timezone.utc)
+        to_ts = datetime.fromtimestamp(1400000101, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, to_ts=to_ts)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1400000100)
@@ -136,7 +136,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
     def test_fetch_listens_5(self):
         self._create_test_data(self.testuser_name, self.testuser_id)
-        from_ts = datetime.utcfromtimestamp(1400000101)
+        from_ts = datetime.fromtimestamp(1400000101, timezone.utc)
         with self.assertRaises(ValueError):
             self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, to_ts=from_ts)
 
@@ -145,7 +145,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
                                test_data_file_name='timescale_listenstore_test_listens_over_greater_time_range.json')
 
         # test from_ts with gaps
-        from_ts = datetime.utcfromtimestamp(1399999999)
+        from_ts = datetime.fromtimestamp(1399999999, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1420000050)
@@ -154,15 +154,15 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
 
         # test from_ts and to_ts with gaps
-        from_ts = datetime.utcfromtimestamp(1400000049)
-        to_ts = datetime.utcfromtimestamp(1420000001)
+        from_ts = datetime.fromtimestamp(1400000049, timezone.utc)
+        to_ts = datetime.fromtimestamp(1420000001, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, to_ts=to_ts)
         self.assertEqual(len(listens), 2)
         self.assertEqual(listens[0].ts_since_epoch, 1420000000)
         self.assertEqual(listens[1].ts_since_epoch, 1400000050)
 
         # test to_ts with gaps
-        to_ts = datetime.utcfromtimestamp(1420000051)
+        to_ts = datetime.fromtimestamp(1420000051, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1420000050)
@@ -174,7 +174,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         """ Test that the recording mbid submitted by the user is preferred over the mapping created by LB """
         self._create_test_data(self.testuser_name, self.testuser_id)
         self._insert_mapping_metadata("c7a41965-9f1e-456c-8b1d-27c0f0dde280")
-        from_ts = datetime.utcfromtimestamp(1400000000)
+        from_ts = datetime.fromtimestamp(1400000000, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].data["mbid_mapping"]["artist_mbids"], ['678d88b2-87b0-403b-b63d-5da7465aecc3'])
@@ -225,7 +225,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name, testuser["id"])
 
-        to_ts = datetime.utcfromtimestamp(1400000300)
+        to_ts = datetime.fromtimestamp(1400000300, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -236,7 +236,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
         self.logstore.delete(testuser["id"])
 
-        to_ts = datetime.utcfromtimestamp(1400000300)
+        to_ts = datetime.fromtimestamp(1400000300, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 0)
 
@@ -246,7 +246,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         testuser_name = testuser['musicbrainz_id']
         self._create_test_data(testuser_name, testuser["id"])
 
-        to_ts = datetime.utcfromtimestamp(1400000300)
+        to_ts = datetime.fromtimestamp(1400000300, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 5)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -255,11 +255,11 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[3].ts_since_epoch, 1400000050)
         self.assertEqual(listens[4].ts_since_epoch, 1400000000)
 
-        self.logstore.delete_listen(datetime.utcfromtimestamp(1400000050), testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
+        self.logstore.delete_listen(datetime.fromtimestamp(1400000050, timezone.utc), testuser["id"], "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
 
         pending = self._get_pending_deletes()
         self.assertEqual(len(pending), 1)
-        self.assertEqual(pending[0]["listened_at"], datetime.utcfromtimestamp(1400000050))
+        self.assertEqual(pending[0]["listened_at"], datetime.fromtimestamp(1400000050, timezone.utc))
         self.assertEqual(pending[0]["user_id"], testuser["id"])
         self.assertEqual(str(pending[0]["recording_msid"]), "c7a41965-9f1e-456c-8b1d-27c0f0dde280")
 
@@ -268,7 +268,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         # clear cache entry so that count is fetched from db again
         cache.delete(REDIS_USER_LISTEN_COUNT + str(testuser["id"]))
 
-        to_ts = datetime.utcfromtimestamp(1400000300)
+        to_ts = datetime.fromtimestamp(1400000300, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=testuser, to_ts=to_ts)
         self.assertEqual(len(listens), 4)
         self.assertEqual(listens[0].ts_since_epoch, 1400000200)
@@ -278,8 +278,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
 
         self.assertEqual(self.logstore.get_listen_count_for_user(testuser["id"]), 4)
         min_ts, max_ts = self.logstore.get_timestamps_for_user(testuser["id"])
-        self.assertEqual(min_ts, datetime.utcfromtimestamp(1400000000))
-        self.assertEqual(max_ts, datetime.utcfromtimestamp(1400000200))
+        self.assertEqual(min_ts, datetime.fromtimestamp(1400000000, timezone.utc))
+        self.assertEqual(max_ts, datetime.fromtimestamp(1400000200, timezone.utc))
 
     def _get_pending_deletes(self):
         with timescale.engine.connect() as connection:
@@ -287,7 +287,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
             return [{
                 "user_id": row.user_id,
                 "recording_msid": row.recording_msid,
-                "listened_at": row.listened_at.replace(tzinfo=None)
+                "listened_at": row.listened_at
             } for row in result.fetchall()]
 
     def _get_count_and_timestamps(self, user_id):
@@ -329,8 +329,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
     def test_get_timestamps_for_user(self):
         self._create_test_data(self.testuser["musicbrainz_id"], self.testuser["id"])
         min_ts, max_ts = self.logstore.get_timestamps_for_user(self.testuser["id"])
-        self.assertEqual(datetime.utcfromtimestamp(1400000200), max_ts)
-        self.assertEqual(datetime.utcfromtimestamp(1400000000), min_ts)
+        self.assertEqual(datetime.fromtimestamp(1400000200, timezone.utc), max_ts)
+        self.assertEqual(datetime.fromtimestamp(1400000000, timezone.utc), min_ts)
 
         # test timestamps consider listens which were created since last cron run as well
         self._create_test_data(
@@ -341,8 +341,8 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         )
         # do not recalculate/update user data
         min_ts, max_ts = self.logstore.get_timestamps_for_user(self.testuser["id"])
-        self.assertEqual(datetime.utcfromtimestamp(1400000500), max_ts)
-        self.assertEqual(datetime.utcfromtimestamp(1400000000), min_ts)
+        self.assertEqual(datetime.fromtimestamp(1400000500, timezone.utc), max_ts)
+        self.assertEqual(datetime.fromtimestamp(1400000000, timezone.utc), min_ts)
 
     def test_fetch_listens_for_since_cron_run(self):
         """ Test listens created since last cron run to update user metadata are returned """
@@ -355,9 +355,9 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
             "timescale_listenstore_test_listens_2.json",
             recalculate=False
         )
-        from_ts = datetime.utcfromtimestamp(1400000300)
+        from_ts = datetime.fromtimestamp(1400000300, timezone.utc)
         listens, min_ts, max_ts = self.logstore.fetch_listens(user=self.testuser, from_ts=from_ts, limit=1)
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].ts_since_epoch, 1400000500)
-        self.assertEqual(min_ts, datetime.utcfromtimestamp(1400000000))
-        self.assertEqual(max_ts, datetime.utcfromtimestamp(1400000500))
+        self.assertEqual(min_ts, datetime.fromtimestamp(1400000000, timezone.utc))
+        self.assertEqual(max_ts, datetime.fromtimestamp(1400000500, timezone.utc))

--- a/listenbrainz/listenstore/tests/util.py
+++ b/listenbrainz/listenstore/tests/util.py
@@ -1,10 +1,8 @@
-# coding=utf-8
-
 import json
 import os
 import uuid
 
-from datetime import datetime
+from datetime import datetime, timezone
 from listenbrainz.listen import Listen
 
 
@@ -16,10 +14,10 @@ def generate_data(test_user_id, user_name, from_ts, num_records, inserted_ts=Non
 
     for i in range(num_records):
         if not inserted_ts:
-            inserted_timestamp = datetime.utcnow()
+            inserted_timestamp = datetime.now(timezone.utc)
         else:
-            inserted_timestamp = datetime.utcfromtimestamp(inserted_ts)
-        timestamp = datetime.utcfromtimestamp(from_ts)
+            inserted_timestamp = datetime.fromtimestamp(inserted_ts, timezone.utc)
+        timestamp = datetime.fromtimestamp(from_ts, timezone.utc)
         item = Listen(
             user_name=user_name,
             user_id=test_user_id,
@@ -41,7 +39,7 @@ def generate_data(test_user_id, user_name, from_ts, num_records, inserted_ts=Non
 
 
 def to_epoch(date):
-    return int((date - datetime.utcfromtimestamp(0)).total_seconds())
+    return int((date - datetime.fromtimestamp(0, timezone.utc)).total_seconds())
 
 
 def create_test_data_for_timescalelistenstore(user_name: str, user_id: int, test_data_file_name: str = None):

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -38,8 +38,8 @@ WINDOW_SIZE_MULTIPLIER = 3
 
 LISTEN_COUNT_BUCKET_WIDTH = 2592000
 
-MAX_FUTURE_SECONDS = timedelta(seconds=1)  # 10 mins in future - max fwd clock skew
-EPOCH = datetime.utcfromtimestamp(0)
+MAX_FUTURE_SECONDS = timedelta(minutes=10)  # max fwd clock skew
+EPOCH = datetime.fromtimestamp(0, timezone.utc)
 
 
 class TimescaleListenStore:
@@ -126,7 +126,7 @@ class TimescaleListenStore:
         else:
             min_ts = row.min_ts
             max_ts = row.max_ts
-        return min_ts.replace(tzinfo=None), max_ts.replace(tzinfo=None)
+        return min_ts, max_ts
 
     def get_total_listen_count(self):
         """ Returns the total number of listens stored in the ListenStore.
@@ -325,7 +325,7 @@ class TimescaleListenStore:
                         done = True
                         break
 
-                    if to_ts > datetime.now() + MAX_FUTURE_SECONDS:
+                    if to_ts > datetime.now(tz=timezone.utc) + MAX_FUTURE_SECONDS:
                         done = True
                         break
 

--- a/listenbrainz/tests/integration/test_api_compat_deprecated.py
+++ b/listenbrainz/tests/integration/test_api_compat_deprecated.py
@@ -21,7 +21,7 @@
 
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from werkzeug.exceptions import BadRequest
 
@@ -140,7 +140,7 @@ class APICompatDeprecatedTestCase(APICompatIntegrationTestCase):
 
         time.sleep(1)
         recalculate_all_user_data()
-        to_ts = datetime.utcnow()
+        to_ts = datetime.now(timezone.utc)
         with self.app.app_context():
             listens, _, _ = self.ls.fetch_listens(self.user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -1,6 +1,6 @@
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from random import randint
 
 import listenbrainz.db.user as db_user
@@ -39,11 +39,12 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
 
-        to_ts = datetime.utcnow()
+        to_ts = datetime.now(timezone.utc)
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
         recent = self.rs.get_recent_listens(4)
+        print(recent)
         self.assertEqual(len(recent), 1)
         self.assertIsInstance(recent[0], Listen)
 
@@ -56,11 +57,11 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
 
-        self.assertEqual(1, self.rs.get_listen_count_for_day(datetime.utcnow()))
+        self.assertEqual(1, self.rs.get_listen_count_for_day(datetime.now(timezone.utc)))
 
         (min_ts, max_ts) = self.ls.get_timestamps_for_user(user["id"])
-        self.assertEqual(min_ts, datetime.utcfromtimestamp(1486449409))
-        self.assertEqual(max_ts, datetime.utcfromtimestamp(1486449409))
+        self.assertEqual(min_ts, datetime.fromtimestamp(1486449409, timezone.utc))
+        self.assertEqual(max_ts, datetime.fromtimestamp(1486449409, timezone.utc))
 
     def test_dedup_user_special_characters(self):
 
@@ -71,7 +72,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         self.assert200(r)
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
-        to_ts = datetime.utcnow()
+        to_ts = datetime.now(timezone.utc)
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -81,7 +82,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'same_batch_duplicates.json')
         self.assert200(r)
 
-        to_ts = datetime.utcnow()
+        to_ts = datetime.now(timezone.utc)
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -99,7 +100,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user2, 'valid_single.json')
         self.assert200(r)
 
-        to_ts = datetime.utcnow()
+        to_ts = datetime.now(timezone.utc)
         listens, _, _ = self.ls.fetch_listens(user1, to_ts=to_ts)
         self.assertEqual(len(listens), 1)
 
@@ -126,6 +127,6 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'same_timestamp_diff_track_valid_single_3.json')
         self.assert200(r)
 
-        to_ts = datetime.utcnow()
+        to_ts = datetime.now(timezone.utc)
         listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
         self.assertEqual(len(listens), 4)

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import psycopg2
 import orjson
@@ -167,8 +167,8 @@ def get_listens(user_name):
     listens, min_ts_per_user, max_ts_per_user = timescale_connection._ts.fetch_listens(
         user,
         limit=count,
-        from_ts=datetime.utcfromtimestamp(min_ts) if min_ts else None,
-        to_ts=datetime.utcfromtimestamp(max_ts) if max_ts else None
+        from_ts=datetime.fromtimestamp(min_ts, timezone.utc) if min_ts else None,
+        to_ts=datetime.fromtimestamp(max_ts, timezone.utc) if max_ts else None
     )
     listen_data = []
     for listen in listens:

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -68,6 +68,7 @@ def get_dump_info():
     return jsonify({
         "id": dump["id"],
         "timestamp": _convert_timestamp_to_string_dump_format(dump["created"]),
+        "dump_type": dump["dump_type"],
     })
 
 

--- a/listenbrainz/webserver/views/test/test_status.py
+++ b/listenbrainz/webserver/views/test/test_status.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from listenbrainz.tests.integration import IntegrationTestCase
 
 import listenbrainz.db.dump as db_dump
@@ -11,23 +11,25 @@ class StatusViewsTestCase(IntegrationTestCase):
         self.assert404(r)
 
     def test_dump_get_200(self):
-        t0 = datetime.now()
-        dump_id = db_dump.add_dump_entry(int(t0.strftime("%s")))
+        t0 = datetime.now(timezone.utc)
+        dump_id = db_dump.add_dump_entry(t0, "full")
         r = self.client.get("/1/status/get-dump-info", query_string={"id": dump_id})
         self.assert200(r)
         self.assertDictEqual(r.json, {
             "id": dump_id,
             "timestamp": t0.strftime("%Y%m%d-%H%M%S"),
+            "dump_type": "full"
         })
 
         # should return the latest dump if no dump ID passed
-        t1 = t0 + timedelta(seconds=1)
-        dump_id_1 = db_dump.add_dump_entry(int(t1.strftime("%s")))
+        t1 = t0 + timedelta(seconds=15)
+        dump_id_1 = db_dump.add_dump_entry(t1, "full")
         r = self.client.get("/1/status/get-dump-info")
         self.assert200(r)
         self.assertDictEqual(r.json, {
             "id": dump_id_1,
             "timestamp": t1.strftime("%Y%m%d-%H%M%S"),
+            "dump_type": "full"
         })
 
     def test_dump_get_400(self):


### PR DESCRIPTION
Currently, all dumps use the previous dumps' created timestamp as the start time regardless of whether it is a full dump or an incremental dump. This is problematic if we want to eliminate the use of full dumps and just rely on incremental dumps. For example,

|                    | start               | end (created)       |
|--------------------|---------------------|---------------------|
| Incremental Dump 1 | 2025-01-30 12:00:01 | 2025-01-31 12:00:02 |
| Full Dump 1        | `LISTEN_MINIMUM_DATE` | 2025-02-01 04:00:05 |
| Incremental Dump 2 | 2025-02-01 04:00:05 | 2025-02-02 12:00:02 |

In this case if we were to just use incremental dumps, we would miss the listens created between 2025-01-31 12:00:02 and 2025-02-01 04:00:05. To fix this issue, update the start time of incremental dumps to use the end time of the last incremental dump only. As currently it is not possible to identify from the data_dump table whether a dump is incremental or full, update it to add dump_type column.

Further, to ensure that full dumps don't contain duplicates with incremental dumps add a where clause to full dumps query with a created check in addition to listened_at.

Additionally, while diagnosing test failures made changes to the code to use datetime aware objects everywhere. If dumps related tests fail silent and involve invocation of click CliRunner, pass in catch_exceptions = False to debug.
