### PR TITLE
Fixed Spotify Redirect URL for Local Development

### DIFF
--- a/docs/developers/devel-env.rst
+++ b/docs/developers/devel-env.rst
@@ -108,7 +108,7 @@ Update the ``LASTFM_API_KEY`` field with your Last.fm API key.
 You also need to update the ``API_URL`` field value to ``http://localhost:8100``.
 
 To use the Spotify importer you need to register an application on the
-`Spotify Developer Dashboard`_. Use ``http://localhost:8100/settings/music-services/spotify/callback/``
+`Spotify Developer Dashboard`_. Use ``https://127.0.0.1:8100/settings/music-services/spotify/callback/``
 as the callback URL.
 
 After that, fill out the Spotify client ID and client secret in the following

--- a/frontend/js/src/utils/Playlist.ts
+++ b/frontend/js/src/utils/Playlist.ts
@@ -7,9 +7,9 @@ import {
 
 export default async function enrichJSPFTracks(
   tracks: JSPFObject["playlist"]["track"],
-  api: APIService,
+  api: APIService
 ): Promise<
-(JSPFObject["playlist"]["track"][number] & {
+  (JSPFObject["playlist"]["track"][number] & {
     duration?: number;
     extension?: {
       [key: string]: {

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -155,9 +155,10 @@ APPROVED_PLAYLIST_BOTS = ['troi-bot', 'troi-bot-debug']
 WHITELISTED_AUTH_TOKENS = []
 
 # SPOTIFY
+# Note: Spotify now requires the redirect url to use HTTPS and an explicit loopback IP address (127.0.0.1) instead of 'localhost'
 SPOTIFY_CLIENT_ID = 'needs a non empty default value for tests, change this'
 SPOTIFY_CLIENT_SECRET = 'needs a non empty default value for tests, change this'
-SPOTIFY_CALLBACK_URL = 'http://localhost:8100/settings/music-services/spotify/callback/'
+SPOTIFY_CALLBACK_URL = 'https://127.0.0.1:8100/settings/music-services/spotify/callback/'
 
 # SPOTIFY-CACHE
 SPOTIFY_CACHE_CLIENT_ID = 'needs a non empty default value for tests, change this'


### PR DESCRIPTION
# Problem


While setting up the ListenBrainz project and integrating Spotify, I encountered an issue with the redirect url `http://localhost:8100/settings/music-services/spotify/callback/`. Spotify  detects this url as not secure in the Developer Dashboard, because they have updated their way of accepting the callback url as I have attached the screenshot .
![Screenshot 2025-05-01 232324](https://github.com/user-attachments/assets/308b8c2a-62a5-46bc-b84c-7d5f82f258b8)

Refer the screenshot below for the updated guidlines of spotify : 
![Screenshot 2025-05-01 232254](https://github.com/user-attachments/assets/5fb43bb3-7948-4f86-9163-c3ea86771365)

I also noticed this url is hardcoded in config.py.sample , so I believe both the docs and this config need an update which will help newcomers for local development

# Solution
successfully updated server development docs by updating the callback/redirect url  of spotify  to : `https://127.0.0.1:8100/settings/music-services/spotify/callback/` as suggested by @amCap1712  to use `127.0.0.1` instead of `localhost` 
and also updated the  config.py.sample  : 
![image](https://github.com/user-attachments/assets/804a383c-74fb-4acb-88fd-ccde949e813f)

and please ignore this commit : `c632f07903b28312f2c407d0d59b5bad517f1d3e`
