### PR TITLE
LB-1228: Position toast container above music player

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -49,13 +49,14 @@
 @pager-border-radius: @border-radius-base;
 
 @import (inline) "react-toastify/dist/ReactToastify.css";
+
+@import (inline, css) "highlight.js/styles/github.css";
+
 // Show the toasts above the player
 .Toastify__toast-container--bottom-left,
 .Toastify__toast-container--bottom-right {
   bottom: calc(1em + @brainzplayer-height);
 }
-
-@import (inline, css) "highlight.js/styles/github.css";
 
 pre code.hljs {
   max-height: 50vh;

--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -49,6 +49,11 @@
 @pager-border-radius: @border-radius-base;
 
 @import (inline) "react-toastify/dist/ReactToastify.css";
+// Show the toasts above the player
+.Toastify__toast-container--bottom-left,
+.Toastify__toast-container--bottom-right {
+  bottom: calc(1em + @brainzplayer-height);
+}
 
 @import (inline, css) "highlight.js/styles/github.css";
 


### PR DESCRIPTION
The toast messages obstruct the player buttons, especially on mobile sizes where it obstructs all the controls.
Add some CSS to show the toast container above the player.
![image](https://github.com/user-attachments/assets/e1807eb4-18b1-4e8f-a995-7e15a1be1a4e)
