### PR TITLE
BrainzPlayer: Fix spotify progress bar and duration

### DIFF
--- a/frontend/js/src/common/brainzplayer/BrainzPlayerContext.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayerContext.tsx
@@ -124,7 +124,8 @@ function valueReducer(
       } else {
         elapsedTimeSinceLastUpdate = performance.now() - updateTime;
         const position = progressMs + elapsedTimeSinceLastUpdate;
-        newProgressMs = position > durationMs ? durationMs : position;
+        newProgressMs =
+          Boolean(durationMs) && position > durationMs ? durationMs : position;
       }
       return {
         ...state,

--- a/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
@@ -583,13 +583,10 @@ export default class SpotifyPlayer
     }
 
     onProgressChange(position);
-
-    if (duration !== durationMs) {
-      onDurationChange(duration);
-      this.setState({
-        durationMs: duration,
-      });
-    }
+    onDurationChange(duration);
+    this.setState({
+      durationMs: duration,
+    });
   };
 
   getAlbumArt = (): JSX.Element | null => {


### PR DESCRIPTION
When playing with Spotify, the track duration  was not being updated properly due to a superfluous check we do in SpotifyPlayer.
Thgis resulted in the progress bar not working either as it uses the duration for calculation.

Also added support for the edge case of a falsy durationMs (undefined, 0, ...)
