### PR TITLE
Add sample data dumps

### DIFF
--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -33,10 +33,12 @@ RSYNC_FULLEXPORT_DIR="$FTP_DIR/fullexport"
 RSYNC_INCREMENTAL_DIR="$FTP_DIR/incremental"
 RSYNC_SPARK_DIR="$FTP_DIR/spark"
 RSYNC_MBCANONICAL_DIR="$FTP_DIR/mbcanonical"
+RSYNC_SAMPLE_DIR="$FTP_DIR/sample"
 RSYNC_FULLEXPORT_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-full'
 RSYNC_INCREMENTAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-incremental'
 RSYNC_SPARK_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-spark'
 RSYNC_MBCANONICAL_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-canonical'
+RSYNC_SAMPLE_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-sample'
 
 # Check to make sure that this container is the prod cron container, otherwise never rsync anything!
 # these variables may also be read by the dump command in python so export to ensure availability

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -105,8 +105,10 @@ elif [ "$DUMP_TYPE" == "feedback" ]; then
     SUB_DIR="spark"
 elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
     SUB_DIR="mbcanonical"
+elif [ "$DUMP_TYPE" == "sample" ]; then
+    SUB_DIR="sample"
 else
-    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental', 'feedback' or 'mbcanonical'"
+    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental', 'feedback', 'mbcanonical' or 'sample'"
     exit
 fi
 
@@ -144,6 +146,11 @@ elif [ "$DUMP_TYPE" == "feedback" ]; then
 elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
     if ! /usr/local/bin/python manage.py dump create_mbcanonical -l "$DUMP_TEMP_DIR" "$@"; then
         echo "MB Canonical dump failed, exiting!"
+        exit 1
+    fi
+elif [ "$DUMP_TYPE" == "sample" ]; then
+    if ! /usr/local/bin/python manage.py dump create_sample -l "$DUMP_TEMP_DIR" "$@"; then
+        echo "Sample dump failed, exiting!"
         exit 1
     fi
 else
@@ -252,6 +259,9 @@ add_rsync_include_rule \
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
     "listenbrainz-statistics-dump-$DUMP_TIMESTAMP.tar.zst"
+add_rsync_include_rule \
+    "$FTP_CURRENT_DUMP_DIR" \
+    "listenbrainz-sample-dump-$DUMP_TIMESTAMP.tar.zst"
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
     "musicbrainz-canonical-dump-$DUMP_TIMESTAMP.tar.zst"

--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -40,8 +40,11 @@ elif [ $DUMP_TYPE == "feedback" ]; then
 elif [ $DUMP_TYPE == "mbcanonical" ]; then
     SOURCE_DIR=$RSYNC_MBCANONICAL_DIR
     SSH_KEY=$RSYNC_MBCANONICAL_KEY
+elif [ $DUMP_TYPE == "sample" ]; then
+    SOURCE_DIR=$RSYNC_SAMPLE_DIR
+    SSH_KEY=$RSYNC_SAMPLE_KEY
 else
-    echo "Could not determine which directory (full, incremental, feedback, mbcanonical) to copy over, exiting!"
+    echo "Could not determine which directory (full, incremental, feedback, mbcanonical, sample) to copy over, exiting!"
     exit 1
 fi
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -323,7 +323,19 @@ CREATE TABLE popularity.recording (
     total_user_count        INTEGER NOT NULL
 );
 
+CREATE TABLE popularity.mlhd_recording (
+    recording_mbid          UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
 CREATE TABLE popularity.artist (
+    artist_mbid             UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+CREATE TABLE popularity.mlhd_artist (
     artist_mbid             UUID NOT NULL,
     total_listen_count      INTEGER NOT NULL,
     total_user_count        INTEGER NOT NULL
@@ -335,7 +347,32 @@ CREATE TABLE popularity.release (
     total_user_count        INTEGER NOT NULL
 );
 
+CREATE TABLE popularity.mlhd_release (
+    release_mbid            UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+CREATE TABLE popularity.release_group (
+    release_group_mbid      UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+CREATE TABLE popularity.mlhd_release_group (
+    release_group_mbid      UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
 CREATE TABLE popularity.top_recording (
+    artist_mbid             UUID NOT NULL,
+    recording_mbid          UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+CREATE TABLE popularity.mlhd_top_recording (
     artist_mbid             UUID NOT NULL,
     recording_mbid          UUID NOT NULL,
     total_listen_count      INTEGER NOT NULL,
@@ -345,6 +382,28 @@ CREATE TABLE popularity.top_recording (
 CREATE TABLE popularity.top_release (
     artist_mbid             UUID NOT NULL,
     release_mbid            UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+CREATE TABLE popularity.mlhd_top_release (
+    artist_mbid             UUID NOT NULL,
+    release_mbid            UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+
+CREATE TABLE popularity.top_release_group (
+    artist_mbid             UUID NOT NULL,
+    release_group_mbid      UUID NOT NULL,
+    total_listen_count      INTEGER NOT NULL,
+    total_user_count        INTEGER NOT NULL
+);
+
+CREATE TABLE popularity.mlhd_top_release_group (
+    artist_mbid             UUID NOT NULL,
+    release_group_mbid      UUID NOT NULL,
     total_listen_count      INTEGER NOT NULL,
     total_user_count        INTEGER NOT NULL
 );

--- a/listenbrainz/db/popularity.py
+++ b/listenbrainz/db/popularity.py
@@ -3,7 +3,7 @@ import logging
 import psycopg2
 from flask import current_app
 from psycopg2.extras import DictCursor, execute_values
-from psycopg2.sql import SQL, Identifier
+from psycopg2.sql import SQL, Identifier, Composable
 from sqlalchemy import text
 
 from listenbrainz.db import color
@@ -137,19 +137,24 @@ def get_all_popularity_datasets():
     return datasets
 
 
+def to_entity_mbid(entity, per_artist):
+    """ Convert entity name to entity_mbid if its a supported entity. """
+    entities = {"recording", "release_group", "release"}
+    if not per_artist:
+        entities.add("artist")
+
+    if entity not in entities:
+        raise ValueError(f"Unsupported entity: {entity}")
+
+    return f"{entity}_mbid"
+
+
 def get_top_entity_for_artist(ts_conn, entity, artist_mbid, count=None):
     """ Get the top 'count' recordings, releases or release-groups for a given artist mbid
 
         By default running all recordings (entities) of the artist returned.
     """
-    if entity == "recording":
-        entity_mbid = "recording_mbid"
-    elif entity == "release_group":
-        entity_mbid = "release_group_mbid"
-    elif entity == "release":
-        entity_mbid = "release_mbid"
-    else:
-        return []
+    entity_mbid = to_entity_mbid(entity, True)
 
     if count is None:
         limit = ""
@@ -183,16 +188,7 @@ def get_top_entity_for_artist(ts_conn, entity, artist_mbid, count=None):
 
 def get_counts(ts_conn, entity, mbids):
     """ Get the total listen and user counts for a given entity and list of mbids """
-    if entity == "recording":
-        entity_mbid = "recording_mbid"
-    elif entity == "release_group":
-        entity_mbid = "release_group_mbid"
-    elif entity == "release":
-        entity_mbid = "release_mbid"
-    elif entity == "artist":
-        entity_mbid = "artist_mbid"
-    else:
-        return [], {}
+    entity_mbid = to_entity_mbid(entity, False)
 
     query = SQL("""
           WITH mbids (mbid) AS (
@@ -216,7 +212,7 @@ def get_counts(ts_conn, entity, mbids):
              , SUM(total_listen_count) AS total_listen_count
              , SUM(total_user_count) AS total_user_count
           FROM intermediate
-      GROUP BY mbid    
+      GROUP BY mbid
     """).format(
         entity_mbid=Identifier(entity_mbid),
         table=Identifier("popularity", entity),

--- a/listenbrainz/dumps/sample.py
+++ b/listenbrainz/dumps/sample.py
@@ -77,8 +77,6 @@ def get_popularity_data(cursor, entity: str, mbids: list[str], *, per_artist: bo
     return results
 
 
-# TODO: Discuss how to fix the issue of recording msid for tracks existing in production but not locally
-#   dump msid table and msid to mbid mapping table too?
 def dump_sample_data(location: str):
     """ Creates a sample data dump containing a subset of metadata and popularity information.
 

--- a/listenbrainz/dumps/sample.py
+++ b/listenbrainz/dumps/sample.py
@@ -1,0 +1,279 @@
+import logging
+import os
+import subprocess
+import tarfile
+from csv import DictWriter
+from uuid import UUID
+
+from flask import current_app
+from orjson import orjson
+from psycopg2.extras import execute_values, RealDictCursor
+from psycopg2.sql import Identifier, SQL
+from sqlalchemy import text
+
+from listenbrainz.db import stats, timescale
+from listenbrainz.db.popularity import to_entity_mbid
+from listenbrainz.dumps.exceptions import SchemaMismatchException
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_SCHEMA_VERSION = 8
+
+
+def get_seed_artist_mbids():
+    data = stats.get_sitewide_stats("artists", "all_time")
+    return [
+        UUID(artist["artist_mbid"]) for artist in data["data"]
+        if artist["artist_mbid"] is not None
+    ][:100]
+
+
+def dump_query_to_jsonl(conn, query, params, fp, callback=None):
+    result = conn.execute(query, params)
+    for row in result.mappings().fetchall():
+        if callback is not None:
+            callback(row)
+        fp.write(orjson.dumps(dict(row), option=orjson.OPT_APPEND_NEWLINE))
+
+
+def get_popularity_data(cursor, entity: str, mbids: list[str], *, per_artist: bool, is_mlhd: bool):
+    """ Retrieves popularity data for a given entity (recording or release group) from the database.
+
+    Args:
+        cursor: A database cursor to execute the query
+        entity: The entity type, either "recording" or "release_group"
+        mbids : A list of MusicBrainz IDs to fetch popularity data for
+        per_artist: If True, retrieves artist-specific popularity data using the "top_entity" tables
+        is_mlhd: If True, uses MLHD tables as data source
+
+    Returns:
+        list: A list of dictionaries containing popularity data including listen count and user count
+    """
+    entity_mbid = Identifier(to_entity_mbid(entity, per_artist))
+    mlhd_prefix = "mlhd_" if is_mlhd else ""
+    if per_artist:
+        select_clause  = SQL("artist_mbid, {entity_mbid}").format(entity_mbid=entity_mbid)
+        on_clause_mbid = Identifier("artist_mbid")
+        table = Identifier("popularity", mlhd_prefix + "top_" + entity)
+    else:
+        on_clause_mbid = select_clause = entity_mbid
+        table = Identifier("popularity", mlhd_prefix + entity)
+    query = SQL("""
+          WITH mbids (mbid) AS (
+                VALUES %s
+             )
+        SELECT {select_clause}
+             , total_listen_count
+             , total_user_count
+          FROM {table}
+          JOIN mbids
+            ON {on_clause_mbid} = mbid::UUID
+    """).format(
+        select_clause=select_clause,
+        on_clause_mbid=on_clause_mbid,
+        table=table
+    )
+    results = execute_values(cursor, query, [(mbid,) for mbid in mbids], fetch=True)
+    return results
+
+
+# TODO: Discuss how to fix the issue of recording msid for tracks existing in production but not locally
+#   dump msid table and msid to mbid mapping table too?
+def dump_sample_data(location: str):
+    """ Creates a sample data dump containing a subset of metadata and popularity information.
+
+    This function extracts sample data from the database, including:
+    - Metadata for artists, recordings, and release groups from a seed list of top artists
+    - Popularity data for recordings and release groups (both standard and MLHD versions)
+    - Artist-specific popularity data for recordings
+
+    The generated files are organized in subdirectories (metadata/ and popularity/).
+
+    Args:
+        location (str): Directory path where the sample dump will be stored
+    """
+    seed_artist_mbids = get_seed_artist_mbids()
+    all_artist_mbids = set(seed_artist_mbids)
+    rg_pop_mbids = set()
+    rec_pop_mbids = set()
+
+    def collect_artist_and_recording_mbids(row):
+        all_artist_mbids.update(row["artist_mbids"])
+        rec_pop_mbids.add(row["recording_mbid"])
+
+    def collect_artist_release_group_mbids(row):
+        all_artist_mbids.update(row["artist_mbids"])
+        rg_pop_mbids.add(row["release_group_mbid"])
+
+    with timescale.engine.connect() as connection, connection.begin() as transaction:
+        metadata_dir = os.path.join(location, "metadata")
+        os.makedirs(metadata_dir, exist_ok=True)
+
+        logging.info("Dumping release_groups_cache")
+        with open(os.path.join(metadata_dir, "release_groups_cache.jsonl"), "wb") as fp:
+            dump_query_to_jsonl(
+                connection,
+                text("SELECT * FROM mapping.mb_release_group_cache c WHERE c.artist_mbids && :artist_mbids"),
+                {"artist_mbids": seed_artist_mbids},
+                fp,
+                collect_artist_release_group_mbids,
+            )
+
+        logging.info("Dumping recordings_cache")
+        with open(os.path.join(metadata_dir, "recordings_cache.jsonl"), "wb") as fp:
+            dump_query_to_jsonl(
+                connection,
+                text("SELECT * FROM mapping.mb_metadata_cache c WHERE c.artist_mbids && :artist_mbids"),
+                {"artist_mbids": seed_artist_mbids},
+                fp,
+                collect_artist_and_recording_mbids,
+            )
+
+        logging.info("Dumping artists_cache")
+        with open(os.path.join(metadata_dir, "artists_cache.jsonl"), "wb") as fp:
+            dump_query_to_jsonl(
+                connection,
+                text("SELECT * FROM mapping.mb_artist_metadata_cache c WHERE c.artist_mbid = ANY(:artist_mbids)"),
+                {"artist_mbids": list(all_artist_mbids)},
+                fp,
+            )
+
+        ts_curs = connection.connection.cursor(cursor_factory=RealDictCursor)
+        popularity_dir = os.path.join(location, "popularity")
+        os.makedirs(popularity_dir, exist_ok=True)
+
+        for is_mlhd in [True, False]:
+            mlhd_prefix = "mlhd_" if is_mlhd else ""
+
+            logging.info(f"Dumping popularity {mlhd_prefix}release_group")
+            rg_pop_data = get_popularity_data(
+                ts_curs, "release_group", rg_pop_mbids, per_artist=False, is_mlhd=is_mlhd
+            )
+            with open(os.path.join(popularity_dir, mlhd_prefix + "release_group.csv"), "w", newline="") as fp:
+                writer = DictWriter(fp, fieldnames=["release_group_mbid", "total_listen_count", "total_user_count"])
+                writer.writeheader()
+                writer.writerows(rg_pop_data)
+
+            logging.info(f"Dumping popularity {mlhd_prefix}recording")
+            rec_pop_data = get_popularity_data(
+                ts_curs, "recording", rg_pop_mbids, per_artist=False, is_mlhd=is_mlhd
+            )
+            with open(os.path.join(popularity_dir, mlhd_prefix + "recording.csv"), "w", newline="") as fp:
+                writer = DictWriter(fp, fieldnames=["recording_mbid", "total_listen_count", "total_user_count"])
+                writer.writeheader()
+                writer.writerows(rec_pop_data)
+
+            logging.info(f"Dumping popularity {mlhd_prefix}top_recording")
+            rec_artist_pop_data = get_popularity_data(
+                ts_curs, "recording", all_artist_mbids, per_artist=True, is_mlhd=is_mlhd
+            )
+            with open(os.path.join(popularity_dir, mlhd_prefix + "top_recording.csv"), "w", newline="") as fp:
+                writer = DictWriter(fp, fieldnames=[
+                    "artist_mbid", "recording_mbid", "total_listen_count", "total_user_count"
+                ])
+                writer.writeheader()
+                writer.writerows(rec_artist_pop_data)
+
+        transaction.rollback()
+
+
+def import_sample_data(archive_path, threads):
+    """ Import sample data dump from the specified archive into the postgres database.
+
+    This function imports various components of the sample data dump:
+    - Metadata for artists, recordings, and release groups (as JSONL files)
+    - Popularity data for recordings and release groups (as CSV files)
+    - Both standard and MLHD versions of popularity data
+
+    The function verifies the schema version before importing to ensure compatibility.
+
+    Args:
+        archive_path: path to the .tar.zst archive containing the sample data dump
+        threads (int): the number of threads to use while decompressing, defaults to
+                        db.DUMP_DEFAULT_THREAD_COUNT
+
+    Raises:
+        SchemaMismatchException: If the schema version in the dump doesn't match SAMPLE_SCHEMA_VERSION
+    """
+    zstd_command = ["zstd", "--decompress", "--stdout", archive_path, f"-T{threads}"]
+    zstd = subprocess.Popen(zstd_command, stdout=subprocess.PIPE)
+
+    jsonl_file_table_map = {
+        "release_groups_cache.jsonl": Identifier("mapping", "mb_release_group_cache"),
+        "recordings_cache.jsonl": Identifier("mapping", "mb_metadata_cache"),
+        "artists_cache.jsonl": Identifier("mapping", "mb_artist_metadata_cache"),
+    }
+    csv_file_table_map = {
+        "mlhd_release_group.csv": Identifier("popularity", "mlhd_release_group"),
+        "release_group.csv": Identifier("popularity", "release_group"),
+        "mlhd_recording.csv": Identifier("popularity", "mlhd_recording"),
+        "recording.csv": Identifier("popularity", "recording"),
+        "mlhd_top_recording.csv": Identifier("popularity", "mlhd_top_recording"),
+        "top_recording.csv": Identifier("popularity", "top_recording"),
+    }
+
+    connection = timescale.engine.raw_connection()
+    try:
+        cursor = connection.cursor()
+        with tarfile.open(fileobj=zstd.stdout, mode="r|") as tar:
+            for member in tar:
+                file_name = member.name.split("/")[-1]
+
+                if file_name == "SCHEMA_SEQUENCE":
+                    # Verifying schema version
+                    schema_seq = int(tar.extractfile(member).read().strip())
+                    if schema_seq != SAMPLE_SCHEMA_VERSION:
+                        raise SchemaMismatchException("Incorrect schema version! Expected: %d, got: %d."
+                                                      "Please, get the latest version of the dump."
+                                                      % (SAMPLE_SCHEMA_VERSION, schema_seq))
+                    else:
+                        current_app.logger.info("Schema version verified.")
+
+                elif file_name in jsonl_file_table_map:
+                    table = jsonl_file_table_map[file_name]
+                    query = SQL("""\
+                        INSERT INTO {table}
+                             SELECT *
+                               FROM jsonb_populate_recordset(NULL::{table}, %s)
+                    """).format(table=table)
+
+                    current_app.logger.info("Importing data into %s table...", jsonl_file_table_map[file_name])
+                    data = tar.extractfile(member)
+
+                    chunk_size = 50
+                    chunk = []
+                    while True:
+                        row = data.readline().decode("utf-8")
+                        if not row:
+                            break
+
+                        chunk.append(row)
+                        if len(chunk) == chunk_size:
+                            param = f"[{','.join(chunk)}]"
+                            cursor.execute(query, (param,))
+                            chunk = []
+
+                    if chunk:
+                        param = f"[{",".join(chunk)}]"
+                        cursor.execute(query, (param,))
+
+                    connection.commit()
+                    current_app.logger.info("Imported table %s", jsonl_file_table_map[file_name])
+                elif file_name in csv_file_table_map:
+                    current_app.logger.info("Importing data into %s table...", csv_file_table_map[file_name])
+
+                    table = csv_file_table_map[file_name]
+                    fp = tar.extractfile(member)
+                    header = fp.readline().decode("utf-8").strip().split(",")
+                    fields = SQL(",").join(map(Identifier, header))
+                    query = SQL("COPY {table}({fields}) FROM STDIN WITH CSV").format(
+                        table=table, fields=fields
+                    )
+                    cursor.copy_expert(query, fp)
+                    connection.commit()
+
+                    current_app.logger.info("Imported table %s", csv_file_table_map[file_name])
+
+    finally:
+        connection.close()
+        zstd.stdout.close()


### PR DESCRIPTION
Preliminary version of sample data dumps to help develop ListenBrainz locally. These dumps include metadata and popularity data used on entity pages and in showing enriched metadata on ListenBrainz web pages.

I intend to include listens using this metadata and similarity in a future iteration of the sample dumps. The incremental dumps might not be good enough as the entity mbids of listens in an incremental dump might not be present in the small subset of data that is included in sample dumps.