### PR TITLE
LB-1783: Better multi-line split for artist on Artist Activity graph

### DIFF
--- a/frontend/js/src/user/stats/components/UserArtistActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserArtistActivity.tsx
@@ -52,15 +52,28 @@ export default function UserArtistActivity(props: UserArtistActivityProps) {
     errorMessage = "",
   } = loaderData || {};
 
+  const wrapWordsByLength = (str: string, maxLen: number): string => {
+    const words = str.split(" ");
+    let lines: string[] = [];
+    let currentLine = words[0];
+    for (let i = 1; i < words.length; i++) {
+      if (currentLine.length + 1 + words[i].length <= maxLen) {
+        currentLine += " " + words[i];
+      } else {
+        lines.push(currentLine);
+        currentLine = words[i];
+      }
+    }
+    lines.push(currentLine);
+    return lines.join("\n");
+  };
+
   const processData = (data?: UserArtistActivityResponse) => {
     if (!data || !data.result || data.result.length === 0) {
       return [];
     }
     return data.result.map((artist) => {
-      let wrappedLabel = artist.name.replace(/(.{14})/g, "$1-\n");
-      if (wrappedLabel.endsWith("-\n")) {
-        wrappedLabel = wrappedLabel.slice(0, -2); // Remove the last hyphen and keep the newline
-      }
+      const wrappedLabel = wrapWordsByLength(artist.name, 14);
       return {
         label: wrappedLabel,
         ...artist.albums.reduce(

--- a/frontend/js/src/user/stats/components/UserArtistActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserArtistActivity.tsx
@@ -54,11 +54,11 @@ export default function UserArtistActivity(props: UserArtistActivityProps) {
 
   const wrapWordsByLength = (str: string, maxLen: number): string => {
     const words = str.split(" ");
-    let lines: string[] = [];
+    const lines: string[] = [];
     let currentLine = words[0];
     for (let i = 1; i < words.length; i++) {
       if (currentLine.length + 1 + words[i].length <= maxLen) {
-        currentLine += " " + words[i];
+        currentLine += ` ${words[i]}`;
       } else {
         lines.push(currentLine);
         currentLine = words[i];


### PR DESCRIPTION
# Problem

[LB-1783: Better multi-line split for artist on Artist Activity graph
](https://tickets.metabrainz.org/projects/LB/issues/LB-1783?filter=allopenissues&orderby=created+DESC%2C+priority+DESC%2C+updated+DESC)

# Solution

![image](https://github.com/user-attachments/assets/7c21e2b8-b658-436c-9d3a-6a5cfb8c8ff7)

Made changes to do a split on the words instead of the characters individually.

# Action

- Let me know if any additional details or corrections are required.
- If the changes look good, kindly proceed with merging the PR.
