### PR TITLE
LB-1765 Check if user exists on last.fm while connecting last.fm username

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -213,11 +213,9 @@ export default function MusicServices() {
           lastfm: "import",
         }));
       } else {
-        if (response.bodyUsed) {
-          const body = await response.json();
-          if (body.error) {
-            throw body.error;
-          }
+        const body = await response.json();
+        if (body?.error) {
+          throw body.error;
         }
         throw response.statusText;
       }

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -252,7 +252,7 @@ def music_services_connect(service_name: str):
         raise APIBadRequest("Missing 'external_user_id' in request.")
     
     
-    lastfm_response = requests.get(f"https://www.last.fm/user/{data['external_user_id']}", timeout=5)
+    lastfm_response = requests.get(f"{current_app.config['LASTFM_API_URL']}?method=user.getinfo&user={data['external_user_id']}&api_key={current_app.config['LASTFM_API_KEY']}&format=json", timeout=5)
     if lastfm_response.status_code == 404:
         raise APINotFound("last.fm user not found.")
 

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -6,6 +6,7 @@ from flask import Blueprint, render_template, request, url_for, \
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_setting as db_usersetting
@@ -251,10 +252,18 @@ def music_services_connect(service_name: str):
     if "external_user_id" not in data:
         raise APIBadRequest("Missing 'external_user_id' in request.")
     
-    
-    lastfm_response = requests.get(f"{current_app.config['LASTFM_API_URL']}?method=user.getinfo&user={data['external_user_id']}&api_key={current_app.config['LASTFM_API_KEY']}&format=json", timeout=5)
-    if lastfm_response.status_code == 404:
-        raise APINotFound("last.fm user not found.")
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter(max_retries=Retry(total=2, backoff_factor=1, allowed_methods=["GET"])))
+
+    params = {
+        "method": "user.getinfo",
+        "user": data['external_user_id'],
+        "format": "json",
+        "api_key": current_app.config["LASTFM_API_KEY"],
+    }
+    response = session.get(current_app.config["LASTFM_API_URL"], params=params)
+    if response.status_code == 404:
+        raise APINotFound(f"Last.FM user with username '{data['external_user_id']}' not found")
 
     latest_listened_at = None
     if data.get("latest_listened_at") is not None:

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -5,6 +5,7 @@ from flask import Blueprint, render_template, request, url_for, \
     redirect, current_app, jsonify
 from flask_login import current_user, login_required
 from werkzeug.exceptions import NotFound, BadRequest
+import requests
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_setting as db_usersetting
@@ -246,8 +247,14 @@ def music_services_connect(service_name: str):
         raise APINotFound("Service %s is invalid." % (service_name,))
 
     data = request.json
+
     if "external_user_id" not in data:
         raise APIBadRequest("Missing 'external_user_id' in request.")
+    
+    
+    lastfm_response = requests.get(f"https://www.last.fm/user/{data['external_user_id']}", timeout=5)
+    if lastfm_response.status_code == 404:
+        raise APINotFound("last.fm user not found.")
 
     latest_listened_at = None
     if data.get("latest_listened_at") is not None:


### PR DESCRIPTION
# Problem

Success message was shown earlier while connecting to last.fm in settings even if the user did not exist on last.fm



# Solution

Fixed it by checking if the user gives 404 or not on querying its user page.