### PR TITLE
LB-1442: Fix sending emails if username contains a special character

### DIFF
--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -178,6 +178,12 @@ def send_mail(subject, to_name, to_email, content, html, logo, logo_cid):
     current_app.logger.info("Email sent to %s", to_name)
 
 
+def sanitize_username(username):
+    weird_chars = '@,;><:"()'
+    table = str.maketrans('','',weird_chars)
+    return username.translate(table)
+
+
 def notify_yim_users(db_conn, ts_conn, year):
     logo_cid = make_msgid()
     with open("/static/img/year-in-music-24/yim24-header-all-email.png", "rb") as img:
@@ -198,7 +204,7 @@ def notify_yim_users(db_conn, ts_conn, year):
     rows = result.fetchall()
 
     for row in rows:
-        user_name = row.musicbrainz_id
+        user_name = sanitize_username(row.musicbrainz_id)
 
         # cannot use url_for because we do not set SERVER_NAME and
         # a request_context will not be available in this script.

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -179,7 +179,7 @@ def send_mail(subject, to_name, to_email, content, html, logo, logo_cid):
 
 
 def sanitize_username(username):
-    weird_chars = {',',':',';','@','<','>','"','(',')'}
+    weird_chars = {',',':',';','@','<','>','"','(',')','[',']','\\'}
     for i in username:
         if i in weird_chars:
             return f'"{username}"'

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -179,9 +179,11 @@ def send_mail(subject, to_name, to_email, content, html, logo, logo_cid):
 
 
 def sanitize_username(username):
-    weird_chars = '@,;><:"()'
-    table = str.maketrans('','',weird_chars)
-    return username.translate(table)
+    weird_chars = {',',':',';','@','<','>','"','(',')'}
+    for i in username:
+        if i in weird_chars:
+            return f'"{username}"'
+    return username
 
 
 def notify_yim_users(db_conn, ts_conn, year):

--- a/listenbrainz/db/year_in_music.py
+++ b/listenbrainz/db/year_in_music.py
@@ -179,11 +179,9 @@ def send_mail(subject, to_name, to_email, content, html, logo, logo_cid):
 
 
 def sanitize_username(username):
-    weird_chars = {',',':',';','@','<','>','"','(',')','[',']','\\'}
-    for i in username:
-        if i in weird_chars:
-            return f'"{username}"'
-    return username
+    username.replace('\\','\\\\')
+    username.replace('"','\\"')
+    return f'"{username}"'
 
 
 def notify_yim_users(db_conn, ts_conn, year):


### PR DESCRIPTION
# Problem
Usernames are added to the "To" header of YIM notification emails, usernames that contains special/non atom characters and arent quoted doesnt comply with [RFC 5322](https://datatracker.ietf.org/doc/html/rfc5322#section-3.2.3) and create problems while sending out multiple mails.
   [JIRA ticket](https://tickets.metabrainz.org/browse/LB-1442)


# Solution
If any character of username contains special characters, enquote them.



