### PR TITLE
Added a checkbox to make multiple listens or albums keeping the modal open 

### DIFF
--- a/frontend/js/src/common/listens/MBIDMappingModal.tsx
+++ b/frontend/js/src/common/listens/MBIDMappingModal.tsx
@@ -50,7 +50,7 @@ export default NiceModal.create(({ listenToMap }: MBIDMappingModalProps) => {
     TrackMetadata
   >();
 
-  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const searchInputRef = React.useRef<SearchInputImperativeHandle>(null);
 
   const closeModal = React.useCallback(() => {
     modal.hide();

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -98,7 +98,7 @@ export default function PlaylistPage() {
 
   // Ref
   const socketRef = React.useRef<Socket | null>(null);
-  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const searchInputRef = React.useRef<SearchInputImperativeHandle>(null);
 
   // States
   const [playlist, setPlaylist] = React.useState<JSPFPlaylist>(

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -5,6 +5,8 @@ import React, {
   useMemo,
   useRef,
   useState,
+  forwardRef,
+  useImperativeHandle,
 } from "react";
 import { toast } from "react-toastify";
 import {
@@ -95,11 +97,10 @@ export function TrackRow({ track, isChecked, onClickCheckbox }: TrackRowProps) {
   );
 }
 
-export default function AddAlbumListens({
-  onPayloadChange,
-  switchMode,
-  initialText,
-}: AddAlbumListensProps) {
+const AddAlbumListens = forwardRef(function AddAlbumListens(
+  { onPayloadChange, switchMode, initialText }: AddAlbumListensProps,
+  ref
+) {
   const { APIService } = useContext(GlobalAppContext);
   const { lookupMBRelease } = APIService;
   const [selectedAlbumMBID, setSelectedAlbumMBID] = useState<string>();
@@ -244,6 +245,15 @@ export default function AddAlbumListens({
     { format: ["minutes", "seconds"] }
   );
 
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      setSelectedAlbumMBID(undefined);
+      setSelectedAlbum(undefined);
+      setSelectedTracks([]);
+      searchInputRef.current?.triggerSearch("");
+    },
+  }));
+
   return (
     <div>
       <SearchAlbumOrMBID
@@ -252,6 +262,7 @@ export default function AddAlbumListens({
         }}
         switchMode={switchMode}
         ref={searchInputRef}
+        requiredInput={selectedAlbumMBID === undefined}
       />
       <div className="track-info">
         {selectedAlbum && (
@@ -348,4 +359,6 @@ export default function AddAlbumListens({
       </div>
     </div>
   );
-}
+});
+
+export default AddAlbumListens;

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -108,11 +108,7 @@ const AddAlbumListens = forwardRef(function AddAlbumListens(
   const [selectedTracks, setSelectedTracks] = useState<Array<MBTrackWithAC>>(
     []
   );
-  const searchInputRef = useRef<{
-    focus(): void;
-    triggerSearch(newText: string): void;
-    reset(): void;
-  }>(null);
+  const searchInputRef = useRef<SearchInputImperativeHandle>(null);
 
   const initialTextRef = useRef(initialText);
   React.useEffect(() => {

--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -111,6 +111,7 @@ const AddAlbumListens = forwardRef(function AddAlbumListens(
   const searchInputRef = useRef<{
     focus(): void;
     triggerSearch(newText: string): void;
+    reset(): void;
   }>(null);
 
   const initialTextRef = useRef(initialText);
@@ -250,7 +251,7 @@ const AddAlbumListens = forwardRef(function AddAlbumListens(
       setSelectedAlbumMBID(undefined);
       setSelectedAlbum(undefined);
       setSelectedTracks([]);
-      searchInputRef.current?.triggerSearch("");
+      searchInputRef.current?.reset();
     },
   }));
 

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -101,12 +101,17 @@ export default NiceModal.create(() => {
   const [customTimestamp, setCustomTimestamp] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [invertOrder, setInvertOrder] = useState(false);
+  const [keepModalOpen, setKeepModalOpen] = useState(false);
   // Used for the automatic switching and search trigger if pasting URL for another entity type
   const [textToSearch, setTextToSearch] = useState<string>();
 
   const closeModal = useCallback(() => {
     modal.hide();
     document?.body?.classList?.remove("modal-open");
+    const backdrop = document?.querySelector(".modal-backdrop");
+    if (backdrop) {
+      backdrop.remove();
+    }
     setTimeout(modal.remove, 200);
   }, [modal]);
 
@@ -186,7 +191,14 @@ export default NiceModal.create(() => {
           />,
           { toastId: "added-listens-success" }
         );
-        closeModal();
+
+        if (!keepModalOpen) {
+          closeModal();
+        } else {
+          // Reset the form state but keep the modal open
+          setSelectedListens([]);
+          setTextToSearch("");
+        }
       } catch (error) {
         handleError(
           error,
@@ -211,6 +223,7 @@ export default NiceModal.create(() => {
     APIService,
     closeModal,
     handleError,
+    keepModalOpen,
   ]);
 
   const switchMode = React.useCallback(
@@ -369,19 +382,31 @@ export default NiceModal.create(() => {
               </div>
             </div>
           </div>
-          <div className="modal-footer">
+          <div
+            className="modal-footer"
+            style={{ display: "flex", alignItems: "center", gap: "1rem" }}
+          >
+            <div style={{ flex: 1 }}>
+              <label style={{ userSelect: "none", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={keepModalOpen}
+                  onChange={(e) => setKeepModalOpen(e.target.checked)}
+                  style={{ marginRight: "0.5em" }}
+                />
+                Add another
+              </label>
+            </div>
             <button
               type="button"
               className="btn btn-default"
-              data-dismiss="modal"
               onClick={closeModal}
             >
               Close
             </button>
             <button
-              type="submit"
+              type="button"
               className="btn btn-success"
-              data-dismiss="modal"
               disabled={!selectedListens?.length}
               onClick={submitListens}
             >

--- a/frontend/js/src/user/components/AddSingleListen.tsx
+++ b/frontend/js/src/user/components/AddSingleListen.tsx
@@ -35,11 +35,7 @@ const AddSingleListen = forwardRef(function AddSingleListen(
       | undefined;
   }>({});
 
-  const searchInputRef = useRef<{
-    focus(): void;
-    triggerSearch(newText: string): void;
-    reset(): void;
-  }>(null);
+  const searchInputRef = useRef<SearchInputImperativeHandle>(null);
 
   const initialTextRef = useRef(initialText);
   React.useEffect(() => {

--- a/frontend/js/src/user/components/AddSingleListen.tsx
+++ b/frontend/js/src/user/components/AddSingleListen.tsx
@@ -38,6 +38,7 @@ const AddSingleListen = forwardRef(function AddSingleListen(
   const searchInputRef = useRef<{
     focus(): void;
     triggerSearch(newText: string): void;
+    reset(): void;
   }>(null);
 
   const initialTextRef = useRef(initialText);
@@ -56,6 +57,7 @@ const AddSingleListen = forwardRef(function AddSingleListen(
     reset: () => {
       setSelectedRecordings([]);
       setSelectedReleases({});
+      searchInputRef.current?.reset();
     },
   }));
 

--- a/frontend/js/src/user/components/AddSingleListen.tsx
+++ b/frontend/js/src/user/components/AddSingleListen.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import {
   faChevronDown,
   faTimesCircle,
@@ -16,11 +22,10 @@ interface AddSingleListenProps {
   initialText?: string;
 }
 
-export default function AddSingleListen({
-  onPayloadChange,
-  switchMode,
-  initialText,
-}: AddSingleListenProps) {
+const AddSingleListen = forwardRef(function AddSingleListen(
+  { onPayloadChange, switchMode, initialText }: AddSingleListenProps,
+  ref
+) {
   const [selectedRecordings, setSelectedRecordings] = useState<
     MusicBrainzRecordingWithReleasesAndRGs[]
   >([]);
@@ -46,6 +51,13 @@ export default function AddSingleListen({
       initialTextRef.current = undefined;
     };
   }, [initialText]);
+
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      setSelectedRecordings([]);
+      setSelectedReleases({});
+    },
+  }));
 
   const removeRecording = (recordingMBID: string) => {
     setSelectedRecordings((prevRecordings) =>
@@ -97,6 +109,7 @@ export default function AddSingleListen({
         expectedPayload="recording"
         onSelectRecording={selectRecording}
         switchMode={switchMode}
+        requiredInput={selectedRecordings.length === 0}
       />
       <div className="track-info">
         <div className="content">
@@ -231,4 +244,6 @@ export default function AddSingleListen({
       </div>
     </div>
   );
-}
+});
+
+export default AddSingleListen;

--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -32,7 +32,10 @@ type SearchAlbumOrMBIDProps = {
   requiredInput?: boolean;
 };
 
-const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
+const SearchAlbumOrMBID = forwardRef<
+  SearchInputImperativeHandle,
+  SearchAlbumOrMBIDProps
+>(function SearchAlbumOrMBID(
   {
     onSelectAlbum,
     defaultValue,

--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -25,14 +25,20 @@ import {
 
 const THROTTLE_MILLISECONDS = 1500;
 
-type SearchTrackOrMBIDProps = {
+type SearchAlbumOrMBIDProps = {
   onSelectAlbum: (releaseMBID?: string) => void;
   defaultValue?: string;
   switchMode?: (text: string) => void;
+  requiredInput?: boolean;
 };
 
 const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
-  { onSelectAlbum, defaultValue, switchMode }: SearchTrackOrMBIDProps,
+  {
+    onSelectAlbum,
+    defaultValue,
+    switchMode,
+    requiredInput = true,
+  }: SearchAlbumOrMBIDProps,
   inputRefForParent
 ) {
   const { APIService } = useContext(GlobalAppContext);
@@ -203,7 +209,7 @@ const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
             setInputValue(event.target.value);
           }}
           placeholder="Album name or MusicBrainz URL/MBID"
-          required
+          required={requiredInput}
           aria-haspopup={Boolean(searchResults?.length)}
         />
         <span className="input-group-btn">

--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -51,20 +51,27 @@ const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
     Array<MusicBrainzRelease & Partial<WithMedia> & WithArtistCredits>
   >([]);
 
+  const reset = useCallback(() => {
+    setInputValue("");
+    setSearchResults([]);
+    onSelectAlbum();
+    setLoading(false);
+    searchInputRef?.current?.focus();
+  }, [onSelectAlbum]);
+
   // Allow parents to focus on input and trigger search
   useImperativeHandle(
     inputRefForParent,
-    () => {
-      return {
-        focus() {
-          searchInputRef?.current?.focus();
-        },
-        triggerSearch(newText: string) {
-          setInputValue(newText);
-        },
-      };
-    },
-    []
+    () => ({
+      focus() {
+        searchInputRef?.current?.focus();
+      },
+      triggerSearch(newText: string) {
+        setInputValue(newText);
+      },
+      reset,
+    }),
+    [reset]
   );
 
   const handleError = useCallback(
@@ -152,14 +159,6 @@ const SearchAlbumOrMBID = forwardRef(function SearchAlbumOrMBID(
     },
     [onSelectAlbum]
   );
-
-  const reset = () => {
-    setInputValue("");
-    setSearchResults([]);
-    onSelectAlbum();
-    setLoading(false);
-    searchInputRef?.current?.focus();
-  };
 
   useEffect(() => {
     if (!inputValue) {

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -48,7 +48,10 @@ type SearchTrackOrMBIDProps = {
   requiredInput?: boolean;
 } & ConditionalReturnValue;
 
-const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
+const SearchTrackOrMBID = forwardRef<
+  SearchInputImperativeHandle,
+  SearchTrackOrMBIDProps
+>(function SearchTrackOrMBID(
   {
     onSelectRecording,
     expectedPayload,

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -70,20 +70,26 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
   const inputRefLocal = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
 
+  const reset = useCallback(() => {
+    setInputValue("");
+    setSearchResults([]);
+    setSelectedIndex(-1);
+    inputRefLocal?.current?.focus();
+  }, []);
+
   // Allow parents to focus on input
   useImperativeHandle(
     inputRefForParent,
-    () => {
-      return {
-        focus() {
-          inputRefLocal?.current?.focus();
-        },
-        triggerSearch(newText: string) {
-          setInputValue(newText);
-        },
-      };
-    },
-    []
+    () => ({
+      focus() {
+        inputRefLocal?.current?.focus();
+      },
+      triggerSearch(newText: string) {
+        setInputValue(newText);
+      },
+      reset,
+    }),
+    [reset]
   );
 
   // Autofocus once on load
@@ -225,13 +231,6 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
       };
       onSelectRecording(metadata);
     }
-  };
-
-  const reset = () => {
-    setInputValue("");
-    setSearchResults([]);
-    setSelectedIndex(-1);
-    inputRefLocal?.current?.focus();
   };
 
   useEffect(() => {

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -45,6 +45,7 @@ type SearchTrackOrMBIDProps = {
   defaultValue?: string;
   expectedPayload: PayloadType;
   switchMode?: (text: string) => void;
+  requiredInput?: boolean;
 } & ConditionalReturnValue;
 
 const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
@@ -54,6 +55,7 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
     defaultValue,
     autofocus = true,
     switchMode,
+    requiredInput = true,
   }: SearchTrackOrMBIDProps,
   inputRefForParent
 ) {
@@ -269,7 +271,7 @@ const SearchTrackOrMBID = forwardRef(function SearchTrackOrMBID(
             setInputValue(event.target.value);
           }}
           placeholder="Track name or MusicBrainz URL/MBID"
-          required
+          required={requiredInput}
         />
         <span className="input-group-btn">
           <button className="btn btn-default" type="button" onClick={reset}>

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -695,7 +695,6 @@ declare type BrainzPlayerSettings = {
   >;
 };
 
-
 declare type UserPreferences = {
   saveData?: boolean;
   brainzplayer?: BrainzPlayerSettings;
@@ -711,3 +710,9 @@ declare type BrainzPlayerQueueItem = Listen & {
 };
 
 declare type BrainzPlayerQueue = BrainzPlayerQueueItem[];
+
+type SearchInputImperativeHandle = {
+  focus(): void;
+  triggerSearch(newText: string): void;
+  reset(): void;
+};


### PR DESCRIPTION


# Problem
[LB-1759](https://tickets.metabrainz.org/browse/LB-1759)  
The problem is when a user wants to add multiple listen in  row (like for each side of a record ) or multiple albums with different timestamps for example ,so the user have to  first submit the listen he is listening to and for adding another listen or album user had to again open the modal and add manually the listen or album he wants to, so this is very frustrating to  open the modal again and again repeatedly, so the user wants an option which help him to keep the modal open so they can add multiple listens with very few clicks

Can see what was earlier :
![image](https://github.com/user-attachments/assets/80884c88-b70f-4357-afb4-0b5880255dba)



# Solution
I added a checkbox named "Add another" to the Add Listens modal in  `AddListenModal.tsx`  . When a user  tick this add another check box, the modal stays open after they  submit a listen, so they can quickly add more without reopening it each time. If they leave it unchecked, the modal closes as usual. This makes adding multiple listens much faster and provides more control, similar to GitHub’s “Create more” option.

I have created a checkbox as 
``` typeScript
            <div
            className="modal-footer"
            style={{ display: "flex", alignItems: "center", gap: "1rem" }}
             >
            <div style={{ flex: 1 }}>
              <label style={{ userSelect: "none", cursor: "pointer" }}>
                <input
                  type="checkbox"
                  checked={keepModalOpen}
                  onChange={(e) => setKeepModalOpen(e.target.checked)}
                  style={{ marginRight: "0.5em" }}
                />
                Add another
              </label>
            </div>
```
The preview of the solution is in the video below :

https://github.com/user-attachments/assets/1529460f-70a5-4e05-ba18-edd6b3399ed9






