### PR TITLE
Fix popularity data generation - II

### DIFF
--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -64,9 +64,9 @@ class PopularityDataset(DatabaseDataset):
         else:
             prefix = "popularity"
         return [
-            f"CREATE INDEX {prefix}_{self.entity}_listen_count_idx_{{suffix}} ON {{table}} (total_listen_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE INDEX {prefix}_{self.entity}_user_count_idx_{{suffix}} ON {{table}} (total_user_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE UNIQUE INDEX {prefix}_{self.entity}_{self.entity}_mbid_idx_{{suffix}} ON {{table}} ({self.entity}_mbid)"
+            f"CREATE INDEX {prefix}_{self.entity}_lc_idx_{{suffix}} ON {{table}} (total_listen_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE INDEX {prefix}_{self.entity}_uc_idx_{{suffix}} ON {{table}} (total_user_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE UNIQUE INDEX {prefix}_{self.entity}_mbid_idx_{{suffix}} ON {{table}} ({self.entity}_mbid)"
         ]
 
 
@@ -120,9 +120,9 @@ class PopularityTopDataset(DatabaseDataset):
         else:
             prefix = "popularity_top"
         return [
-            f"CREATE INDEX {prefix}_{self.entity}_artist_mbid_listen_count_idx_{{suffix}} ON {{table}} (artist_mbid, total_listen_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE INDEX {prefix}_{self.entity}_artist_mbid_user_count_idx_{{suffix}} ON {{table}} (artist_mbid, total_user_count) INCLUDE ({self.entity_mbid})",
-            f"CREATE UNIQUE INDEX {prefix}_{self.entity}_artist_mbid_idx_{{suffix}} ON {{table}} (artist_mbid, {self.entity_mbid})"
+            f"CREATE INDEX {prefix}_{self.entity}_am_lc_idx_{{suffix}} ON {{table}} (artist_mbid, total_listen_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE INDEX {prefix}_{self.entity}_am_uc_idx_{{suffix}} ON {{table}} (artist_mbid, total_user_count) INCLUDE ({self.entity_mbid})",
+            f"CREATE UNIQUE INDEX {prefix}_{self.entity}_am_idx_{{suffix}} ON {{table}} (artist_mbid, {self.entity_mbid})"
         ]
 
 

--- a/listenbrainz_spark/popularity/common.py
+++ b/listenbrainz_spark/popularity/common.py
@@ -113,4 +113,5 @@ class PopularityMessageCreator(MessageCreator):
                 "is_mlhd": self.is_mlhd,
                 "entity": self.entity,
                 "data": multiple_stats,
+                "only_inc": only_inc
             }


### PR DESCRIPTION
1. Add only_inc field to popularity messages.
2. PG automatically truncates long index names leading to conflicts during index creation in atomic table switches. To avoid these issues, shorten index names.