### PR TITLE
Fix forgotten react-router import

### DIFF
--- a/frontend/js/src/user/playlists/components/ImportSoundCloudPlaylistModal.tsx
+++ b/frontend/js/src/user/playlists/components/ImportSoundCloudPlaylistModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import NiceModal, { useModal } from "@ebay/nice-modal-react";
 import { toast } from "react-toastify";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import { ToastMsg } from "../../../notifications/Notifications";
 import Loader from "../../../components/Loader";


### PR DESCRIPTION
One import forgotten in #3288

See failing test at https://github.com/metabrainz/listenbrainz-server/actions/runs/15395266698/job/43314280051?pr=3290#step:4:2123