### PR TITLE
Spark Misc. fixes and improvements

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -59,7 +59,7 @@ MAILTO=""
 0 9 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_similarity_datasets >> /logs/similarity_datasets.log 2>&1
 
 # run weekly cron job to update popularity datasets
-0 10 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py spark request_popularity >> /logs/popularity_datasets.log 2>&1
+0 10 * * 0 root /usr/local/bin/python /code/listenbrainz/manage.py spark cron_request_popularity >> /logs/popularity_datasets.log 2>&1
 
 # delete old and expired user data exports
 0 11 * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete-old-user-data-exports >> /logs/user_data_exports.log 2>&1

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -357,7 +357,7 @@ def request_similar_users(max_num_users):
                                         " (the limit is instructive. upto 2x recordings may be returned than"
                                         " the limit).", required=True)
 @click.option("--skip", type=int, help="the minimum difference threshold to mark track as skipped", required=True)
-def request_similar_recordings(session, contribution, threshold, limit, skip):
+def request_similar_recordings_mlhd(session, contribution, threshold, limit, skip):
     """ Send the cluster a request to generate similar recordings index. """
     send_request_to_spark_cluster(
         "similarity.recording.mlhd",
@@ -569,3 +569,12 @@ def cron_request_similarity_datasets(ctx):
                threshold=10, limit=100, skip=30, production=True)
     ctx.invoke(request_similar_artists, days=7500, session=300, contribution=5,
                threshold=10, limit=100, skip=30, production=True)
+
+
+@cli.command(name='cron_request_popularity')
+@click.pass_context
+def cron_request_popularity(ctx):
+    for entity in ["artist", "recording", "release", "release_group"]:
+        ctx.invoke(request_popularity, mlhd=False, entity=entity)
+    for entity in ["recording", "release", "release_group"]:
+        ctx.invoke(request_per_artist_popularity, mlhd=False, entity=entity)

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -429,7 +429,7 @@ def request_similar_artists(days, session, contribution, threshold, limit, skip,
 
 @cli.command(name="request_popularity")
 @click.option("--use-mlhd", "mlhd", is_flag=True, help="Use MLHD+ data or ListenBrainz listens data")
-@click.option("--entity", "entity", type=click.Choice(["artist", "recording", "release", "release_group"]))
+@click.option("--entity", "entity", type=click.Choice(["artist", "recording", "release", "release_group"]), required=True)
 def request_popularity(mlhd, entity):
     """ Request mlhd popularity data using the specified dataset. """
     send_request_to_spark_cluster("popularity.popularity", entity=entity, mlhd=mlhd, type="popularity")
@@ -437,7 +437,7 @@ def request_popularity(mlhd, entity):
 
 @cli.command(name="request_per_artist_popularity")
 @click.option("--use-mlhd", "mlhd", is_flag=True, help="Use MLHD+ data or ListenBrainz listens data")
-@click.option("--entity", "entity", type=click.Choice(["recording", "release", "release_group"]))
+@click.option("--entity", "entity", type=click.Choice(["recording", "release", "release_group"]), required=True)
 def request_per_artist_popularity(mlhd, entity):
     """ Request mlhd popularity data using the specified dataset. """
     send_request_to_spark_cluster("popularity.popularity", entity=entity, mlhd=mlhd, type="popularity_top")

--- a/listenbrainz_spark/listens/compact.py
+++ b/listenbrainz_spark/listens/compact.py
@@ -7,6 +7,7 @@ from listenbrainz_spark.listens.cache import unpersist_incremental_df
 from listenbrainz_spark.listens.data import get_listens_from_dump
 from listenbrainz_spark.listens.metadata import get_listens_metadata, generate_new_listens_location, \
     update_listens_metadata
+from listenbrainz_spark.path import LISTENBRAINZ_BASE_STATS_DIRECTORY
 
 
 def main():
@@ -64,3 +65,5 @@ def write_partitioned_listens(table):
 
     if existing_location and path_exists(existing_location):
         hdfs_connection.client.delete(existing_location, recursive=True, skip_trash=True)
+
+    hdfs_connection.client.delete(LISTENBRAINZ_BASE_STATS_DIRECTORY, recursive=True, skip_trash=True)

--- a/listenbrainz_spark/mlhd/download.py
+++ b/listenbrainz_spark/mlhd/download.py
@@ -148,10 +148,13 @@ def download_chunk(filename, dest) -> str:
 
 
 def process_chunk(filename):
-    with tempfile.TemporaryDirectory() as local_temp_dir:
-        downloaded_chunk = download_chunk(filename, local_temp_dir)
-        extract_chunk(filename, downloaded_chunk, local_temp_dir)
-        transform_chunk(local_temp_dir)
+    try:
+        with tempfile.TemporaryDirectory() as local_temp_dir:
+            downloaded_chunk = download_chunk(filename, local_temp_dir)
+            extract_chunk(filename, downloaded_chunk, local_temp_dir)
+            transform_chunk(local_temp_dir)
+    except Exception:
+        logger.error(f"Error while processing chunk {filename}: ", exc_info=True)
 
 
 def import_mlhd_dump_to_hdfs():

--- a/listenbrainz_spark/mlhd/download.py
+++ b/listenbrainz_spark/mlhd/download.py
@@ -158,8 +158,8 @@ def import_mlhd_dump_to_hdfs():
     """ Import the MLHD+ dump. """
     MLHD_PLUS_FILES = [f"mlhdplus-complete-{chunk}.tar" for chunk in MLHD_PLUS_CHUNKS]
 
-    for filename in MLHD_PLUS_FILES:
-        with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        for filename in MLHD_PLUS_FILES:
             executor.submit(process_chunk, filename)
 
     post_process_mlhd_plus()

--- a/listenbrainz_spark/popularity/common.py
+++ b/listenbrainz_spark/popularity/common.py
@@ -104,7 +104,7 @@ class PopularityMessageCreator(MessageCreator):
     def parse_row(self, row: Dict) -> Optional[Dict]:
         return row
 
-    def create_messages(self, results: DataFrame) -> Iterator[Dict]:
+    def create_messages(self, results: DataFrame, only_inc: bool) -> Iterator[Dict]:
         itr = results.toLocalIterator()
         for chunk in chunked(itr, ROWS_PER_MESSAGE):
             multiple_stats = [row.asDict(recursive=True) for row in chunk]

--- a/listenbrainz_spark/popularity/main.py
+++ b/listenbrainz_spark/popularity/main.py
@@ -30,4 +30,4 @@ def main(type, entity, mlhd):
         engine = MlhdStatsEngine(provider, message_creator)
     else:
         engine = IncrementalStatsEngine(provider, message_creator)
-    return engine.main()
+    return engine.run()

--- a/listenbrainz_spark/popularity/mlhd.py
+++ b/listenbrainz_spark/popularity/mlhd.py
@@ -57,9 +57,9 @@ class MlhdStatsEngine:
         results_df = run_query(results_query)
         return results_df
 
-    def main(self):
+    def run(self):
         results = self.generate_stats()
         yield self.message_creator.create_start_message()
-        for message in self.message_creator.create_messages(results):
+        for message in self.message_creator.create_messages(results, False):
             yield message
         yield self.message_creator.create_end_message()

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -203,7 +203,6 @@ class IncrementalStatsEngine:
             final_df = run_query(final_query)
         else:
             final_df = partial_df
-            self._only_inc = False
 
         self._final_table = f"{prefix}_final_aggregate"
         final_df.createOrReplaceTempView(self._final_table)


### PR DESCRIPTION
1. Speed up MLHD+ imports.
2. Fix popularity data generation.
3. Fix stats for the case where listens have been compacted but no new incremental dump has been imported yet.