### PR TITLE
UserFeed: improve empty or incomplete "thank you" events

### DIFF
--- a/frontend/js/src/user-feed/UserFeed.tsx
+++ b/frontend/js/src/user-feed/UserFeed.tsx
@@ -779,6 +779,10 @@ export default function UserFeedPage() {
                       const subEvent = events?.find(
                         (evt) => evt.id === original_event_id && evt.event_type === original_event_type
                       );
+                      if(!subEvent){
+                        // Search for the event?
+                        subEventElement = <div className="muted">Load more evens to preview this older event</div>
+                      }
                       subEventElement = renderSubEvent(subEvent);
                     }
 

--- a/frontend/js/src/user-feed/UserFeed.tsx
+++ b/frontend/js/src/user-feed/UserFeed.tsx
@@ -523,6 +523,9 @@ export default function UserFeedPage() {
     }
     if (event.event_type === EventType.THANKS && !event.hidden) {
       const { metadata } = event as TimelineEvent<ThanksMetadata>;
+      if(!metadata?.blurb_content?.length){
+        return null;
+      }
       return (
         <div className="event-content">
           <Card className="listen-card">


### PR DESCRIPTION
This PR fixes two issue with missing content regarding thank you events in the user feed.

1. An empty listencard is rendered when there is no text content (text is optional for this event)
2. Show a placeholder instead of nothing when the original recommendation event is not on the page
 
We currently show a preview of the original recommendation using the events currently shown on the page, basically rendering it again under the thank you event for context.
But if the event is older than the current events shown on the page, it does not render anything, which is  confusing for users. It can be "fixed" by loading more events until the original one is retrieved. Far from ideal...

We should implement a way to fetch an event by ID, which I don't think currently exists in the API.
This would be the right solution to show the context of the thank yo event, and the placeholder added in this PR is just to make do for now.


Before:
![image](https://github.com/user-attachments/assets/d03c3038-4b34-44f4-8baf-46d3385d0760)

After:
![image](https://github.com/user-attachments/assets/273fa31d-b2f2-4bb6-a305-3a8cd0db1486)


