### PR TITLE
LB-1766: Fix Internal Server Error (500) when accessing listening history

### DIFF
--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import orjson
@@ -162,21 +162,21 @@ class UserViewsTestCase(IntegrationTestCase):
         # max_ts query param -> to_ts timescale param
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'max_ts': 1520946000})
-        req_call = mock.call(user, limit=25, to_ts=datetime.utcfromtimestamp(1520946000))
+        req_call = mock.call(user, limit=25, to_ts=datetime.fromtimestamp(1520946000, timezone.utc)) 
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # min_ts query param -> from_ts timescale param
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000})
-        req_call = mock.call(user, limit=25, from_ts=datetime.utcfromtimestamp(1520941000))
+        req_call = mock.call(user, limit=25, from_ts=datetime.fromtimestamp(1520941000, timezone.utc))
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # If max_ts and min_ts set, only max_ts is used
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000, 'max_ts': 1520946000})
-        req_call = mock.call(user, limit=25, to_ts=datetime.utcfromtimestamp(1520946000))
+        req_call = mock.call(user, limit=25, to_ts=datetime.fromtimestamp(1520946000, timezone.utc))
         timescale.assert_has_calls([req_call])
 
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from math import ceil
 from collections import defaultdict
 
@@ -79,9 +79,9 @@ def profile(user_name):
 
     args = {}
     if max_ts:
-        args['to_ts'] = datetime.utcfromtimestamp(max_ts)
+        args['to_ts'] = datetime.fromtimestamp(max_ts, timezone.utc)
     elif min_ts:
-        args['from_ts'] = datetime.utcfromtimestamp(min_ts)
+        args['from_ts'] = datetime.fromtimestamp(min_ts, timezone.utc)
     data, min_ts_per_user, max_ts_per_user = ts_conn.fetch_listens(
         user.to_dict(), limit=LISTENS_PER_PAGE, **args)
     min_ts_per_user = int(min_ts_per_user.timestamp())


### PR DESCRIPTION
# Problem

In user.py, Timezone isnt being added to the datetime object (making it offset-naive) which is later sent to timescale_listenstore, where its getting compared with another datetime object with timezone i.e min_user_ts. This is leading to ambigous behaviour for users with less amount of listens.
[Ticket](https://tickets.metabrainz.org/browse/LB-1766)

# Solution

Add UTC timezone to both from_ts and to_ts (similar to how we do it in api.py ) .


