### PR TITLE
LB-1782 Fixed volume slider for full screen player

### DIFF
--- a/frontend/js/src/common/brainzplayer/VolumeControlButton.tsx
+++ b/frontend/js/src/common/brainzplayer/VolumeControlButton.tsx
@@ -3,7 +3,7 @@ import { useBrainzPlayerDispatch } from "./BrainzPlayerContext";
 
 function VolumeControlButton() {
   const dispatch = useBrainzPlayerDispatch();
-  const handleVolumeChange = (e: React.MouseEvent<HTMLInputElement>) => {
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch({
       type: "VOLUME_CHANGE",
       data: e.currentTarget?.value ?? 100,
@@ -11,7 +11,7 @@ function VolumeControlButton() {
   };
   return (
     <input
-      onMouseUp={handleVolumeChange}
+      onChange={handleVolumeChange}
       className="volume-input"
       type="range"
       defaultValue="100"


### PR DESCRIPTION

# Problem
[LB - 1782](https://tickets.metabrainz.org/browse/LB-1782): Changing volume with the fullscreen player does nothing on mobile browsers.

<img width="1440" alt="Screenshot 2025-04-10 at 12 03 42 AM" src="https://github.com/user-attachments/assets/42310ebf-3f21-4c09-8cbf-4d83ff480106" />

There was very basic issue in the existing code `listenbrainzserver/frontend/js/src/common/brainzplayer/VolumeControlButton.tsx` where  using  `onMouseUp` which was creating issue on full screen(mobile browsers mostly).
```typescript
const handleVolumeChange = (e: React.MouseEvent<HTMLInputElement>) => {
    dispatch({ 

      };
      return (
        <input
          onMouseUp={handleVolumeChange}

}

export default VolumeControlButton;
```

# Solution
I have simply Changed the event type as well as event handler which make sure that volume slider works on both desktop browsers as well mobile browsers(full screen).
`React.MouseEvent --> React.ChangeEvent` && `onMouseUp --> onChange`
```typescript 
const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    dispatch({

    
  };
  return (
    <input
      onChange={handleVolumeChange}
    
}

export default VolumeControlButton;
```





