### PR TITLE
Fix event_type enum serialization

### DIFF
--- a/listenbrainz/db/model/user_timeline_event.py
+++ b/listenbrainz/db/model/user_timeline_event.py
@@ -19,7 +19,7 @@
 from pydantic import BaseModel, NonNegativeInt, constr, conlist
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Union, Optional, List
 
 from data.model.listen import APIListen, TrackMetadata
@@ -27,7 +27,7 @@ from listenbrainz.db.model.review import CBReviewTimelineMetadata
 from listenbrainz.db.msid_mbid_mapping import MsidMbidModel
 
 
-class UserTimelineEventType(Enum):
+class UserTimelineEventType(StrEnum):
     RECORDING_RECOMMENDATION = 'recording_recommendation'
     FOLLOW = 'follow'
     LISTEN = 'listen'

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -211,10 +211,6 @@ def feed():
 
     user_events = user_events[:count]
 
-    # Sadly, we need to serialize the event_type ourselves, otherwise, jsonify converts it badly.
-    for index, event in enumerate(user_events):
-        user_events[index].event_type = event.event_type.value
-
     return jsonify({
         'events': [event.dict() for event in user_events],
     })

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -282,10 +282,6 @@ def user_feed(user_name: str):
     user_events = get_feed_events_for_user(
         user=user, followed_users=users_following, min_ts=min_ts, max_ts=max_ts, count=count)
 
-    # Sadly, we need to serialize the event_type ourselves, otherwise, jsonify converts it badly.
-    for index, event in enumerate(user_events):
-        user_events[index].event_type = event.event_type.value
-
     user_events = user_events[:count]
 
     return jsonify({'payload': {
@@ -333,7 +329,7 @@ def user_feed_event(user_name: str, event_id: int):
     # Format the event
     user_event = APITimelineEvent(
         id=user_event.id,
-        event_type=user_event.event_type.value,
+        event_type=user_event.event_type,
         user_name=user_name,
         created=user_event.created.timestamp(),
         metadata=user_event.metadata,
@@ -389,10 +385,6 @@ def user_feed_listens_following(user_name: str):
         listen_events = get_all_listen_events(
             users_following, min_ts, max_ts, count)
 
-    # Sadly, we need to serialize the event_type ourselves, otherwise, jsonify converts it badly.
-    for index, event in enumerate(listen_events):
-        listen_events[index].event_type = event.event_type.value
-
     return jsonify({'payload': {
         'count': len(listen_events),
         'user_id': user_name,
@@ -447,9 +439,7 @@ def user_feed_listens_similar(user_name: str):
     id_similarity_map = {user["musicbrainz_id"]
         : user["similarity"] for user in similar_users}
 
-    # Sadly, we need to serialize the event_type ourselves, otherwise, jsonify converts it badly.
     for index, event in enumerate(listen_events):
-        listen_events[index].event_type = event.event_type.value
         listen_events[index].similarity = id_similarity_map[event.user_name]
 
     return jsonify({


### PR DESCRIPTION
Json serialization of enum string values fails, forcing us to manually serialize the value.
There are a few instances of us doing that in the codebase.
I didn't do the conversion properly in #3247 , but it seemd like a very annoying and easy to forget little obstacle, so I looked into it closer to avoid future copy-paste issues or people like me just not knowing why this needs to be done.

It turns out we can make the enum a subclass of 'str' and that will be enough of a hint for json serialization to workv just fine... Thanks internet stranger! https://stackoverflow.com/a/51976841/4904467

For minimal testing: https://www.online-python.com/xBoJlNdSML