### PR TITLE
LB-1778: Use artist_mbid in artist activity chart

### DIFF
--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -292,6 +292,7 @@ declare type UserArtistActivityResponse = {
   result: Array<{
     name: string;
     listen_count: number;
+    artist_mbid: string | null;
     albums: Array<{
       name: string;
       listen_count: number;

--- a/listenbrainz/db/metadata.py
+++ b/listenbrainz/db/metadata.py
@@ -3,7 +3,7 @@ import psycopg2.extras
 
 from listenbrainz.db.model.metadata import RecordingMetadata, ArtistMetadata, ReleaseGroupMetadata
 from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_GET
-from typing import List
+from typing import List, Dict
 
 
 def fixup_mbids_to_artists(row):
@@ -83,10 +83,10 @@ def get_metadata_for_artist(ts_conn, artist_mbid_list: List[str]) -> List[Artist
         to recording_mbid
 
         Args:
-            artist_mbid_list: A list of recording_mbids to fetch metadata for
+            artist_mbid_list: A list of artist_mbids to fetch metadata for
 
         Returns:
-            A list of RecordingMetadata objects
+            A list of ArtistMetadata objects
     """
 
     artist_mbid_list = tuple(artist_mbid_list)

--- a/listenbrainz/db/metadata.py
+++ b/listenbrainz/db/metadata.py
@@ -3,7 +3,7 @@ import psycopg2.extras
 
 from listenbrainz.db.model.metadata import RecordingMetadata, ArtistMetadata, ReleaseGroupMetadata
 from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_GET
-from typing import List, Dict
+from typing import List
 
 
 def fixup_mbids_to_artists(row):

--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -1,30 +1,14 @@
 import json
-from copy import deepcopy
-from datetime import datetime
-from unittest.mock import patch
 
-import requests
 import orjson
+import requests
 from brainzutils.ratelimit import set_rate_limits
 
 import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
-import requests_mock
-
-from data.model.user_artist_map import UserArtistMapRecord
-
-from listenbrainz.config import LISTENBRAINZ_LABS_API_URL
 from listenbrainz.db import couchdb
 from listenbrainz.spark.handlers import handle_entity_listener
 from listenbrainz.tests.integration import IntegrationTestCase
-
-
-class MockDate(datetime):
-    """ Mock class for datetime which returns epoch """
-
-    @classmethod
-    def now(cls, tzinfo=None):
-        return cls.fromtimestamp(0)
 
 
 class StatsAPITestCase(IntegrationTestCase):
@@ -366,7 +350,6 @@ class StatsAPITestCase(IntegrationTestCase):
                     expected["user_id"] = self.user["id"]
                 self.assertDailyActivityEqual(expected, response)
 
-    @patch('listenbrainz.webserver.views.stats_api.datetime', MockDate)
     def test_artist_map_stat(self):
         endpoint = self.non_entity_endpoints["artist_map"]["endpoint"]
         with self.subTest(f"test valid response is received for artist_map stats"):

--- a/listenbrainz/webserver/models.py
+++ b/listenbrainz/webserver/models.py
@@ -1,3 +1,5 @@
+from typing import TypedDict, Optional, Any, Dict, List
+
 import pydantic
 
 
@@ -5,3 +7,18 @@ class SubmitListenUserMetadata(pydantic.BaseModel):
     """ Represents the fields of a user required in submission pipeline"""
     musicbrainz_id: str
     user_id: int
+
+
+class ArtistActivityArtistEntry(TypedDict):
+    name: str
+    artist_mbid: Optional[str]
+    listen_count: int
+    albums: Dict[str, Dict]
+
+
+class ArtistActivityReleaseGroupData(TypedDict):
+    listen_count: int
+    release_group_name: str
+    release_group_mbid: Optional[str]
+    artist_name: Optional[str]
+    artists: Optional[List[Dict[str, str]]]

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -438,7 +438,7 @@ def _build_artist_activity_entries(
 
 
 def _get_artist_activity(release_groups_list):
-    result = {}
+    result: dict = {}
     for release_group in release_groups_list:
         if artists := release_group.get("artists"):
             for artist in artists:
@@ -452,18 +452,19 @@ def _get_artist_activity(release_groups_list):
         item["albums"] = list(item["albums"].values())
 
     top_results = heapq.nlargest(15, result.values(), key=lambda x: x["listen_count"])
+
     artist_mbids = [x["artist_mbid"] for x in top_results if x["artist_mbid"] is not None]
-    metadata = get_metadata_for_artist(ts_conn, artist_mbids)
-
-    # replace credited artist name on release group with artist name where possible
-    artist_mbid_name_map = {}
-    for item in metadata:
-        artist_mbid_name_map[str(item.artist_mbid)] = item.artist_data["name"]
-
-    for result in top_results:
-        artist_mbid = result["artist_mbid"]
-        if artist_mbid in artist_mbid_name_map:
-            result["artist_name"] = artist_mbid_name_map[artist_mbid]
+    if artist_mbids:
+        metadata = get_metadata_for_artist(ts_conn, artist_mbids)
+        # replace credited artist name on release group with artist name where possible
+        artist_mbid_name_map: dict[str, str] = {
+            str(item.artist_mbid): item.artist_data["name"]
+            for item in metadata
+        }
+        for result in top_results:
+            artist_mbid = result["artist_mbid"]
+            if artist_mbid in artist_mbid_name_map:
+                result["artist_name"] = artist_mbid_name_map[artist_mbid]
 
     return top_results
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -411,7 +411,27 @@ def get_listening_activity(user_name: str):
 
 
 def _build_artist_activity_entries(result, artist_name, artist_mbid, release_group):
-    listen_count = release_group["listen_count"]
+
+class ArtistEntry(TypedDict):
+    name: str
+    artist_mbid: Optional[str]
+    listen_count: int
+    albums: Dict[str, Any]
+
+class ReleaseGroupData(TypedDict):
+    listen_count: int
+    release_group_name: str
+    release_group_mbid: Optional[str]
+    artist_name: Optional[str]
+    artists: Optional[List[Dict[str, str]]]
+
+
+def _build_artist_activity_entries(
+    result: Dict[str, ArtistEntry],
+    artist_name: str,
+    artist_mbid: Optional[str],
+    release_group: ReleaseGroupData
+) -> None:
     release_group_name = release_group["release_group_name"]
     release_group_mbid = release_group.get("release_group_mbid")
 


### PR DESCRIPTION
Group artists based on mbid instead of name if available in activity stats. Also, replace the credited artist name on release groups with the artist's main name where available using artist_mbid for consistency.