### PR TITLE
LB-1728: Hide lastfm warning when connected

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -438,29 +438,31 @@ export default function MusicServices() {
               Connect to your Last.FM account to import your entire listening
               history and automatically add your new scrobbles to ListenBrainz.
             </p>
-            <div
-              className="alert alert-warning alert-dismissible fade in"
-              role="alert"
-            >
-              You must first disable the &#34;Hide recent listening
-              information&#34; setting in your Last.fm{" "}
-              <a
-                href="https://www.last.fm/settings/privacy"
-                target="_blank"
-                rel="noreferrer"
+            {!permissions.lastfm && (
+              <div
+                className="alert alert-warning alert-dismissible fade in"
+                role="alert"
               >
-                privacy settings
-              </a>
-              .
-              <button
-                type="button"
-                className="close"
-                data-dismiss="alert"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
+                You must first disable the &#34;Hide recent listening
+                information&#34; setting in your Last.fm{" "}
+                <a
+                  href="https://www.last.fm/settings/privacy"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  privacy settings
+                </a>
+                .
+                <button
+                  type="button"
+                  className="close"
+                  data-dismiss="alert"
+                  aria-label="Close"
+                >
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+            )}
             <form onSubmit={handleConnectToLaftFM}>
               <div className="flex flex-wrap" style={{ gap: "1em" }}>
                 <div>


### PR DESCRIPTION
For some reason I thought this was already implemented, but it is not.
The ticket was reopened as it is confusing to have a warning about LFM privacy settings when you are already connected...
The warning is dismissable, but navigating away and back reverts it.
There are some good suggestions to refactor the UX of that page, but in the meantime this should be a good stopgap: when the user is connected, hide the warning.

@Aerozol I know it's not what you asked for, but it took me a full minute to make this PR and fix the confusion issue, at least.
I think we will indeed want to review the connect services page UX, but as we have GSOC projects that will add to it I suggest we wait until after the summer to see if we have more changes to improve those too