### PR TITLE
Improve incremental dump error reporting

### DIFF
--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -51,3 +51,5 @@ TS_PASSWORD = ""
 LB_JDBC_URI = ""
 LB_USER = ""
 LB_PASSWORD = ""
+
+LISTENBRAINZ_API_URL = "http://localhost:8100"

--- a/listenbrainz_spark/dump/__init__.py
+++ b/listenbrainz_spark/dump/__init__.py
@@ -3,6 +3,8 @@ from enum import Enum
 from typing import NamedTuple
 from abc import ABC, abstractmethod
 
+import requests
+
 from listenbrainz_spark.exceptions import DumpNotFoundException
 
 
@@ -101,3 +103,15 @@ class ListenbrainzDumpLoader(ABC):
             sha = f.read().lstrip().split(" ", 1)[0].strip()
 
         return sha
+
+    @abstractmethod
+    def get_api_base_url(self):
+        """ Get the base url for listenbrainz api """
+        pass
+
+    def check_dump_type(self, dump_id: int):
+        """ Query ListenBrainz dump info API to check whether the given dump ID is an incremental or full dump """
+        url = f"{self.get_api_base_url()}/1/status/get-dump-info"
+        response = requests.get(url, params={"id": dump_id})
+        response.raise_for_status()
+        return DumpType.FULL if response.json()["dump_type"] == "full" else DumpType.INCREMENTAL

--- a/listenbrainz_spark/dump/ftp.py
+++ b/listenbrainz_spark/dump/ftp.py
@@ -156,3 +156,6 @@ class ListenBrainzFtpDumpLoader(ListenbrainzDumpLoader):
         dest_path = self.download_dump(filename , directory)
         logger.info(f"Done. Total time: {time.monotonic() - t0:.2f} sec")
         return dest_path
+
+    def get_api_base_url(self):
+        return "https://api.listenbrainz.org"

--- a/listenbrainz_spark/dump/local.py
+++ b/listenbrainz_spark/dump/local.py
@@ -1,5 +1,6 @@
 import os
 
+from listenbrainz_spark import config
 from listenbrainz_spark.dump import ListenbrainzDumpLoader, DumpType
 
 
@@ -9,7 +10,7 @@ class ListenbrainzLocalDumpLoader(ListenbrainzDumpLoader):
         files = os.listdir('listenbrainz-export')
         return list(filter(lambda x: x.startswith(f'listenbrainz-dump-'), files))
 
-    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> (str, str, int):
+    def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> tuple[str, str, int]:
         dump_directories = self.list_dump_directories(dump_type)
 
         listens_dump_list = sorted(dump_directories, key=lambda x: int(x.split('-')[2]))
@@ -19,6 +20,9 @@ class ListenbrainzLocalDumpLoader(ListenbrainzDumpLoader):
         dump_id = int(req_listens_dump.split('-')[2])
 
         return dest_path, listens_file_name, dump_id
+
+    def get_api_base_url(self):
+        return config.LISTENBRAINZ_API_URL
 
     def close(self):
         pass

--- a/listenbrainz_spark/listens/tests/test_dump.py
+++ b/listenbrainz_spark/listens/tests/test_dump.py
@@ -128,10 +128,11 @@ class DumpImporterJobTestCase(SparkNewTestCase):
 
     @patch("ftplib.FTP")
     @patch.object(ListenBrainzFtpDumpLoader, "get_latest_dump_id", return_value=210)
+    @patch.object(ListenBrainzFtpDumpLoader, "check_dump_type", return_value=DumpType.INCREMENTAL)
     @patch("listenbrainz_spark.listens.dump.import_incremental_dump_to_hdfs", side_effect=mock_import_dump_to_hdfs)
     @patch("listenbrainz_spark.listens.dump.search_dump", side_effect=mock_search_dump)
     @patch("listenbrainz_spark.listens.dump.get_latest_full_dump")
-    def test_import_incremental_dump_handler(self, mock_latest_full_dump, _, mock_import_dump, __, ___):
+    def test_import_incremental_dump_handler(self, mock_latest_full_dump, _, mock_import_dump, __, ___, ____):
         """ Test to make sure required incremental dumps are imported. """
         mock_latest_full_dump.return_value = {
             "dump_id": 202,
@@ -151,10 +152,11 @@ class DumpImporterJobTestCase(SparkNewTestCase):
 
     @patch("ftplib.FTP")
     @patch.object(ListenBrainzFtpDumpLoader, "get_latest_dump_id", return_value=210)
+    @patch.object(ListenBrainzFtpDumpLoader, "check_dump_type", return_value=DumpType.INCREMENTAL)
     @patch("listenbrainz_spark.listens.dump.import_incremental_dump_to_hdfs", side_effect=mock_import_dump_to_hdfs_error)
     @patch("listenbrainz_spark.listens.dump.search_dump", side_effect=mock_search_dump)
     @patch("listenbrainz_spark.listens.dump.get_latest_full_dump")
-    def test_import_incremental_dump_handler_error(self, mock_latest_full_dump, _, mock_import_dump, __, ___):
+    def test_import_incremental_dump_handler_error(self, mock_latest_full_dump, _, mock_import_dump, __, ___, ____):
         """ Test to make sure import continues if there is a fatal error. """
         mock_latest_full_dump.return_value = {
             "dump_id": 202,

--- a/listenbrainz_spark/tests/__init__.py
+++ b/listenbrainz_spark/tests/__init__.py
@@ -39,6 +39,9 @@ class ListenBrainzTestDumpLoader(ListenbrainzDumpLoader):
                     tar.add(src_path, arcname=os.path.join(tar_name, filename))
         return dump_tar.name, dump_name, listens_dump_id
 
+    def get_api_base_url(self):
+        return "http://localhost:8100"
+
 
 class SparkNewTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Incremental dumps report an error when any dump id is missing or could not be imported since the last full dump id. This used to work fine because always had the latest full dump available and only imported incremental dumps since then. However, now spark doesn't regularly import full dumps and there are gaps in the incremental dumps id as a result. Therefore, to avoid false errors where the gap is expected, check if the gap is because of a full dump id and ignore it.