### PR TITLE
Make dumps storage location dynamic

### DIFF
--- a/listenbrainz/spark/request_queries.json
+++ b/listenbrainz/spark/request_queries.json
@@ -113,11 +113,6 @@
     "description": "Import artist relation into the spark cluster.",
     "params": []
   },
-  "import.musicbrainz_release_dump": {
-    "name": "import.musicbrainz_release_dump",
-    "description": "Import musicbrainz release json dump into the spark cluster.",
-    "params": []
-  },
   "similarity.similar_users": {
     "name": "similarity.similar_users",
     "description": "Generate similar user correlation",

--- a/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/tests/test_fresh_releases.py
@@ -2,12 +2,9 @@ import json
 
 import requests_mock
 
-from listenbrainz_spark.hdfs.utils import create_dir
-from listenbrainz_spark.hdfs.utils import path_exists
 from listenbrainz_spark.fresh_releases import fresh_releases
 from listenbrainz_spark.fresh_releases.fresh_releases import FRESH_RELEASES_ENDPOINT
 from listenbrainz_spark.listens.dump import import_incremental_dump_to_hdfs
-from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY
 from listenbrainz_spark.tests import SparkNewTestCase
 
 
@@ -15,14 +12,11 @@ class FreshReleasesTestCase(SparkNewTestCase):
 
     def setUp(self):
         super(FreshReleasesTestCase, self).setUp()
-        if not path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
-            create_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY)
-
         import_incremental_dump_to_hdfs(self.dump_loader, 4)
 
     def tearDown(self):
-        super(FreshReleasesTestCase, self).tearDown()
         self.delete_uploaded_listens()
+        super(FreshReleasesTestCase, self).tearDown()
 
     @requests_mock.Mocker(real_http=True)
     def test_fresh_releases(self, mock_requests):

--- a/listenbrainz_spark/listens/cache.py
+++ b/listenbrainz_spark/listens/cache.py
@@ -1,9 +1,9 @@
+import os
 from typing import Optional
 
 from pandas import DataFrame
 
-from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH, INCREMENTAL_USERS_DF, DELETED_LISTENS_SAVE_PATH, \
-    DELETED_USER_LISTEN_HISTORY_SAVE_PATH
+from listenbrainz_spark.listens.metadata import get_listens_metadata
 from listenbrainz_spark.utils import read_files_from_HDFS
 
 _incremental_listens_df: Optional[DataFrame] = None
@@ -39,7 +39,9 @@ def get_incremental_listens_df() -> DataFrame:
     """
     global _incremental_listens_df
     if _incremental_listens_df is None:
-        _incremental_listens_df = read_files_from_HDFS(INCREMENTAL_DUMPS_SAVE_PATH)
+        listens_location = get_listens_metadata().location
+        inc_listens_location = os.path.join(listens_location, "incremental")
+        _incremental_listens_df = read_files_from_HDFS(inc_listens_location)
         _incremental_listens_df.persist()
     return _incremental_listens_df
 
@@ -47,7 +49,9 @@ def get_incremental_listens_df() -> DataFrame:
 def get_incremental_users_df() -> DataFrame:
     global _incremental_users_df
     if _incremental_users_df is None:
-        _incremental_users_df = read_files_from_HDFS(INCREMENTAL_USERS_DF)
+        listens_location = get_listens_metadata().location
+        inc_users_location = os.path.join(listens_location, "incremental-users")
+        _incremental_users_df = read_files_from_HDFS(inc_users_location)
         _incremental_users_df.persist()
     return _incremental_users_df
 
@@ -55,7 +59,9 @@ def get_incremental_users_df() -> DataFrame:
 def get_deleted_listens_df() -> DataFrame:
     global _deleted_listens_df
     if _deleted_listens_df is None:
-        _deleted_listens_df = read_files_from_HDFS(DELETED_LISTENS_SAVE_PATH)
+        listens_location = get_listens_metadata().location
+        deleted_listens_location = os.path.join(listens_location, "deleted-listens")
+        _deleted_listens_df = read_files_from_HDFS(deleted_listens_location)
         _deleted_listens_df.persist()
     return _deleted_listens_df
 
@@ -63,6 +69,8 @@ def get_deleted_listens_df() -> DataFrame:
 def get_deleted_users_listen_history_df() -> DataFrame:
     global _deleted_users_listen_history_df
     if _deleted_users_listen_history_df is None:
-        _deleted_users_listen_history_df = read_files_from_HDFS(DELETED_USER_LISTEN_HISTORY_SAVE_PATH)
+        listens_location = get_listens_metadata().location
+        deleted_user_listen_history_location = os.path.join(listens_location, "deleted-user-listen-history")
+        _deleted_users_listen_history_df = read_files_from_HDFS(deleted_user_listen_history_location)
         _deleted_users_listen_history_df.persist()
     return _deleted_users_listen_history_df

--- a/listenbrainz_spark/listens/data.py
+++ b/listenbrainz_spark/listens/data.py
@@ -1,58 +1,29 @@
 import os
+import os.path
 from datetime import datetime
 from textwrap import dedent
-from typing import List
+from typing import Optional
 
 from dateutil.relativedelta import relativedelta
-from pyspark.sql import DataFrame, functions
+from pyspark.sql import functions, DataFrame
 
 import listenbrainz_spark
 from listenbrainz_spark import hdfs_connection
-from listenbrainz_spark.listens.cache import get_deleted_listens_df, get_deleted_users_listen_history_df
-from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY, LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY, \
-    INCREMENTAL_DUMPS_SAVE_PATH, DELETED_LISTENS_SAVE_PATH, DELETED_USER_LISTEN_HISTORY_SAVE_PATH
+from listenbrainz_spark.listens.cache import get_incremental_listens_df, \
+    get_deleted_listens_df
+from listenbrainz_spark.listens.metadata import get_listens_metadata
 from listenbrainz_spark.schema import listens_new_schema
-from listenbrainz_spark.utils import read_files_from_HDFS
 
 
-def get_listen_files_list() -> List[str]:
-    """ Get list of name of parquet files containing the listens.
-    The list of file names is in order of newest to oldest listens.
-    """
-    files = hdfs_connection.client.list(LISTENBRAINZ_NEW_DATA_DIRECTORY)
-    has_incremental = False
-    file_names = []
-
-    for file in files:
-        # handle incremental dumps separately because later we want to sort
-        # based on numbers in file name
-        if file == "incremental.parquet":
-            has_incremental = True
-            continue
-        if file in {"delete.parquet", "deleted-user-listen-history.parquet", "incremental-users.parquet"} :
-            continue
-        if file.endswith(".parquet"):
-            file_names.append(file)
-
-    # parquet files which come from full dump are named as 0.parquet, 1.parquet so
-    # on. listens are stored in ascending order of listened_at. so higher the number
-    # in the name of the file, newer the listens. Therefore, we sort the list
-    # according to numbers in name of parquet files, in reverse order to start
-    # loading newer listens first.
-    file_names.sort(key=lambda x: int(x.split(".")[0]), reverse=True)
-
-    # all incremental dumps are stored in incremental.parquet. these are the newest
-    # listens. but an incremental dump might not always exist for example at the time
-    # when a full dump has just been imported. so check if incremental dumps are
-    # present, if yes then add those to the start of list
-    if has_incremental:
-        file_names.insert(0, "incremental.parquet")
-
-    return file_names
+def incremental_listens_exist() -> bool:
+    """ Check if incremental listens dump exists """
+    metadata = get_listens_metadata()
+    incremental_location = os.path.join(metadata.location, "incremental")
+    return hdfs_connection.client.status(incremental_location, strict=False)
 
 
 def get_listens_from_dump(start: datetime = None, end: datetime = None,
-                          include_incremental=True, remove_deleted=False) -> DataFrame:
+                          include_incremental: bool = True, remove_deleted: bool = False) -> DataFrame:
     """ Load listens with listened_at between from_ts and to_ts from HDFS in a spark dataframe.
 
         Args:
@@ -66,23 +37,25 @@ def get_listens_from_dump(start: datetime = None, end: datetime = None,
     """
     df = listenbrainz_spark.session.createDataFrame([], listens_new_schema)
 
-    if hdfs_connection.client.status(LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY, strict=False):
-        full_df = get_intermediate_stats_df(start, end)
+    metadata = get_listens_metadata()
+    base_listens_location = os.path.join(metadata.location, "base")
+
+    if hdfs_connection.client.status(base_listens_location, strict=False):
+        full_df = get_base_listens_df(base_listens_location, start, end)
         df = df.union(full_df)
 
-    if include_incremental and hdfs_connection.client.status(INCREMENTAL_DUMPS_SAVE_PATH, strict=False):
-        inc_df = read_files_from_HDFS(INCREMENTAL_DUMPS_SAVE_PATH)
-        df = df.union(inc_df)
+    if include_incremental and incremental_listens_exist():
+        df = df.union(get_incremental_listens_df())
 
     df = filter_listens_by_range(df, start, end)
 
     if remove_deleted:
-        df = filter_deleted_listens(df)
+        df = filter_deleted_listens(df, metadata.location)
 
     return df
 
 
-def filter_listens_by_range(listens_df: DataFrame, start: datetime, end: datetime) -> DataFrame:
+def filter_listens_by_range(listens_df: DataFrame, start: Optional[datetime], end: Optional[datetime]) -> DataFrame:
     """ Filter listens dataframe to only keep listens with listened_at between start and end. """
     if start:
         listens_df = listens_df.where(f"listened_at >= to_timestamp('{start}')")
@@ -91,16 +64,18 @@ def filter_listens_by_range(listens_df: DataFrame, start: datetime, end: datetim
     return listens_df
 
 
-def filter_deleted_listens(listens_df: DataFrame) -> DataFrame:
+def filter_deleted_listens(listens_df: DataFrame, location: str) -> DataFrame:
     """ Filter listens dataframe to remove listens that have been deleted from LB db. """
-    if hdfs_connection.client.status(DELETED_LISTENS_SAVE_PATH, strict=False):
+    deleted_listens_save_path = os.path.join(location, "deleted-listens")
+    if hdfs_connection.client.status(deleted_listens_save_path, strict=False):
         delete_df = get_deleted_listens_df()
         listens_df = listens_df \
             .join(delete_df, ["user_id", "listened_at", "recording_msid", "created"], "anti") \
             .select(*listens_df.columns)
 
-    if hdfs_connection.client.status(DELETED_USER_LISTEN_HISTORY_SAVE_PATH, strict=False):
-        delete_df2 = get_deleted_users_listen_history_df()
+    deleted_user_listen_history_save_path = os.path.join(location, "deleted-user-listen-history")
+    if hdfs_connection.client.status(deleted_user_listen_history_save_path, strict=False):
+        delete_df2 = get_deleted_listens_df()
         listens_df = listens_df \
             .join(delete_df2, ["user_id"], "left_outer") \
             .where((delete_df2.max_created.isNull()) | (listens_df.created >= delete_df2.max_created)) \
@@ -109,7 +84,7 @@ def filter_deleted_listens(listens_df: DataFrame) -> DataFrame:
     return listens_df
 
 
-def get_intermediate_stats_df(start: datetime, end: datetime):
+def get_base_listens_df(location, start: datetime, end: datetime):
     if start is None and end is None:
         where_clause = ""
     else:
@@ -133,20 +108,21 @@ def get_intermediate_stats_df(start: datetime, end: datetime):
              , recording_name
              , recording_mbid
              , artist_credit_mbids
-          from parquet.`{LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY}`
+          from parquet.`{location}`
     """) + where_clause
     return listenbrainz_spark.sql_context.sql(query)
 
 
 def get_latest_listen_ts() -> datetime:
-    """" Get the listened_at time of the latest listen present
-     in the imported dumps
-     """
-    latest_listen_file = get_listen_files_list()[0]
-    df = read_files_from_HDFS(
-        os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, latest_listen_file)
-    )
-    return df \
-        .select('listened_at') \
-        .agg(functions.max('listened_at').alias('latest_listen_ts'))\
-        .collect()[0]['latest_listen_ts']
+    """ Get the max listened_at timestamp present in the imported listens dumps """
+    metadata = get_listens_metadata()
+    base_latest_listen_ts = metadata.max_listened_at
+
+    if incremental_listens_exist():
+        inc_latest_listen_ts = get_incremental_listens_df() \
+            .select("listened_at") \
+            .agg(functions.max("listened_at").alias("inc_latest_listen_ts"))\
+            .collect()[0]["inc_latest_listen_ts"]
+        return max(base_latest_listen_ts, inc_latest_listen_ts)
+
+    return base_latest_listen_ts

--- a/listenbrainz_spark/listens/metadata.py
+++ b/listenbrainz_spark/listens/metadata.py
@@ -1,0 +1,61 @@
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional, Union
+
+from pyspark import Row
+from pyspark.sql import DataFrame
+
+import listenbrainz_spark
+from listenbrainz_spark import config, hdfs_connection
+from listenbrainz_spark.hdfs.utils import create_dir
+from listenbrainz_spark.path import LISTENBRAINZ_LISTENS_METADATA, LISTENBRAINZ_LISTENS_DIRECTORY_PREFIX
+from listenbrainz_spark.schema import listens_metadata_schema
+
+_listens_metadata_df: Optional[DataFrame] = None
+
+
+def get_listens_metadata() -> Union[Row, None]:
+    """ Retrieve listens metadata from HDFS """
+    global _listens_metadata_df
+    if _listens_metadata_df is None \
+        and hdfs_connection.client.status(LISTENBRAINZ_LISTENS_METADATA, strict=False):
+        _listens_metadata_df = listenbrainz_spark \
+            .session \
+            .read \
+            .json(config.HDFS_CLUSTER_URI + LISTENBRAINZ_LISTENS_METADATA, schema=listens_metadata_schema)
+
+    if _listens_metadata_df is not None:
+        return _listens_metadata_df.collect()[0]
+
+
+def update_listens_metadata(new_location, max_listened_at, max_created):
+    """ Update listens metadata in HDFS """
+    row = Row(
+        location=new_location,
+        max_listened_at=max_listened_at,
+        max_created=max_created,
+        updated_at=datetime.now(timezone.utc)
+    )
+    listenbrainz_spark \
+        .session \
+        .createDataFrame([row], schema=listens_metadata_schema) \
+        .repartition(1) \
+        .write \
+        .mode("overwrite") \
+        .json(config.HDFS_CLUSTER_URI + LISTENBRAINZ_LISTENS_METADATA)
+
+    unpersist_listens_metadata()
+
+
+def unpersist_listens_metadata():
+    global _listens_metadata_df
+    if _listens_metadata_df is not None:
+        _listens_metadata_df.unpersist()
+        _listens_metadata_df = None
+
+
+def generate_new_listens_location() -> str:
+    location = os.path.join(LISTENBRAINZ_LISTENS_DIRECTORY_PREFIX, str(uuid.uuid4()))
+    create_dir(location)
+    return location

--- a/listenbrainz_spark/path.py
+++ b/listenbrainz_spark/path.py
@@ -1,9 +1,7 @@
 import os
 
-# Location new parquet dump listen files
-LISTENBRAINZ_NEW_DATA_DIRECTORY = os.path.join('/', 'data', 'listenbrainz-new')
-
-LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY = os.path.join('/', 'data', 'stats-new')
+LISTENBRAINZ_LISTENS_METADATA = os.path.join("/", "data", "listens-metadata")
+LISTENBRAINZ_LISTENS_DIRECTORY_PREFIX = os.path.join("/", "data", "listens")
 
 LISTENBRAINZ_BASE_STATS_DIRECTORY = os.path.join('/', 'stats')
 LISTENBRAINZ_SITEWIDE_STATS_DIRECTORY = os.path.join(LISTENBRAINZ_BASE_STATS_DIRECTORY, 'sitewide')
@@ -15,14 +13,6 @@ LISTENBRAINZ_MLHD_POPULARITY_DIRECTORY = os.path.join(LISTENBRAINZ_BASE_STATS_DI
 # MLHD+ dump files
 MLHD_PLUS_RAW_DATA_DIRECTORY = os.path.join("/", "mlhd-raw")
 MLHD_PLUS_DATA_DIRECTORY = os.path.join("/", "mlhd")  # processed MLHD+ dump data
-
-# path to save incremental dumps
-INCREMENTAL_DUMPS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "incremental.parquet")
-INCREMENTAL_USERS_DF = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "incremental-users.parquet")
-
-# path to save deleted listens
-DELETED_LISTENS_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "delete.parquet")
-DELETED_USER_LISTEN_HISTORY_SAVE_PATH = os.path.join(LISTENBRAINZ_NEW_DATA_DIRECTORY, "deleted-user-listen-history.parquet")
 
 # Directory containing RDD checkpoints to break lineage while using iterative algorithms.
 CHECKPOINT_DIR = os.path.join('/', 'checkpoint')
@@ -93,13 +83,6 @@ USER_SIMILARITY_METADATA_DATAFRAME = os.path.join(
     USER_SIMILARITY_DATAFRAME_DIR, 'dataframe_metadata.parquet')
 USER_SIMILARITY_MAPPED_LISTENS = os.path.join(
     USER_SIMILARITY_DATAFRAME_DIR, 'mapped_listens_df.parquet')
-
-# MusicBrainz Release JSON dump
-MUSICBRAINZ_RELEASE_DUMP = "/musicbrainz/release"
-MUSICBRAINZ_RELEASE_DUMP_JSON_FILE = "/musicbrainz/release/mbdump/release"
-
-# Release colors
-RELEASE_COLOR_DUMP = "/release_color.json"
 
 RELEASE_METADATA_CACHE_DATAFRAME = "/release_metadata_cache"
 RELEASE_GROUP_METADATA_CACHE_DATAFRAME = "/release_group_metadata_cache"

--- a/listenbrainz_spark/recommendations/recording/tests/__init__.py
+++ b/listenbrainz_spark/recommendations/recording/tests/__init__.py
@@ -7,7 +7,7 @@ from pyspark.sql.types import StructType, StructField, IntegerType
 import listenbrainz_spark
 from listenbrainz_spark import utils
 from listenbrainz_spark.listens.dump import import_incremental_dump_to_hdfs
-from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY, RECOMMENDATION_RECORDING_MAPPED_LISTENS
+from listenbrainz_spark.path import RECOMMENDATION_RECORDING_MAPPED_LISTENS
 from listenbrainz_spark.tests import SparkNewTestCase, TEST_DATA_PATH, PLAYCOUNTS_COUNT, TEST_PLAYCOUNTS_PATH
 from listenbrainz_spark.hdfs.utils import upload_to_HDFS
 

--- a/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
+++ b/listenbrainz_spark/recommendations/tests/test_dataframe_utils.py
@@ -18,8 +18,8 @@ class DataframeUtilsTestCase(SparkNewTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(DataframeUtilsTestCase, cls).tearDownClass()
         cls.delete_uploaded_listens()
+        super(DataframeUtilsTestCase, cls).tearDownClass()
 
     def test_generate_dataframe_id(self):
         prefix = 'listenbrainz-recommendation-dataframe'

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -3,6 +3,13 @@ from pyspark.sql import Row
 from pyspark.sql.types import StructField, StructType, ArrayType, StringType, TimestampType, FloatType, \
     IntegerType, LongType
 
+listens_metadata_schema = StructType([
+    StructField('location', StringType(), False),
+    StructField('max_listened_at', TimestampType(), False),
+    StructField('max_created', TimestampType(), False),
+    StructField('updated_at', TimestampType(), False),
+])
+
 # Keeping track of the from_date and the to_date used to create the partial aggressive from full dump listens.
 # Assuming dumps are imported twice a month, the aggregates for weekly stats need to be refreshed (generated from
 # different range of listens in the full dump) sooner. The existing_aggrrgate_usable method reads this from/to date

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -9,14 +9,15 @@ from pyspark.errors import AnalysisException
 import listenbrainz_spark
 from listenbrainz_spark import hdfs_connection
 from listenbrainz_spark.config import HDFS_CLUSTER_URI
-from listenbrainz_spark.path import INCREMENTAL_DUMPS_SAVE_PATH
 from listenbrainz_spark.listens.cache import get_incremental_listens_df
+from listenbrainz_spark.listens.metadata import get_listens_metadata
 from listenbrainz_spark.schema import BOOKKEEPING_SCHEMA, INCREMENTAL_BOOKKEEPING_SCHEMA
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats.incremental.message_creator import MessageCreator
 from listenbrainz_spark.stats.incremental.query_provider import QueryProvider
 from listenbrainz_spark.utils import read_files_from_HDFS
-from listenbrainz_spark.listens.data import get_listens_from_dump, filter_listens_by_range, filter_deleted_listens
+from listenbrainz_spark.listens.data import get_listens_from_dump, filter_listens_by_range, filter_deleted_listens, \
+    incremental_listens_exist
 
 logger = logging.getLogger(__name__)
 
@@ -116,10 +117,6 @@ class IncrementalStatsEngine:
 
         return full_df
 
-    def incremental_dump_exists(self) -> bool:
-        """ Check if incremental listen dumps exist """
-        return hdfs_connection.client.status(INCREMENTAL_DUMPS_SAVE_PATH, strict=False)
-
     def create_incremental_aggregate(self) -> DataFrame:
         """
         Create an incremental aggregate from incremental listens.
@@ -131,7 +128,7 @@ class IncrementalStatsEngine:
 
         inc_listens_df = get_incremental_listens_df()
         inc_listens_df = filter_listens_by_range(inc_listens_df, self.provider.from_date, self.provider.to_date)
-        inc_listens_df = filter_deleted_listens(inc_listens_df)
+        inc_listens_df = filter_deleted_listens(inc_listens_df, get_listens_metadata().location)
         inc_listens_df.createOrReplaceTempView(self.incremental_table)
 
         inc_query = self.provider.get_aggregate_query(self.incremental_table)
@@ -173,7 +170,7 @@ class IncrementalStatsEngine:
         partial_table = f"{prefix}_existing_aggregate"
         partial_df.createOrReplaceTempView(partial_table)
 
-        if self.incremental_dump_exists():
+        if incremental_listens_exist():
             inc_df = self.create_incremental_aggregate()
             inc_table = f"{prefix}_incremental_aggregate"
             inc_df.createOrReplaceTempView(inc_table)

--- a/listenbrainz_spark/stats/user/tests/test_listening_activity_range_selector.py
+++ b/listenbrainz_spark/stats/user/tests/test_listening_activity_range_selector.py
@@ -20,8 +20,8 @@ class ListeningActivityListenRangeSelectorTestCase(SparkNewTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super().tearDownClass()
         cls.delete_uploaded_listens()
+        super().tearDownClass()
 
     def test_get_listening_activity_week(self):
         selector = ListeningActivityListenRangeSelector("week")

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -10,11 +10,12 @@ from listenbrainz_spark import hdfs_connection, config
 from listenbrainz_spark.dump import ListenbrainzDumpLoader, DumpType
 from listenbrainz_spark.listens.cache import unpersist_incremental_df, unpersist_deleted_df
 from listenbrainz_spark.listens.dump import import_full_dump_to_hdfs, import_incremental_dump_to_hdfs
-from listenbrainz_spark.path import LISTENBRAINZ_NEW_DATA_DIRECTORY, LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY
+from listenbrainz_spark.listens.metadata import unpersist_listens_metadata
+from listenbrainz_spark.path import LISTENBRAINZ_LISTENS_DIRECTORY_PREFIX
 from listenbrainz_spark.hdfs.utils import delete_dir, path_exists, hdfs_walk
 
-TEST_PLAYCOUNTS_PATH = '/tests/playcounts.parquet'
-TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'testdata')
+TEST_PLAYCOUNTS_PATH = "/tests/playcounts.parquet"
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testdata")
 PLAYCOUNTS_COUNT = 100
 
 
@@ -46,16 +47,17 @@ class SparkNewTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        listenbrainz_spark.context.stop()
+        unpersist_listens_metadata()
         cls.delete_dir()
+        listenbrainz_spark.context.stop()
 
     @classmethod
     def delete_dir(cls):
-        walk = hdfs_walk('/', depth=1)
-        # dirs in '/'
+        walk = hdfs_walk("/", depth=1)
+        # dirs in "/"
         dirs = next(walk)[1]
         for directory in dirs:
-            delete_dir(os.path.join('/', directory), recursive=True)
+            delete_dir(os.path.join("/", directory), recursive=True)
 
     @classmethod
     def upload_test_listens(cls):
@@ -69,12 +71,11 @@ class SparkNewTestCase(unittest.TestCase):
         # to avoid unhelpful py4j errors. spark context is started and stopped
         # for each class but cached dataframes being global variables are not
         # cleared automatically between tests.
+        unpersist_listens_metadata()
         unpersist_incremental_df()
         unpersist_deleted_df()
-        if path_exists(LISTENBRAINZ_NEW_DATA_DIRECTORY):
-            delete_dir(LISTENBRAINZ_NEW_DATA_DIRECTORY, recursive=True)
-        if path_exists(LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY):
-            delete_dir(LISTENBRAINZ_INTERMEDIATE_STATS_DIRECTORY, recursive=True)
+        if path_exists(LISTENBRAINZ_LISTENS_DIRECTORY_PREFIX):
+            delete_dir(LISTENBRAINZ_LISTENS_DIRECTORY_PREFIX, recursive=True)
 
     @staticmethod
     def path_to_data_file(file_name):


### PR DESCRIPTION
A future PR will implement compacting full dumps, incremental dump and deleted listens. It is easier to write a new location after this step instead of writing in place or writing to a new location then moving it to the fixed location. Hence, making the dumps storage location dynamic.