### PR TITLE
Disable color sync

### DIFF
--- a/mbid_mapping/docker/crontab
+++ b/mbid_mapping/docker/crontab
@@ -1,9 +1,6 @@
 # Create the mapping indexes (typesense, canonical data tables) each day at 4am
 0 5 * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py cron cron-create-all >> /code/mapper/lb-cron.log 2>&1
 
-# Run the huesound color sync hourly
-10 * * * * listenbrainz /usr/local/bin/python /code/mapper/manage.py cron cron-update-coverart >> /code/mapper/lb-cron.log 2>&1
-
 # Rebuild the spotify metadata index every friday at 1 A.M.
 0 1 * * 5 listenbrainz /usr/local/bin/python /code/mapper/manage.py cron cron-build-spotify-metadata-index >> /code/mapper/cron-spotify-metadata-index.log 2>&1
 


### PR DESCRIPTION
When IA is down, the color sync can pile a number of threads and db connections starving the other containers from connecting to the db. Disable color sync until this fixed.