### PR TITLE
Fix fallback to release-group cover art

### DIFF
--- a/frontend/js/src/common/brainzplayer/MusicPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/MusicPlayer.tsx
@@ -221,11 +221,7 @@ function MusicPlayer(props: MusicPlayerProps) {
       track: BrainzPlayerQueueItem,
       setCoverArt: React.Dispatch<React.SetStateAction<string>>
     ) => {
-      const coverArt = await getAlbumArtFromListenMetadata(
-        track,
-        spotifyAuth,
-        APIService
-      );
+      const coverArt = await getAlbumArtFromListenMetadata(track, spotifyAuth);
       setCoverArt(coverArt ?? "");
     };
 

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -774,8 +774,7 @@ export default function ListenCardWrapper(props: ListenCardProps) {
       try {
         const albumArtURL = await getAlbumArtFromListenMetadata(
           listen,
-          spotifyAuth,
-          APIService
+          spotifyAuth
         );
         return albumArtURL ?? "";
       } catch (error) {

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseCard.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseCard.tsx
@@ -122,13 +122,11 @@ export default function ReleaseCard(props: ReleaseCardProps) {
   React.useEffect(() => {
     async function getCoverArt() {
       let coverartURL;
-      if (releaseMBID) {
+      if (releaseMBID || releaseGroupMBID) {
         coverartURL = await getAlbumArtFromReleaseMBID(
           releaseMBID,
-          releaseGroupMBID ?? true
+          releaseGroupMBID
         );
-      } else if (releaseGroupMBID) {
-        coverartURL = await getAlbumArtFromReleaseGroupMBID(releaseGroupMBID);
       }
       if (coverartURL) {
         setCoverartSrc(coverartURL);

--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -947,7 +947,9 @@ const getAlbumArtFromListenMetadata = async (
     // release group cover art of the user submitted release mbid next
     const userSubmittedReleaseAlbumArt = await getAlbumArtFromReleaseMBID(
       userSubmittedReleaseMBID,
-      Boolean(caaReleaseMbid) && userSubmittedReleaseMBID !== caaReleaseMbid,
+      (Boolean(caaReleaseMbid) &&
+        userSubmittedReleaseMBID !== caaReleaseMbid) ||
+        true,
       APIService,
       undefined,
       true // we only want front images, otherwise skip


### PR DESCRIPTION
We have some fallback mechanisms in place for cases where there is no release MBID available, but one check is currently too restrictive and prevents the fallback from triggering, for example for pseudo-releases with no cover art.

If the use-submitted clean data with a release MBID and a release-group MBID, if the release does not have cover art it will currently not fall back to the release group cover art because we check if the user-submitted and the auto-mapped release MBIDs are equal.
If there is no mapped release the fallback will not trigger.