### PR TITLE
LB-1761 : Save filter state in local

### DIFF
--- a/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
@@ -177,6 +177,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
     if (includeVariousArtists === true) {
       setIncludeVariousArtists(false);
     }
+    clearSavedFilters();
   }, [releaseTags, releaseTypes]);
 
   React.useEffect(() => {
@@ -260,6 +261,13 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
             {"  "}
             <b>Filter</b>
           </h4>
+          <button
+            onClick={clearSavedFilters}
+            className="btn btn-default btn-reset-filters"
+            style={{ margin: "10px 0" }}
+          >
+            Reset All Filters
+          </button>
         </div>
 
         {filtersOpen && (

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
@@ -155,29 +155,31 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
     releaseTagsExcludeCheckList,
     includeVariousArtists,
     coverartOnly,
-    showPastReleases,
-    showFutureReleases,
     setCheckedList,
     setReleaseTagsCheckList,
     setReleaseTagsExcludeCheckList,
     setIncludeVariousArtists,
     setCoverartOnly,
-    setShowPastReleases,
-    setShowFutureReleases,
   });
 
+  const hasMounted = React.useRef(false);
   // Reset filters when range changes
   React.useEffect(() => {
-    if (coverartOnly === true) {
-      setCoverartOnly(false);
+    if (hasMounted.current) {
+      // Reset filters when releaseTags or releaseTypes change (but not on first render)
+      if (coverartOnly === true) {
+        setCoverartOnly(false);
+      }
+      if (checkedList?.length > 0) {
+        setCheckedList([]);
+      }
+      if (includeVariousArtists === true) {
+        setIncludeVariousArtists(false);
+      }
+      clearSavedFilters();
+    } else {
+      hasMounted.current = true;
     }
-    if (checkedList?.length > 0) {
-      setCheckedList([]);
-    }
-    if (includeVariousArtists === true) {
-      setIncludeVariousArtists(false);
-    }
-    clearSavedFilters();
   }, [releaseTags, releaseTypes]);
 
   React.useEffect(() => {
@@ -242,6 +244,14 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
         </p>
       </div>
       <div className="sidenav-content-grid">
+        <button
+          onClick={clearSavedFilters}
+          type="button"
+          className="btn btn-default btn-reset-filters"
+          style={{ margin: "10px 0" }}
+        >
+          Reset All Filters
+        </button>
         <div
           onClick={toggleFilters}
           onKeyDown={(e) => {
@@ -261,13 +271,6 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
             {"  "}
             <b>Filter</b>
           </h4>
-          <button
-            onClick={clearSavedFilters}
-            className="btn btn-default btn-reset-filters"
-            style={{ margin: "10px 0" }}
-          >
-            Reset All Filters
-          </button>
         </div>
 
         {filtersOpen && (

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
@@ -11,6 +11,7 @@ import type {
   filterRangeOption,
 } from "../FreshReleases";
 import { PAGE_TYPE_SITEWIDE, filterRangeOptions } from "../FreshReleases";
+import useFilterPersistence from "../../../hooks/userPersistanceFilter";
 
 const VARIOUS_ARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
@@ -147,6 +148,23 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
           (option) => option !== filterRangeOptions.three_months
         )
       : Object.values(filterRangeOptions);
+
+  const { clearSavedFilters } = useFilterPersistence({
+    checkedList,
+    releaseTagsCheckList,
+    releaseTagsExcludeCheckList,
+    includeVariousArtists,
+    coverartOnly,
+    showPastReleases,
+    showFutureReleases,
+    setCheckedList,
+    setReleaseTagsCheckList,
+    setReleaseTagsExcludeCheckList,
+    setIncludeVariousArtists,
+    setCoverartOnly,
+    setShowPastReleases,
+    setShowFutureReleases,
+  });
 
   // Reset filters when range changes
   React.useEffect(() => {

--- a/frontend/js/src/hooks/userPersistanceFilter.ts
+++ b/frontend/js/src/hooks/userPersistanceFilter.ts
@@ -1,0 +1,136 @@
+import { useEffect } from "react";
+import localforage from "localforage";
+
+const FILTERS_STORAGE_KEY = "releaseFiltersState";
+
+interface StoredFilters {
+  checkedList: Array<string | undefined>;
+  releaseTagsCheckList: Array<string | undefined>;
+  releaseTagsExcludeCheckList: Array<string | undefined>;
+  includeVariousArtists: boolean;
+  coverartOnly: boolean;
+  showPastReleases: boolean;
+  showFutureReleases: boolean;
+}
+
+interface UseFilterPersistenceParams {
+  // State values
+  checkedList: Array<string | undefined>;
+  releaseTagsCheckList: Array<string | undefined>;
+  releaseTagsExcludeCheckList: Array<string | undefined>;
+  includeVariousArtists: boolean;
+  coverartOnly: boolean;
+  showPastReleases: boolean;
+  showFutureReleases: boolean;
+
+  // State setters
+  setCheckedList: (list: Array<string | undefined>) => void;
+  setReleaseTagsCheckList: (list: Array<string | undefined>) => void;
+  setReleaseTagsExcludeCheckList: (list: Array<string | undefined>) => void;
+  setIncludeVariousArtists: (value: boolean) => void;
+  setCoverartOnly: (value: boolean) => void;
+  setShowPastReleases?: (value: boolean) => void;
+  setShowFutureReleases?: (value: boolean) => void;
+}
+
+export default function useFilterPersistence(
+  params: UseFilterPersistenceParams
+) {
+  const {
+    checkedList,
+    releaseTagsCheckList,
+    releaseTagsExcludeCheckList,
+    includeVariousArtists,
+    coverartOnly,
+    showPastReleases,
+    showFutureReleases,
+    setCheckedList,
+    setReleaseTagsCheckList,
+    setReleaseTagsExcludeCheckList,
+    setIncludeVariousArtists,
+    setCoverartOnly,
+    setShowPastReleases,
+    setShowFutureReleases,
+  } = params;
+
+  // Load filters on component mount
+  useEffect(() => {
+    const loadFilters = async () => {
+      try {
+        const savedFilters = await localforage.getItem<StoredFilters>(
+          FILTERS_STORAGE_KEY
+        );
+        if (savedFilters) {
+          setCheckedList(savedFilters.checkedList ?? []);
+          setReleaseTagsCheckList(savedFilters.releaseTagsCheckList ?? []);
+          setReleaseTagsExcludeCheckList(
+            savedFilters.releaseTagsExcludeCheckList ?? []
+          );
+          setIncludeVariousArtists(savedFilters.includeVariousArtists ?? false);
+          setCoverartOnly(savedFilters.coverartOnly ?? false);
+
+          setShowPastReleases?.(savedFilters.showPastReleases ?? true);
+          setShowFutureReleases?.(savedFilters.showFutureReleases ?? true);
+        }
+      } catch (error) {
+        console.error("Failed to load filters:", error);
+      }
+    };
+
+    loadFilters();
+  }, []);
+
+  // Save filters when they change
+  useEffect(() => {
+    const saveFilters = async () => {
+      try {
+        // Filter out undefined values before saving
+        const filtersToSave: StoredFilters = {
+          checkedList: checkedList.filter(
+            (item): item is string => item !== undefined
+          ),
+          releaseTagsCheckList: releaseTagsCheckList.filter(
+            (item): item is string => item !== undefined
+          ),
+          releaseTagsExcludeCheckList: releaseTagsExcludeCheckList.filter(
+            (item): item is string => item !== undefined
+          ),
+          includeVariousArtists,
+          coverartOnly,
+          showPastReleases,
+          showFutureReleases,
+        };
+        await localforage.setItem(FILTERS_STORAGE_KEY, filtersToSave);
+      } catch (error) {
+        console.error("Failed to save filters:", error);
+      }
+    };
+
+    saveFilters();
+  }, [
+    checkedList,
+    releaseTagsCheckList,
+    releaseTagsExcludeCheckList,
+    includeVariousArtists,
+    coverartOnly,
+    showPastReleases,
+    showFutureReleases,
+  ]);
+
+  const clearSavedFilters = async () => {
+    try {
+      await localforage.removeItem(FILTERS_STORAGE_KEY);
+      setCheckedList([]);
+      setReleaseTagsCheckList([]);
+      setReleaseTagsExcludeCheckList([]);
+      setIncludeVariousArtists(false);
+      setCoverartOnly(false);
+      setShowPastReleases?.(true);
+      setShowFutureReleases?.(true);
+    } catch (error) {
+      console.error("Failed to clear filters:", error);
+    }
+  };
+
+  return { clearSavedFilters };
+}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.

-     Remember that it helps us review if you give more helpful info for us to
-     understand your change.
- 
-     Ensure that you've read through and followed the Contributing Guidelines, in
-     ./github/CONTRIBUTING.md.
- -->
- 
- # Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.

    Mention and link a JIRA ticket if there is one that's relevant.
-->
Currently we don't store the state of filter in fresh-releases so when user refreshes the page all the choices of user gets reset. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
So to solve this issue we are storing the filter state in local storage using localForage library. 
In this we are storing these states:

-   checkedList,
-   releaseTagsCheckList,
-   releaseTagsExcludeCheckList,
-   includeVariousArtists,
-   coverartOnly,

We are using a custom hook `userfilterpersistence.ts`  in `listenbrainz/hooks/userfilterpersistence.ts` to define the operations for filter data.

# Action
This needs to be checked if all the parameters that needs to be stored are correct. Also filters gets reset when we toggle from `All` to `For you` and also when refreshed.
