### PR TITLE
LB-1779: Catch image load errors when using Vibrant

### DIFF
--- a/frontend/js/src/album/AlbumPage.tsx
+++ b/frontend/js/src/album/AlbumPage.tsx
@@ -112,7 +112,9 @@ export default function AlbumPage(): JSX.Element {
       .getPalette()
       .then((palette) => {
         setAlbumArtPalette(palette);
-      });
+      })
+      // eslint-disable-next-line no-console
+      .catch(console.error);
   }, []);
 
   React.useEffect(() => {

--- a/frontend/js/src/metadata-viewer/components/MetadataViewer.tsx
+++ b/frontend/js/src/metadata-viewer/components/MetadataViewer.tsx
@@ -72,7 +72,9 @@ export default function MetadataViewer(props: MetadataViewerProps) {
       .getPalette()
       .then((palette) => {
         setAlbumArtPalette(palette);
-      });
+      })
+      // eslint-disable-next-line no-console
+      .catch(console.error);
   }, []);
   const backgroundGradient = albumArtPalette
     ? `linear-gradient(to bottom, ${albumArtPalette?.Vibrant?.hex} 60%, ${albumArtPalette?.DarkVibrant?.hex})`


### PR DESCRIPTION
I have been seeing some errors on Sentry after introducing Vibrant in the album page to get color palettes (#3238).

The issue is that if image loading fails, an error is thrown by the library and not caught in our code, resulting in an error page.
Catching the error and logging to console ensures we don't end up with an error page, although i will need to investigate the root cause of the issue (CORS errors it looks like, sob).
Printing the error to the console, as I don't think there is anything else we want to do with that error (the result is only cosmetic).

One thing that I find confusing is that despite the error status of the request, it has a 200 status code and the image does seem to have been loaded, as I do see the color extract from the image.
Not sure what is happening there, but in the meantime this PR prevents the bug making the album pages unusable.