### PR TITLE
UserFeed: improve missing "thank you" events preview (Part II)

### DIFF
--- a/frontend/js/src/user-feed/ThanksModal.tsx
+++ b/frontend/js/src/user-feed/ThanksModal.tsx
@@ -76,8 +76,8 @@ export default NiceModal.create(
             if (status === 200) {
               toast.success(
                 <ToastMsg
-                  title={`You thanked this ${original_event_type}`}
-                  message="OK"
+                  title="Success"
+                  message={`You thanked this ${original_event_type}`}
                 />,
                 { toastId: "thanks-success" }
               );

--- a/frontend/js/src/user-feed/UserFeed.tsx
+++ b/frontend/js/src/user-feed/UserFeed.tsx
@@ -222,7 +222,17 @@ export default function UserFeedPage() {
           queryFn: () => APIService.getFeedEvent(eventId, currentUser.name, currentUser.auth_token as string),
         });
       });
-      const resultsArray:TimelineEvent<EventMetadata>[] = await Promise.all(promises);
+      const resultsArray:TimelineEvent<EventMetadata>[] = [];
+      const promiseResults = await Promise.allSettled(promises);
+      promiseResults.forEach((res,idx) => {
+        if(res.status === "fulfilled"){
+          resultsArray.push(res.value);
+        }
+        else{
+          // eslint-disable-next-line no-console
+          console.error(res.reason);
+        }
+      })
       setSeparatelyLoadedEvents(resultsArray);
     }
     const feedEvents = data?.pages.map((page) => page.events).flat();
@@ -654,7 +664,7 @@ export default function UserFeedPage() {
   };
 
   const renderSubEvent = (subEvent: TimelineEvent<EventMetadata> | undefined) => {
-    if (!subEvent) return <div className="muted">Load more evens to preview this older event</div>;
+    if (!subEvent) return <div className="muted">This event was deleted or cannot be loaded</div>;
 
     return (
       <div>

--- a/frontend/js/src/user-feed/UserFeed.tsx
+++ b/frontend/js/src/user-feed/UserFeed.tsx
@@ -6,7 +6,7 @@ import {
   faComments,
   faEye,
   faEyeSlash,
-  faHandshake,
+  faHandHoldingHeart,
   faHeadphones,
   faHeart,
   faPaperPlane,
@@ -104,7 +104,7 @@ function getEventTypeIcon(eventType: EventTypeT) {
     case EventType.PERSONAL_RECORDING_RECOMMENDATION:
       return faPaperPlane;
     case EventType.THANKS:
-      return faHandshake;
+      return faHandHoldingHeart;
     default:
       return faQuestion;
   }
@@ -457,9 +457,10 @@ export default function UserFeedPage() {
         <>
           { isThankable && (
             <ListenControl
-              title="Thanks"
+              title="Say thanks"
               text=""
-              icon={faHandshake}
+              icon={faHandHoldingHeart}
+              iconSize="lg"
               buttonClassName="btn btn-link btn-xs"
               action={() => {
                 NiceModal.show(ThanksModal, {
@@ -475,6 +476,7 @@ export default function UserFeedPage() {
             title="Unhide Event"
             text=""
             icon={faEye}
+            iconSize="lg"
             buttonClassName="btn btn-link btn-xs"
             action={() => {
               hideEventMutation(event);
@@ -485,6 +487,7 @@ export default function UserFeedPage() {
             title="Hide Event"
             text=""
             icon={faEyeSlash}
+            iconSize="lg"
             buttonClassName="btn btn-link btn-xs"
             action={() => {
               hideEventMutation(event);
@@ -495,6 +498,7 @@ export default function UserFeedPage() {
             title="Delete Event"
             text=""
             icon={faTrash}
+            iconSize="lg"
             buttonClassName="btn btn-link btn-xs"
             action={() => {
               deleteEventMutation(event);
@@ -835,7 +839,7 @@ export default function UserFeedPage() {
                               <FontAwesomeIcon
                                 icon={getEventTypeIcon(event_type) as IconProp}
                                 inverse
-                                transform="shrink-4"
+                                transform="shrink-3"
                                 fixedWidth
                               />
                             </span>

--- a/frontend/js/src/user-feed/UserFeed.tsx
+++ b/frontend/js/src/user-feed/UserFeed.tsx
@@ -215,7 +215,7 @@ export default function UserFeedPage() {
   >([]);
 
   React.useEffect(() => {
-    async function fetchOGEvents(missingEventsIDs: number[]) {
+    async function fetchThankedEvents(missingEventsIDs: number[]) {
       // Prefetch each missing original event missing from thank you events
       // separately from fetching the feed pages
       const promises = missingEventsIDs.map((eventId) => {
@@ -253,7 +253,7 @@ export default function UserFeedPage() {
       (originalEventId) => !feedEvents?.some((ev) => ev.id === originalEventId)
     );
     if (missingEventsIDs?.length) {
-      fetchOGEvents(missingEventsIDs);
+      fetchThankedEvents(missingEventsIDs);
     }
   }, [data, APIService, currentUser, queryClient]);
 

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1385,6 +1385,25 @@ export default class APIService {
     return response.json();
   };
 
+  getFeedEvent = async (
+    eventId: number,
+    username: string,
+    userToken: string
+  ): Promise<any> => {
+    if (!eventId) {
+      throw new SyntaxError("Event ID not present");
+    }
+    const query = `${this.APIBaseURI}/user/${username}/feed/events/${eventId}`;
+    const response = await fetch(query, {
+      method: "GET",
+      headers: {
+        Authorization: `Token ${userToken}`,
+      },
+    });
+    await this.checkStatus(response);
+    return response.json();
+  };
+
   deleteFeedEvent = async (
     eventType: string,
     username: string,

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1389,7 +1389,7 @@ export default class APIService {
     eventId: number,
     username: string,
     userToken: string
-  ): Promise<any> => {
+  ): Promise<TimelineEvent<EventMetadata>> => {
     if (!eventId) {
       throw new SyntaxError("Event ID not present");
     }
@@ -1401,7 +1401,8 @@ export default class APIService {
       },
     });
     await this.checkStatus(response);
-    return response.json();
+    const result = await response.json();
+    return result.payload.events?.[0];
   };
 
   deleteFeedEvent = async (

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -295,7 +295,7 @@ def user_feed(user_name: str):
     }})
 
 
-@user_timeline_event_api_bp.get('/user/<user_name>/feed/events/<event_id>')
+@user_timeline_event_api_bp.get('/user/<string:user_name>/feed/events/<int:event_id>')
 @crossdomain
 @ratelimit()
 @api_listenstore_needed

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -324,11 +324,21 @@ def user_feed_event(user_name: str, event_id: int):
     user_event = db_user_timeline_event.get_user_timeline_event_by_id(
         db_conn, event_id)
 
-    _ = fetch_track_metadata_for_items(
-        ts_conn, [user_event.metadata])
-
     if not user_event:
         raise APIBadRequest(f"Event with id {event_id} not found")
+
+    # Get metadata for event
+    _ = fetch_track_metadata_for_items(ts_conn, [user_event.metadata])
+
+    # Format the event
+    user_event = APITimelineEvent(
+        id=user_event.id,
+        event_type=user_event.event_type.value,
+        user_name=user_name,
+        created=user_event.created.timestamp(),
+        metadata=user_event.metadata,
+        hidden=False,
+    )
 
     # Sadly, we need to serialize the event_type ourselves, otherwise, jsonify converts it badly.
     user_event.event_type = user_event.event_type.value

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -325,7 +325,7 @@ def user_feed_event(user_name: str, event_id: int):
         db_conn, event_id)
 
     if not user_event:
-        raise APIBadRequest(f"Event with id {event_id} not found")
+        raise APINotFound(f"Event with id {event_id} not found")
 
     # Get metadata for event
     _ = fetch_track_metadata_for_items(ts_conn, [user_event.metadata])

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -340,9 +340,6 @@ def user_feed_event(user_name: str, event_id: int):
         hidden=False,
     )
 
-    # Sadly, we need to serialize the event_type ourselves, otherwise, jsonify converts it badly.
-    user_event.event_type = user_event.event_type.value
-
     return jsonify({'payload': {
         'count': 1,
         'user_id': user_name,


### PR DESCRIPTION
Following in the steps of #3242 I wanted to add a better system than showing a placeholder for missing thank you events previews.

For this event type, we show a preview of the original event underneath it.
We sometimes do not have the original event in the currently loaded pages of events tough, as they may be older events.

This PR adds an API endpoint and some front-end query cache magic to load these missing events separately when needed.

Before:
![image](https://github.com/user-attachments/assets/20275e4c-4930-4a08-87e6-e992256ceb90)
After:
![image](https://github.com/user-attachments/assets/625d2cf7-d65f-4fd8-a7ff-c70c8887fa4f)

In case the original event was deleted in the meantime, or in case of unforeseen issues:
![image](https://github.com/user-attachments/assets/71e05ede-207f-49fc-8306-5a63c8caf512)