### PR TITLE
Cache donor queries results

### DIFF
--- a/listenbrainz/webserver/views/donor_api.py
+++ b/listenbrainz/webserver/views/donor_api.py
@@ -9,7 +9,6 @@ from listenbrainz.webserver.views.api_tools import _parse_int_arg
 
 donor_api_bp = Blueprint('donor_api_v1', __name__)
 
-
 DEFAULT_DONOR_COUNT = 25
 
 
@@ -17,14 +16,12 @@ DEFAULT_DONOR_COUNT = 25
 @crossdomain
 @ratelimit()
 def recent_donors():
-    """ Get a list of most recent MeB donors with flairs.
-
-    """
+    """ Get a list of most recent MeB donors with flairs. """
     count = _parse_int_arg("count", DEFAULT_DONOR_COUNT)
     offset = _parse_int_arg("offset", 0)
 
     if not current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
-        return []
+        return jsonify([])
 
     donors, _ = get_recent_donors(meb_conn, db_conn, count, offset)
     return jsonify(donors)
@@ -34,14 +31,12 @@ def recent_donors():
 @crossdomain
 @ratelimit()
 def biggest_donors():
-    """ Get a list of the biggest MeB donors with flairs.
-
-    """
+    """ Get a list of the biggest MeB donors with flairs. """
     count = _parse_int_arg("count", DEFAULT_DONOR_COUNT)
     offset = _parse_int_arg("offset", 0)
 
     if not current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
-        return []
+        return jsonify([])
 
     donors, _ = get_biggest_donors(meb_conn, db_conn, count, offset)
     return jsonify(donors)
@@ -68,6 +63,9 @@ def all_flairs():
     """
     users_with_flair = get_all_flairs(db_conn)
     eligible_donors = are_users_eligible_donors(meb_conn, [u.musicbrainz_row_id for u in users_with_flair])
+
+    if not current_app.config["SQLALCHEMY_METABRAINZ_URI"]:
+        return jsonify({})
 
     result = {
         r.musicbrainz_id: r.flair

--- a/listenbrainz/webserver/views/donors.py
+++ b/listenbrainz/webserver/views/donors.py
@@ -12,8 +12,8 @@ DEFAULT_DONOR_COUNT = 25
 donors_bp = Blueprint("donors", __name__)
 
 
-@donors_bp.get("/",  defaults={'path': ''})
-@donors_bp.get('/<path:path>/')
+@donors_bp.get("/",  defaults={"path": ""})
+@donors_bp.get("/<path:path>/")
 def donors(path):
     return render_template("index.html")
 
@@ -31,7 +31,7 @@ def donors_post():
 
     donation_count_pages = ceil(donation_count / DEFAULT_DONOR_COUNT)
 
-    musicbrainz_ids = [donor["musicbrainz_id"] for donor in donors if donor['is_listenbrainz_user']]
+    musicbrainz_ids = [donor["musicbrainz_id"] for donor in donors if donor["is_listenbrainz_user"]]
     donors_info = db_user.get_many_users_by_mb_id(db_conn, musicbrainz_ids) if musicbrainz_ids else {}
     donor_ids = [donor_info.id for _, donor_info in donors_info.items()]
 
@@ -41,11 +41,11 @@ def donors_post():
     for donor in donors:
         donor_info = donors_info.get(donor["musicbrainz_id"].lower())
         if not donor_info:
-            donor['listenCount'] = None
-            donor['playlistCount'] = None
+            donor["listenCount"] = None
+            donor["playlistCount"] = None
         else:
-            donor['listenCount'] = user_listen_count.get(donor_info.id, 0)
-            donor['playlistCount'] = user_playlist_count.get(donor_info.id, 0)
+            donor["listenCount"] = user_listen_count.get(donor_info.id, 0)
+            donor["playlistCount"] = user_playlist_count.get(donor_info.id, 0)
 
     return jsonify({
         "data": donors,


### PR DESCRIPTION
LB recent listens page and LB pages showing user flairs in general query the donor endpoint which currently always queries the MeB DB. This can create lots of db connections under increased traffic and cause PG bouncer to refuse new connections causing downtime. Hence, cache the donor db calls response for 10 minutes.