### PR TITLE
LB-1789: Close button for youtube music player

### DIFF
--- a/frontend/css/brainzplayer.less
+++ b/frontend/css/brainzplayer.less
@@ -114,6 +114,13 @@
             cursor: grabbing;
           }
         }
+
+        .youtube-close-button {
+          height: @youtube-drag-handle-size;
+          display: inline-block;
+          background: fadeout(black, 50%);
+          color: @white;
+        }
       }
     }
   }

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -855,6 +855,25 @@ export default function BrainzPlayer() {
     });
   };
 
+  const handleCloseYoutubePlayer = () => {
+    // Stop the playback first
+    if (!brainzPlayerContextRef.current.playerPaused) {
+      const dataSource =
+        dataSourceRefs[brainzPlayerContextRef.current.currentDataSourceIndex]
+          ?.current;
+      if (dataSource) {
+        dataSource.togglePlay();
+      }
+    }
+
+    // Reset player state
+    stopPlayerStateTimer();
+    reinitializeWindowTitle();
+
+    // Hide the player
+    dispatch({ isActivated: false });
+  };
+
   const playNextListenFromQueue = (datasourceIndex: number = 0): void => {
     const currentPlayingListenIndex =
       brainzPlayerContextRef.current.currentListenIndex;
@@ -1070,6 +1089,7 @@ export default function BrainzPlayer() {
             handleError={handleError}
             handleWarning={handleWarning}
             handleSuccess={handleSuccess}
+            onClose={handleCloseYoutubePlayer}
           />
         )}
         {userPreferences?.brainzplayer?.soundcloudEnabled !== false && (

--- a/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
@@ -15,6 +15,7 @@ import {
   faArrowsAlt,
   faWindowMaximize,
   faWindowMinimize,
+  faTimes,
 } from "@fortawesome/free-solid-svg-icons";
 import { faYoutube } from "@fortawesome/free-brands-svg-icons";
 import { Link } from "react-router-dom";
@@ -30,6 +31,7 @@ import { dataSourcesInfo } from "../../settings/brainzplayer/BrainzPlayerSetting
 export type YoutubePlayerProps = DataSourceProps & {
   youtubeUser?: YoutubeUser;
   refreshYoutubeToken: () => Promise<string>;
+  onClose?: () => void;
 };
 
 // For some reason Youtube types do not document getVideoData,
@@ -361,7 +363,7 @@ export default class YoutubePlayer extends React.Component<YoutubePlayerProps>
   };
 
   render() {
-    const { show } = this.props;
+    const { show, onClose } = this.props;
     const options: Options = {
       playerVars: {
         controls: 0,
@@ -380,6 +382,19 @@ export default class YoutubePlayer extends React.Component<YoutubePlayerProps>
     const leftBound =
       document.body.clientWidth - draggableBoundPadding * 2 - 350;
 
+    // Handle close button click
+    const handleClose = () => {
+      if (this.youtubePlayer) {
+        this.youtubePlayer.stopVideo();
+        // Clear playlist
+        this.youtubePlayer.cueVideoById("");
+      }
+      // Hide the player by updating the show prop in the parent component
+      if (this.props.onVisibilityChange) {
+        this.props.onVisibilityChange(false);
+      }
+    };
+
     return (
       <Draggable
         handle=".youtube-drag-handle"
@@ -395,6 +410,13 @@ export default class YoutubePlayer extends React.Component<YoutubePlayerProps>
         >
           <button className="btn btn-sm youtube-drag-handle" type="button">
             <FontAwesomeIcon icon={faArrowsAlt} />
+          </button>
+          <button
+            className="btn btn-sm youtube-close-button"
+            type="button"
+            onClick={onClose}
+          >
+            <FontAwesomeIcon icon={faTimes} />
           </button>
           <YouTube
             className="youtube-player"


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
According to [this ticket](https://tickets.metabrainz.org/projects/LB/issues/LB-1789?filter=allopenissues) we are unable to close the youtube music player window. All we have is the drag button and to close the window we have to reload the page which is quite inconvenient.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
1. Added a close button to the header of the `YoutubePlayer` component which uses the `onClose` prop passed through `BrainzPlayer`. 
2. Implemented a `handleCloseYoutubePlayer` function which is passed as the onClose prop.
3. Added `.youtube-close-button` css class for styling.

https://github.com/user-attachments/assets/47f0ed3c-378b-468a-86ad-00e8a8eec593



# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


