### PR TITLE
LB-1760

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -355,7 +355,7 @@ export default function MusicServices() {
               premium user -{" "}
               <b>ListenBrainz will never read these pieces of data</b>. Please
               feel free to{" "}
-              <a href="https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz/spotify_updater/spotify_read_listens.py">
+              <a href="https://github.com/metabrainz/listenbrainz-server/">
                 inspect our source code
               </a>{" "}
               any time!


### PR DESCRIPTION
## Problem
[LB-1760](https://tickets.metabrainz.org/browse/LB-1760) – The link in settings/music-services/details/ was redirecting to a non-existing page, causing a 404 error.

## Solution
Updated the redirect URL point to the [listenbrainz-server](https://github.com/metabrainz/listenbrainz-server/), correcting the issue.
## Action
Please review and accept this pull request. No additional changes are required.