### PR TITLE
Replace usages of deprecated datetime.utcnow

### DIFF
--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -853,7 +853,7 @@ def insert_recordings(db_conn, ts_conn, playlist_id: int, recordings: List[model
     """)
     return_recordings = []
     user_id_map = {}
-    insert_ts = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+    insert_ts = datetime.datetime.now(tz=datetime.timezone.utc)
     for recording in recordings:
         if not recording.created:
             recording.created = insert_ts

--- a/listenbrainz/listenstore/tests/test_redislistenstore.py
+++ b/listenbrainz/listenstore/tests/test_redislistenstore.py
@@ -85,7 +85,7 @@ class RedisListenStoreTestCase(DatabaseTestCase):
             self.assertEqual(r.timestamp, listens[i].timestamp)
 
     def test_incr_listen_count_for_day(self):
-        today = datetime.datetime.utcnow()
+        today = datetime.datetime.today()
         # get without setting any value, should return None
         self.assertIsNone(self._redis.get_listen_count_for_day(today))
 

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app,flash,redirect
 from flask_admin.model import action
@@ -15,11 +15,11 @@ class User(db.Model):
     __tablename__ = 'user'
 
     id = db.Column(db.Integer, primary_key=True)
-    created = db.Column(db.DateTime(timezone=True), default=datetime.utcnow)
+    created = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(tz=timezone.utc))
     musicbrainz_id = db.Column(db.String)
     auth_token = db.Column(db.String)
-    last_login = db.Column(db.DateTime(timezone=True), default=datetime.utcnow, nullable=False)
-    latest_import = db.Column(db.DateTime(timezone=True), default=lambda: datetime.fromutctimestamp(0))
+    last_login = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(tz=timezone.utc), nullable=False)
+    latest_import = db.Column(db.DateTime(timezone=True), default=lambda: datetime.fromtimestamp(0, tz=timezone.utc))
     gdpr_agreed = db.Column(db.DateTime(timezone=True))
     musicbrainz_row_id = db.Column(db.Integer, nullable=False)
     login_id = db.Column(db.String)

--- a/listenbrainz/spark/tests/test_handlers.py
+++ b/listenbrainz/spark/tests/test_handlers.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 from unittest.mock import call
 
@@ -423,7 +423,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_dataframes(self, mock_send_mail):
         with self.app.app_context():
-            time = datetime.utcnow()
+            time = datetime.now(tz=timezone.utc)
 
             self.app.config['TESTING'] = True
             handle_dataframes({
@@ -448,7 +448,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_model(self, mock_send_mail):
         with self.app.app_context():
-            time = datetime.utcnow()
+            time = datetime.now(tz=timezone.utc)
 
             self.app.config['TESTING'] = True
             handle_model({
@@ -469,7 +469,7 @@ class HandlersTestCase(DatabaseTestCase):
     @mock.patch('listenbrainz.spark.handlers.send_mail')
     def test_handle_candidate_sets(self, mock_send_mail):
         with self.app.app_context():
-            time = datetime.utcnow()
+            time = datetime.now(tz=timezone.utc)
 
             self.app.config['TESTING'] = True
             handle_candidate_sets({

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -138,7 +138,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
             return len(data)
 
         try:
-            redis_connection._redis.increment_listen_count_for_day(day=datetime.utcnow(), count=len(rows_inserted))
+            redis_connection._redis.increment_listen_count_for_day(day=datetime.today(), count=len(rows_inserted))
         except Exception:
             # Not critical, so if this errors out, just log it to Sentry and move forward
             current_app.logger.error("Could not update listen count per day in redis", exc_info=True)

--- a/listenbrainz/troi/weekly_playlists.py
+++ b/listenbrainz/troi/weekly_playlists.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import text
 from troi.patches.periodic_jams import WEEKLY_JAMS_DESCRIPTION, WEEKLY_EXPLORATION_DESCRIPTION
@@ -53,7 +53,7 @@ def exclude_playlists_from_deleted_users(slug, jam_name, description, all_playli
             "algorithm_metadata": {
                 "source_patch": slug
             },
-            "expires_at": (datetime.utcnow() + timedelta(weeks=PERIODIC_PLAYLIST_LIFESPAN)).isoformat()
+            "expires_at": (datetime.now(tz=timezone.utc) + timedelta(weeks=PERIODIC_PLAYLIST_LIFESPAN)).isoformat()
         }
 
         playlists.append(playlist)

--- a/listenbrainz/webserver/testing.py
+++ b/listenbrainz/webserver/testing.py
@@ -247,6 +247,8 @@ class APICompatServerTestCase(ServerTestCase):
 
     @classmethod
     def create_app(cls):
-        app = create_api_compat_app()
+        # set debug = false to avoid initializing Flask-DebugToolbar
+        # related warnings from missing body tag in response.
+        app = create_api_compat_app(debug=False)
         app.config['TESTING'] = True
         return app

--- a/listenbrainz/webserver/views/index.py
+++ b/listenbrainz/webserver/views/index.py
@@ -79,8 +79,8 @@ def current_status():
 
     listen_counts_per_day: List[dict] = []
     for delta in range(2):
+        day = datetime.today() - relativedelta(days=delta)
         try:
-            day = datetime.utcnow() - relativedelta(days=delta)
             day_listen_count = _redis.get_listen_count_for_day(day)
         except:
             current_app.logger.error("Could not get %s listen count from redis", day.strftime('%Y-%m-%d'),

--- a/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
+++ b/listenbrainz/webserver/views/test/test_recommendations_cf_recording.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import orjson
 import listenbrainz.db.user as db_user
-from datetime import datetime
+from datetime import datetime, timezone
 
 from unittest.mock import patch
 from flask import render_template, url_for
@@ -96,7 +96,7 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
                     'score': 0.4
                 }]
             },
-            'created': datetime.utcnow(),
+            'created': datetime.now(tz=timezone.utc),
             'user_id': self.user["id"]
         })
         mock_get_recommendations.return_value = []
@@ -112,7 +112,7 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
     def test_get_props(self, mock_get_recommendations, mock_get_rec):
         # active_section = 'raw'
         user = User.from_dbrow(self.user2)
-        created = datetime.utcnow()
+        created = datetime.now(tz=timezone.utc)
 
         mock_get_rec.return_value = UserRecommendationsData(**{
             'recording_mbid': {
@@ -121,7 +121,7 @@ class CFRecommendationsViewsTestCase(NonAPIIntegrationTestCase):
                     'score': 0.9
                 }]
             },
-            'created': datetime.utcnow(),
+            'created': datetime.now(tz=timezone.utc),
             'user_id': self.user["id"]
         })
 

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -895,7 +895,7 @@ def get_listen_events(
             max_ts = datetime.fromtimestamp(max_ts, timezone.utc)
             min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW
         else:
-            max_ts = datetime.utcnow()
+            max_ts = datetime.now(tz=timezone.utc)
             min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW
 
     listens = timescale_connection._ts.fetch_recent_listens_for_users(
@@ -954,7 +954,7 @@ def get_all_listen_events(
         max_ts = datetime.fromtimestamp(max_ts, timezone.utc)
         min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW_NEW
     else:
-        max_ts = datetime.utcnow()
+        max_ts = datetime.now(tz=timezone.utc)
         min_ts = max_ts - DEFAULT_LISTEN_EVENT_WINDOW_NEW
 
     listens = timescale_connection._ts.fetch_all_recent_listens_for_users(

--- a/listenbrainz_spark/recommendations/recording/train_models.py
+++ b/listenbrainz_spark/recommendations/recording/train_models.py
@@ -298,7 +298,7 @@ def main(ranks=None, lambdas=None, iterations=None, alphas=None, use_transformed
     best_model, all_models = train_models(training_data, test_data, use_transformed_listencounts,
                                           ranks, lambdas, iterations, alphas, context)
 
-    context["model_html_file"] = f"Model-{datetime.utcnow().strftime('%Y-%m-%d-%H:%M')}-{uuid.uuid4()}.html"
+    context["model_html_file"] = f"Model-{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d-%H:%M')}-{uuid.uuid4()}.html"
 
     save_model(best_model, context)
     save_training_html(context)

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pyspark.sql import Row
 from pyspark.sql.types import StructField, StructType, ArrayType, StringType, TimestampType, FloatType, \
     IntegerType, LongType
@@ -145,7 +145,7 @@ def convert_model_metadata_to_row(meta):
     """
     return Row(
         dataframe_id=meta.get('dataframe_id'),
-        model_created=datetime.utcnow(),
+        model_created=datetime.now(tz=timezone.utc),
         model_html_file=meta.get('model_html_file'),
         model_id=meta.get('model_id'),
         model_param=Row(
@@ -169,7 +169,7 @@ def convert_dataframe_metadata_to_row(meta):
             pyspark.sql.Row object - a Spark SQL Row based on the defined dataframe metadata schema.
     """
     return Row(
-        dataframe_created=datetime.utcnow(),
+        dataframe_created=datetime.now(tz=timezone.utc),
         dataframe_id=meta.get('dataframe_id'),
         from_date=meta.get('from_date'),
         listens_count=meta.get('listens_count'),


### PR DESCRIPTION
`datetime.utcnow()` is deprecated and scheduled for removal, hence replace it with `datetime.now(tz=timezone.utc)`.