### PR TITLE
Migrate from xz to zstd for dumps compression

### DIFF
--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -236,22 +236,22 @@ touch "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
-    "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.xz"
+    "listenbrainz-public-dump-$DUMP_TIMESTAMP.tar.zst"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
-    "listenbrainz-public-timescale-dump-$DUMP_TIMESTAMP.tar.xz"
+    "listenbrainz-public-timescale-dump-$DUMP_TIMESTAMP.tar.zst"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
-    "listenbrainz-listens-dump-$DUMP_ID-$DUMP_TIMESTAMP-$DUMP_TYPE.tar.xz"
+    "listenbrainz-listens-dump-$DUMP_ID-$DUMP_TIMESTAMP-$DUMP_TYPE.tar.zst"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-spark-dump-$DUMP_ID-$DUMP_TIMESTAMP-$DUMP_TYPE.tar"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
-    "listenbrainz-feedback-dump-$DUMP_TIMESTAMP.tar.xz"
+    "listenbrainz-feedback-dump-$DUMP_TIMESTAMP.tar.zst"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
-    "listenbrainz-statistics-dump-$DUMP_TIMESTAMP.tar.xz"
+    "listenbrainz-statistics-dump-$DUMP_TIMESTAMP.tar.zst"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
     "musicbrainz-canonical-dump-$DUMP_TIMESTAMP.tar.zst"

--- a/docs/users/listenbrainz-dumps.rst
+++ b/docs/users/listenbrainz-dumps.rst
@@ -22,28 +22,28 @@ File Descriptions
 
 A ListenBrainz data dump consists of three archives:
 
-#. ``listenbrainz-public-dump.tar.xz``
+#. ``listenbrainz-public-dump.tar.zst``
 
-#. ``listenbrainz-listens-dump.tar.xz``
+#. ``listenbrainz-listens-dump.tar.zst``
 
-#. ``listenbrainz-listens-dump-spark.tar.xz``
+#. ``listenbrainz-listens-dump-spark.tar.zst``
 
 
-listenbrainz-public-dump.tar.xz
+listenbrainz-public-dump.tar.zst
 -------------------------------
 
 This file contains information about ListenBrainz users and statistics derived
 from listens submitted to ListenBrainz calculated from users, artists, recordings etc.
 
 
-listenbrainz-listens-dump.tar.xz
+listenbrainz-listens-dump.tar.zst
 --------------------------------
 
 This is the core ListenBrainz data dump. This file contains all the listens
 submitted to ListenBrainz by its users.
 
 
-listenbrainz-listens-dump-spark.tar.xz
+listenbrainz-listens-dump-spark.tar.zst
 --------------------------------------
 
 This is also a dump of the core ListenBrainz listen data. These dumps are

--- a/listenbrainz/db/tests/test_dump.py
+++ b/listenbrainz/db/tests/test_dump.py
@@ -82,9 +82,9 @@ class DumpTestCase(DatabaseTestCase):
 
         found = set()
         found_stats = None
-        xz_command = ['xz', '--decompress', '--stdout', dump_location, '-T4']
-        xz = subprocess.Popen(xz_command, stdout=subprocess.PIPE)
-        with tarfile.open(fileobj=xz.stdout, mode='r|') as tar:
+        zstd_command = ['zstd', '--decompress', '--stdout', dump_location, '-T4']
+        zstd = subprocess.Popen(zstd_command, stdout=subprocess.PIPE)
+        with tarfile.open(fileobj=zstd.stdout, mode='r|') as tar:
             for member in tar:
                 file_name = member.name.split('/')[-1]
                 if file_name.endswith(".jsonl"):

--- a/listenbrainz/db/tests/test_dump_manager.py
+++ b/listenbrainz/db/tests/test_dump_manager.py
@@ -21,6 +21,7 @@
 
 import os
 import shutil
+import subprocess
 import tarfile
 import tempfile
 import time
@@ -148,13 +149,13 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         # dumps should contain the 7 archives
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 5)
 
         private_archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir_private, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 private_archive_count += 1
         self.assertEqual(private_archive_count, 2)
 
@@ -197,13 +198,13 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         # dumps should contain the 7 archives
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 5)
 
         private_archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir_private, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 private_archive_count += 1
         self.assertEqual(private_archive_count, 2)
 
@@ -276,7 +277,7 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         # make sure that the dump contains a full listens and spark dump
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 2)
 
@@ -315,14 +316,16 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         # make sure that the dump contains a full listens and spark dump
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith(".tar.xz") or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 2)
 
-        dump_file_name = dump_name.replace("dump", "listens-dump") + ".tar.xz"
+        dump_file_name = dump_name.replace("dump", "listens-dump") + ".tar.zst"
         listens_dump_file = os.path.join(self.tempdir, dump_name, dump_file_name)
-        with tarfile.open(listens_dump_file, "r:xz") as f:
-            for member in f.getmembers():
+        zstd_command = ["zstd", "--decompress", "--stdout", listens_dump_file, "-T4"]
+        zstd = subprocess.Popen(zstd_command, stdout=subprocess.PIPE)
+        with tarfile.open(fileobj=zstd.stdout, mode="r|") as f:
+            for member in f:
                 if member.name.endswith(".listens"):
                     lines = f.extractfile(member).readlines()
                     # five listens were dumped as expected as only five listens were created until the
@@ -353,7 +356,7 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         # dump should contain the listen and spark archive
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 2)
 
@@ -419,6 +422,6 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         # make sure that the dump contains a feedback dump
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
-            if file_name.endswith('.tar.xz') or file_name.endswith(".tar"):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 1)

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -397,7 +397,7 @@ class HandlersTestCase(DatabaseTestCase):
     def test_handle_dump_imported(self, mock_send_mail):
         with self.app.app_context():
             time = datetime.now()
-            dump_name = 'listenbrainz-listens-dump-20200223-000000-spark-full.tar.xz'
+            dump_name = 'listenbrainz-listens-dump-20200223-000000-spark-full.tar.zst'
             errors = ["Could not download dump!"]
 
             # testing, should not send a mail


### PR DESCRIPTION
Tested on jsonl statistics dumps which are 43G uncompressed, the results are as follows:

|             | xz     | zstd (-10) |
|-------------|--------|------------|
| Compression | 8.3x   | 6.7x       |
| Time Taken  | 87m 3s | 33m 12s    |

xz compresses a little better but zstd is much faster, and I feel the overall tradeoffs are in favour of zstd.