### PR TITLE
Persist deleted listens df

### DIFF
--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -18,11 +18,11 @@ MLHD_PLUS_DATA_DIRECTORY = os.path.join("/", "mlhd")  # processed MLHD+ dump dat
 
 # path to save incremental dumps
 INCREMENTAL_DUMPS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "incremental.parquet")
-INCREMENTAL_USERS_DF = os.path.join("/", "incremental-users")
+INCREMENTAL_USERS_DF = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "incremental-users.parquet")
 
 # path to save deleted listens
 DELETED_LISTENS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "delete.parquet")
-DELETED_USER_LISTEN_HISTORY_SAVE_PATH = os.path.join("/", "deleted-user-listen-history.parquet")
+DELETED_USER_LISTEN_HISTORY_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "deleted-user-listen-history.parquet")
 
 # Directory containing RDD checkpoints to break lineage while using iterative algorithms.
 CHECKPOINT_DIR = os.path.join('/', 'checkpoint')

--- a/listenbrainz_spark/persisted.py
+++ b/listenbrainz_spark/persisted.py
@@ -2,11 +2,14 @@ from typing import Optional
 
 from pandas import DataFrame
 
-from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH, INCREMENTAL_USERS_DF
+from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH, INCREMENTAL_USERS_DF, DELETED_LISTENS_SAVE_PATH, \
+    DELETED_USER_LISTEN_HISTORY_SAVE_PATH
 from listenbrainz_spark.utils import read_files_from_HDFS
 
 _incremental_listens_df: Optional[DataFrame] = None
 _incremental_users_df: Optional[DataFrame] = None
+_deleted_listens_df: Optional[DataFrame] = None
+_deleted_users_listen_history_df: Optional[DataFrame] = None
 
 
 def unpersist_incremental_df():
@@ -17,6 +20,16 @@ def unpersist_incremental_df():
     if _incremental_users_df is not None:
         _incremental_users_df.unpersist()
         _incremental_users_df = None
+
+
+def unpersist_deleted_df():
+    global _deleted_listens_df, _deleted_users_listen_history_df
+    if _deleted_listens_df is not None:
+        _deleted_listens_df.unpersist()
+        _deleted_listens_df = None
+    if _deleted_users_listen_history_df is not None:
+        _deleted_users_listen_history_df.unpersist()
+        _deleted_users_listen_history_df = None
 
 
 def get_incremental_listens_df() -> DataFrame:
@@ -37,3 +50,19 @@ def get_incremental_users_df() -> DataFrame:
         _incremental_users_df = read_files_from_HDFS(INCREMENTAL_USERS_DF)
         _incremental_users_df.persist()
     return _incremental_users_df
+
+
+def get_deleted_listens_df() -> DataFrame:
+    global _deleted_listens_df
+    if _deleted_listens_df is None:
+        _deleted_listens_df = read_files_from_HDFS(DELETED_LISTENS_SAVE_PATH)
+        _deleted_listens_df.persist()
+    return _deleted_listens_df
+
+
+def get_deleted_users_listen_history_df() -> DataFrame:
+    global _deleted_users_listen_history_df
+    if _deleted_users_listen_history_df is None:
+        _deleted_users_listen_history_df = read_files_from_HDFS(DELETED_USER_LISTEN_HISTORY_SAVE_PATH)
+        _deleted_users_listen_history_df.persist()
+    return _deleted_users_listen_history_df

--- a/listenbrainz_spark/request_consumer/jobs/delete_listens.py
+++ b/listenbrainz_spark/request_consumer/jobs/delete_listens.py
@@ -3,6 +3,7 @@ import uuid
 from listenbrainz_spark import config, hdfs_connection
 from listenbrainz_spark.hdfs.utils import move
 from listenbrainz_spark.path import DELETED_LISTENS_SAVE_PATH, DELETED_USER_LISTEN_HISTORY_SAVE_PATH
+from listenbrainz_spark.persisted import unpersist_deleted_df
 from listenbrainz_spark.postgres.utils import load_from_db
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.utils import read_files_from_HDFS
@@ -79,3 +80,4 @@ def main():
     """ Import deleted listens from timescale """
     import_deleted_listens()
     import_deleted_user_listen_history()
+    unpersist_deleted_df()

--- a/listenbrainz_spark/request_consumer/jobs/import_dump.py
+++ b/listenbrainz_spark/request_consumer/jobs/import_dump.py
@@ -8,9 +8,7 @@ import listenbrainz_spark.request_consumer.jobs.utils as utils
 from listenbrainz_spark.dump import DumpType
 from listenbrainz_spark.dump.local import ListenbrainzLocalDumpLoader
 from listenbrainz_spark.ftp.download import ListenbrainzDataDownloader
-from listenbrainz_spark.hdfs.utils import path_exists, delete_dir
 from listenbrainz_spark.hdfs.upload import ListenbrainzDataUploader
-from listenbrainz_spark.path import DELETED_USER_LISTEN_HISTORY_SAVE_PATH
 from listenbrainz_spark.persisted import unpersist_incremental_df
 
 logger = logging.getLogger(__name__)
@@ -39,8 +37,6 @@ def import_full_dump_to_hdfs(loader: ListenbrainzDataDownloader, dump_id: int = 
         uploader.process_full_listens_dump()
     utils.insert_dump_data(dump_id, DumpType.FULL, datetime.now(tz=timezone.utc))
     unpersist_incremental_df()
-    if path_exists(DELETED_USER_LISTEN_HISTORY_SAVE_PATH):
-        delete_dir(DELETED_USER_LISTEN_HISTORY_SAVE_PATH, recursive=True)
     return dump_name
 
 


### PR DESCRIPTION
Persist deleted listens df and move them under data dumps directory for automatic cleanup on full dumps import.