### PR TITLE
Use cosine similarity instead of pearson coefficient for similar users

### DIFF
--- a/listenbrainz_spark/similarity/user.py
+++ b/listenbrainz_spark/similarity/user.py
@@ -54,11 +54,11 @@ def process_similarities(matrix: CoordinateMatrix, max_num_users: int) -> DataFr
     """
     all_similar_users = defaultdict(list)
     for entry in matrix.entries.collect():
-        if entry.x == entry.y or math.isnan(entry.value) or entry.value < 0:
+        if entry.i == entry.j or math.isnan(entry.value) or entry.value < 0:
             continue
 
-        all_similar_users[entry.x].append((entry.y, entry.value))
-        all_similar_users[entry.y].append((entry.x, entry.value))
+        all_similar_users[entry.i].append((entry.j, entry.value))
+        all_similar_users[entry.j].append((entry.i, entry.value))
 
     thresholded_similar_users = {}
     for user_id, similar_users in all_similar_users.items():


### PR DESCRIPTION
Calculating the pearson coefficient using the inbuilt spark utilities requires building a dense feature matrix/dataframe which often leads to a Out of Memory error. The `columnSimilarities` on `RowMatrix` should avoid this and work well enough for our use case.