### PR TITLE
LB-1760: Fix the link in the details section to redirect to the correct file.

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -355,7 +355,7 @@ export default function MusicServices() {
               premium user -{" "}
               <b>ListenBrainz will never read these pieces of data</b>. Please
               feel free to{" "}
-              <a href="https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz/spotify_updater/spotify_read_listens.py">
+              <a target="_blank" rel="noreferrer" href="https://github.com/metabrainz/listenbrainz-server/blob/master/listenbrainz/listens_importer/spotify.py">
                 inspect our source code
               </a>{" "}
               any time!


### PR DESCRIPTION
# Problem

The "Inspect our source code" link at `settings/music-services/details/` was redirecting to a non-existent file.
# Solution

Added the correct link now it redirects to spotify.py.

# Action

Review for feedback.


