### PR TITLE
LB-1477: Make Youtube thumbnails a fallback option

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -939,11 +939,6 @@ const getAlbumArtFromListenMetadata = async (
     const trackID = SpotifyPlayer.getSpotifyTrackIDFromListen(listen);
     return getAlbumArtFromSpotifyTrackID(trackID, spotifyUser);
   }
-  if (YoutubePlayer.isListenFromThisService(listen)) {
-    const videoId = YoutubePlayer.getVideoIDFromListen(listen);
-    const images = YoutubePlayer.getThumbnailsFromVideoid(videoId);
-    return images?.[0].src;
-  }
   /** Could not load image from music service, fetching from CoverArtArchive if MBID is available */
   // directly access additional_info.release_mbid instead of using getReleaseMBID because we only want
   // to query CAA for user submitted mbids.
@@ -971,6 +966,13 @@ const getAlbumArtFromListenMetadata = async (
   // user submitted release mbids not found, check if there is a match from mbid mapper.
   if (caaId && caaReleaseMbid) {
     return generateAlbumArtThumbnailLink(caaId, caaReleaseMbid);
+  }
+  /* We are putting Youtube thumbnails as last resort fallback as the quality
+  and format is usually not very good, user preferring proper cover art. */
+  if (YoutubePlayer.isListenFromThisService(listen)) {
+    const videoId = YoutubePlayer.getVideoIDFromListen(listen);
+    const images = YoutubePlayer.getThumbnailsFromVideoid(videoId);
+    return images?.[0].src;
   }
   return undefined;
 };


### PR DESCRIPTION
We are putting Youtube thumbnails as last resort fallback as the quality and format is usually not very good, and after some discussion our users prefer better cover art options if available.

As discussed in https://community.metabrainz.org/t/youtube-listeners-should-we-get-rid-of-youtube-video-thumbnails/754171

Before:
![image](https://github.com/user-attachments/assets/4d402871-abb3-4f6c-81fb-639ae0bd522a)

After:
![image](https://github.com/user-attachments/assets/4765ea24-931c-4ad1-94aa-07efa1207f15)

