### PR TITLE
Fixed Nonetype error!

### DIFF
--- a/listenbrainz/webserver/views/explore.py
+++ b/listenbrainz/webserver/views/explore.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request, jsonify
+from flask import Blueprint, render_template, request, jsonify, flash, redirect, url_for
 from flask_login import current_user
 from sqlalchemy import text
 
@@ -32,8 +32,15 @@ def artist_similarity():
        ORDER BY total_listen_count DESC
           LIMIT 1
      """))
-
-    artist_mbid = result.fetchone()[0]
+    
+    # artist_mbid = result.fetchone()[0]   #getting error if its return None
+    
+    result_row = result.fetchone()
+    if result_row is None:
+        flash("Artist not found")
+        return redirect(url_for('explore.index'))
+    else:
+        artist_mbid = result_row[0]
     data = {
         "algorithm": "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30",
         "artist_mbid": artist_mbid


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem
<img width="1440" alt="Screenshot 2025-03-21 at 10 48 44 AM" src="https://github.com/user-attachments/assets/05cb56e7-c884-4807-8183-6044f0938eaf" />

I encountered an issue in the `artist_similarity` function within `listenbrainz/webserver/views/explore.py` at line 36. The specific error was a `TypeError: 'NoneType' object is not subscriptable`, which occurred when I tried to access the first element (`[0]`) of a database query result using `artist_mbid = result.fetchone()[0]`. The root cause was that the `fetchone()` method returned `None` when the database query didn’t find any matching records, likely because the artist name or ID I was searching for didn’t exist in the database, or there might be a logic issue in the SQL query itself. This caused the application to crash since I was attempting to index a `None` value, which isn’t possible.

This issue could affect users trying to explore artist similarity if the queried artist isn’t found, leading to an unhandled error instead of a graceful response.


# Solution

To fix this, I modified the `artist_similarity` function to handle the case where `fetchone()` returns `None`. I introduced a new variable, `result_row`, to store the result of `result.fetchone()`. Then, I added a conditional check: if `result_row` is `None`, I flash a message to the user saying "Artist not found" and redirect them to the explore index page. If `result_row` is not `None`, I proceed to extract the `artist_mbid` from `result_row[0]` and continue with the rest of the function as before. This ensures the application doesn’t crash when the artist isn’t found and provides a better user experience by redirecting with a helpful message.

Here’s the updated code for clarity:

```python
result_row = result.fetchone()
if result_row is None:
    flash("Artist not found")
    return redirect(url_for('explore.index'))
else:
    artist_mbid = result_row[0]
data = {
    "algorithm": "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30",
    "artist_mbid": artist_mbid
}
return jsonify(data) 
```

I considered other approaches, like adding a default value for `artist_mbid`, but I felt that redirecting with a flash message was more appropriate for the user experience in this context. I also didn’t modify the underlying SQL query since the issue seems to be more about handling the absence of results rather than a query error, but this could be revisited if needed.

# Action

I’d appreciate it if the reviewers could take a look at the conditional logic I added to ensure it aligns with the project’s standards for error handling and user feedback. Additionally, if there are any suggestions for improving the flash message or the redirect behavior, I’d be happy to incorporate them. No other actions are needed beyond merging the change.


