### PR TITLE
LB-1739: Sitewide stats: return correct 'count' and total_entity_count

### DIFF
--- a/listenbrainz/testdata/sitewide_top_artists_db.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db.json
@@ -14,5 +14,6 @@
     ],
     "to_ts": 1593043183,
     "stats_range": "all_time",
-    "count": 2
+    "count": 2,
+    "total_artist_count": 123
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test.json
@@ -301,5 +301,6 @@
       "artist_mbid": "12379346-99d9-4941-b4a2-f04144a39863"
     }
   ],
-  "count": 60
+  "count": 60,
+  "total_artist_count": 60
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_month.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_month.json
@@ -301,5 +301,6 @@
       "artist_mbid": "78df245f-0fe0-4a21-b1d4-e79f695354fd"
     }
   ],
-  "count": 60
+  "count": 60,
+  "total_artist_count": 60
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_too_many.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_too_many.json
@@ -1011,5 +1011,6 @@
       "artist_mbid": "218bbe3d-63cc-46bc-8e43-e56a2f6c9829"
     }
   ],
-  "count": 202
+  "count": 202,
+  "total_artist_count": 202
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_week.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_week.json
@@ -1001,5 +1001,6 @@
       "artist_mbid": "a2c1ed01-991f-4a9d-81e0-9b04c8df1c80"
     }
   ],
-  "count": 200
+  "count": 200,
+  "total_artist_count": 200
 }

--- a/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_year.json
+++ b/listenbrainz/testdata/sitewide_top_artists_db_data_for_api_test_year.json
@@ -301,5 +301,6 @@
       "artist_mbid": "a63d3de8-9c39-4320-8199-784df3f4c74c"
     }
   ],
-  "count": 60
+  "count": 60,
+  "total_artist_count": 60
 }

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -245,7 +245,9 @@ class StatsAPITestCase(IntegrationTestCase):
 
         received = orjson.loads(response.data)['payload']
 
-        self.assertEqual(sent['count'], received['count'])
+        singular_entity = entity[:-1] if entity.endswith('s') else entity
+        self.assertEqual(sent[f'total_{singular_entity}_count'], received[f'total_{singular_entity}_count'])
+        self.assertEqual(count, received['count'])
         self.assertEqual(sent['from_ts'], received['from_ts'])
         self.assertEqual(sent['to_ts'], received['to_ts'])
         self.assertEqual(stats_range, received['range'])

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -833,6 +833,7 @@ def get_sitewide_artist():
                 ],
                 "offset": 0,
                 "count": 2,
+                "total_artist_count": 2,
                 "range": "year",
                 "last_updated": 1588494361,
                 "from_ts": 1009823400,
@@ -859,7 +860,7 @@ def get_sitewide_artist():
     :statuscode 400: Bad request, check ``response['error']`` for more details
     :resheader Content-Type: *application/json*
     """
-    return _get_sitewide_stats("artists")
+    return _get_sitewide_stats("artists", "total_artist_count")
 
 
 @stats_api_bp.get("/sitewide/releases")
@@ -900,6 +901,7 @@ def get_sitewide_release():
                 ],
                 "offset": 0,
                 "count": 2,
+                "total_release_count": 2,
                 "range": "year",
                 "last_updated": 1588494361,
                 "from_ts": 1009823400,
@@ -926,7 +928,7 @@ def get_sitewide_release():
     :statuscode 400: Bad request, check ``response['error']`` for more details
     :resheader Content-Type: *application/json*
     """
-    return _get_sitewide_stats("releases")
+    return _get_sitewide_stats("releases", "total_release_count")
 
 
 @stats_api_bp.get("/sitewide/release-groups")
@@ -970,6 +972,7 @@ def get_sitewide_release_group():
                 ],
                 "offset": 0,
                 "count": 2,
+                "total_release_group_count": 2,
                 "range": "year",
                 "last_updated": 1588494361,
                 "from_ts": 1009823400,
@@ -995,7 +998,7 @@ def get_sitewide_release_group():
     :statuscode 400: Bad request, check ``response['error']`` for more details
     :resheader Content-Type: *application/json*
     """
-    return _get_sitewide_stats("release_groups")
+    return _get_sitewide_stats("release_groups", "total_release_group_count")
 
 
 @stats_api_bp.get("/sitewide/recordings")
@@ -1033,6 +1036,7 @@ def get_sitewide_recording():
                 ],
                 "offset": 0,
                 "count": 2,
+                "total_recording_count": 2,
                 "range": "year",
                 "last_updated": 1588494361,
                 "from_ts": 1009823400,
@@ -1060,10 +1064,10 @@ def get_sitewide_recording():
     :statuscode 400: Bad request, check ``response['error']`` for more details
     :resheader Content-Type: *application/json*
     """
-    return _get_sitewide_stats("recordings")
+    return _get_sitewide_stats("recordings", "total_recording_count")
 
 
-def _get_sitewide_stats(entity: str, entire_range: bool = False):
+def _get_sitewide_stats(entity: str, count_key: str, entire_range: bool = False):
     stats_range = request.args.get("range", default="all_time")
     if not _is_valid_range(stats_range):
         raise APIBadRequest(f"Invalid range: {stats_range}")
@@ -1077,7 +1081,7 @@ def _get_sitewide_stats(entity: str, entire_range: bool = False):
 
     count = min(count, MAX_ITEMS_PER_GET)
     total_entity_count = stats["count"]
-    
+
     if entire_range:
         entity_list = stats["data"]
     else:
@@ -1088,7 +1092,8 @@ def _get_sitewide_stats(entity: str, entire_range: bool = False):
             entity: entity_list,
             "range": stats_range,
             "offset": offset,
-            "count": total_entity_count,
+            "count": count,
+            count_key: total_entity_count,
             "from_ts": stats["from_ts"],
             "to_ts": stats["to_ts"],
             "last_updated": stats["last_updated"]


### PR DESCRIPTION
Currently the total entity count is returned as 'count' instead of the expected count of results.
Said count is useful to calculate pagination options, and the total entity count also useful for a variety of things.

Adapt these sitewide stats endpoints to return the same format as user stats with count and total_{entity}_count (adapted to each entity name), using the same `count_key` attribute as is used in the `_get_entity_stats` function.
Basically adapting sitewide stats to work the same and return the same data as user stats.
