### PR TITLE
update readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 sphinx:
    configuration: docs/conf.py


### PR DESCRIPTION
doc builds are failing because of missing imports on older python versions.