### PR TITLE
LB-1630: Dashboard for users with sporadic listens loads slowly

### DIFF
--- a/frontend/js/tests/__mocks__/recentListensProps.json
+++ b/frontend/js/tests/__mocks__/recentListensProps.json
@@ -1033,6 +1033,8 @@
       ],
     "oldestListenTs": 1586440000,
     "latestListenTs": 1586523524,
+    "searchStartTs": 1586523524,
+    "searchEndTs": 1552827524,
     "latestSpotifyUri": "spotify:track:5svEhroDfeTt0ePvASUtZ6",
     "artistCount": null,
     "userPinnedRecording": {

--- a/frontend/js/tests/common/listens/ListensControls.test.tsx
+++ b/frontend/js/tests/common/listens/ListensControls.test.tsx
@@ -27,12 +27,16 @@ const {
   oldestListenTs,
   user,
   currentUser,
+  searchStartTs,
+  searchEndTs,
 } = recentListensPropsOneListen;
 
 const props: ListensProps = {
   latestListenTs,
   listens,
   oldestListenTs,
+  searchStartTs,
+  searchEndTs,
   user,
   already_reported_user: false,
 };

--- a/frontend/js/tests/user/Dashboard.test.tsx
+++ b/frontend/js/tests/user/Dashboard.test.tsx
@@ -37,6 +37,8 @@ const {
   oldestListenTs,
   user,
   userPinnedRecording,
+  searchStartTs,
+  searchEndTs,
 } = recentListensProps;
 
 const props: ListensProps = {
@@ -44,6 +46,8 @@ const props: ListensProps = {
   listens,
   oldestListenTs,
   user,
+  searchStartTs,
+  searchEndTs,
   userPinnedRecording,
   already_reported_user: false,
 };

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -82,10 +82,12 @@ def profile(user_name):
         args['to_ts'] = datetime.fromtimestamp(max_ts, timezone.utc)
     elif min_ts:
         args['from_ts'] = datetime.fromtimestamp(min_ts, timezone.utc)
-    data, min_ts_per_user, max_ts_per_user = ts_conn.fetch_listens(
+    data, min_ts_per_user, max_ts_per_user, search_start_ts, search_end_ts = ts_conn.fetch_listens(
         user.to_dict(), limit=LISTENS_PER_PAGE, **args)
     min_ts_per_user = int(min_ts_per_user.timestamp())
     max_ts_per_user = int(max_ts_per_user.timestamp())
+    search_start_ts = int(search_start_ts.timestamp())
+    search_end_ts = int(search_end_ts.timestamp())
 
     listens = []
     for listen in data:
@@ -116,6 +118,9 @@ def profile(user_name):
         "playingNow": playing_now,
         "logged_in_user_follows_user": logged_in_user_follows_user(user),
         "already_reported_user": already_reported_user,
+        "searchStartTs": search_start_ts,
+        "searchEndTs": search_end_ts,
+
     }
 
     return jsonify(data)


### PR DESCRIPTION

# Problem

Slow lookup times for users with sporadic listens. [Ticket.](https://tickets.metabrainz.org/browse/LB-1630)


# Solution

1. Changed the maximum number of passes from 10 to 3, fixing the maximum size of search window to 9 months in one pass.
2. Api returns search_start_ts and search_end_ts so that frontend uses these timestamps and doesnt make redundant requests.
3. If listens are less than expected, render a Load More listens button which uses the search_end_ts as max_ts and makes next request.



