### PR TITLE
Add Internet Archive metadata cache schema and related SQL changes

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -69,9 +69,14 @@ CREATE UNIQUE INDEX soundcloud_cache_artist_soundcloud_id_idx ON soundcloud_cach
 
 
 -- Internet Archive indexes
-CREATE UNIQUE INDEX internetarchive_cache_track_id_idx ON internetarchive_cache.track (track_id);
-CREATE INDEX internetarchive_cache_track_artist_idx ON internetarchive_cache.track (artist);
+CREATE UNIQUE INDEX internetarchive_cache_track_track_id_idx ON internetarchive_cache.track (track_id);
+CREATE INDEX internetarchive_cache_track_creator_idx ON internetarchive_cache.track (creator);
 CREATE INDEX internetarchive_cache_track_title_idx ON internetarchive_cache.track (title);
+CREATE INDEX internetarchive_cache_track_album_idx ON internetarchive_cache.track (album);
+CREATE INDEX internetarchive_cache_track_year_idx ON internetarchive_cache.track (year);
+CREATE INDEX internetarchive_cache_track_notes_idx ON internetarchive_cache.track (notes);
+CREATE INDEX internetarchive_cache_track_topics_idx ON internetarchive_cache.track (topics);
+
 
 CREATE UNIQUE INDEX similar_recordings_dev_uniq_idx ON similarity.recording_dev (mbid0, mbid1);
 CREATE UNIQUE INDEX similar_recordings_dev_reverse_uniq_idx ON similarity.recording_dev (mbid1, mbid0);

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -67,6 +67,12 @@ CREATE INDEX apple_cache_rel_track_artist_track_id_idx ON apple_cache.rel_track_
 CREATE UNIQUE INDEX soundcloud_cache_track_soundcloud_id_idx ON soundcloud_cache.track (track_id);
 CREATE UNIQUE INDEX soundcloud_cache_artist_soundcloud_id_idx ON soundcloud_cache.artist (artist_id);
 
+
+-- Internet Archive indexes
+CREATE UNIQUE INDEX internetarchive_cache_track_id_idx ON internetarchive_cache.track (track_id);
+CREATE INDEX internetarchive_cache_track_artist_idx ON internetarchive_cache.track (artist);
+CREATE INDEX internetarchive_cache_track_title_idx ON internetarchive_cache.track (title);
+
 CREATE UNIQUE INDEX similar_recordings_dev_uniq_idx ON similarity.recording_dev (mbid0, mbid1);
 CREATE UNIQUE INDEX similar_recordings_dev_reverse_uniq_idx ON similarity.recording_dev (mbid1, mbid0);
 CREATE INDEX similar_recordings_algorithm_dev_idx ON similarity.recording_dev USING gin (metadata);

--- a/admin/timescale/create_schemas.sql
+++ b/admin/timescale/create_schemas.sql
@@ -4,6 +4,7 @@ CREATE SCHEMA mapping;
 CREATE SCHEMA spotify_cache;
 CREATE SCHEMA apple_cache;
 CREATE SCHEMA soundcloud_cache;
+CREATE SCHEMA internetarchive_cache;
 CREATE SCHEMA similarity;
 CREATE SCHEMA tags;
 CREATE SCHEMA popularity;

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -271,6 +271,22 @@ CREATE TABLE soundcloud_cache.track (
     data                    JSONB NOT NULL
 );
 
+-- Internet Archive metadata cache tables
+CREATE SCHEMA IF NOT EXISTS internetarchive_cache;
+
+CREATE TABLE internetarchive_cache.track (
+    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    track_id                TEXT NOT NULL,
+    title                   TEXT NOT NULL,
+    artist                  TEXT,
+    data                    JSONB NOT NULL
+);
+
+CREATE TABLE background_worker_state (
+    key     TEXT NOT NULL,
+    value   TEXT
+);
+
 CREATE TABLE background_worker_state (
     key     TEXT NOT NULL,
     value   TEXT

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -286,11 +286,6 @@ CREATE TABLE background_worker_state (
     key     TEXT NOT NULL,
     value   TEXT
 );
-
-CREATE TABLE background_worker_state (
-    key     TEXT NOT NULL,
-    value   TEXT
-);
 COMMENT ON TABLE background_worker_state IS 'This table is used to store miscellaneous data by various background processes or the ListenBrainz webserver. Use it when storing the data is redis is not reliable enough.';
 
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -275,12 +275,22 @@ CREATE TABLE soundcloud_cache.track (
 CREATE SCHEMA IF NOT EXISTS internetarchive_cache;
 
 CREATE TABLE internetarchive_cache.track (
-    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
-    track_id                TEXT NOT NULL,
-    title                   TEXT NOT NULL,
-    artist                  TEXT,
-    data                    JSONB NOT NULL
+    id            INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    track_id      TEXT NOT NULL,              -- corresponds to your model's id or stream_url
+    title         TEXT NOT NULL,
+    creator       TEXT,                       -- corresponds to 'creator' in your model
+    album         TEXT,
+    year          TEXT,
+    notes         TEXT,
+    topics        TEXT,
+    stream_url    TEXT NOT NULL,
+    duration      INTEGER,
+    artwork_url   TEXT,
+    date          TEXT,
+    data          JSONB NOT NULL,             -- (optional) store the full JSON as backup
+    last_updated  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
 
 CREATE TABLE background_worker_state (
     key     TEXT NOT NULL,

--- a/admin/timescale/updates/2025-07-04-add-internetarchive-metadata-cache.sql
+++ b/admin/timescale/updates/2025-07-04-add-internetarchive-metadata-cache.sql
@@ -1,0 +1,17 @@
+
+BEGIN;
+
+CREATE SCHEMA internetarchive_cache;
+CREATE TABLE internetarchive_cache.track (
+    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
+    track_id                TEXT NOT NULL,
+    title                   TEXT NOT NULL,
+    artist                  TEXT,
+    data                    JSONB NOT NULL
+);
+
+CREATE UNIQUE INDEX internetarchive_cache_track_id_idx ON internetarchive_cache.track (track_id);
+CREATE INDEX internetarchive_cache_track_artist_idx ON internetarchive_cache.track (artist);
+CREATE INDEX internetarchive_cache_track_title_idx ON internetarchive_cache.track (title);
+
+COMMIT;

--- a/admin/timescale/updates/2025-07-04-add-internetarchive-metadata-cache.sql
+++ b/admin/timescale/updates/2025-07-04-add-internetarchive-metadata-cache.sql
@@ -1,17 +1,30 @@
-
 BEGIN;
 
-CREATE SCHEMA internetarchive_cache;
+CREATE SCHEMA IF NOT EXISTS internetarchive_cache;
+
 CREATE TABLE internetarchive_cache.track (
-    id                      INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL,
-    track_id                TEXT NOT NULL,
-    title                   TEXT NOT NULL,
-    artist                  TEXT,
-    data                    JSONB NOT NULL
+    id            INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    track_id      TEXT NOT NULL,              -- unique identifier for the track
+    title         TEXT NOT NULL,
+    creator       TEXT,
+    album         TEXT,
+    year          TEXT,
+    notes         TEXT,
+    topics        TEXT,
+    stream_url    TEXT NOT NULL,
+    duration      INTEGER,
+    artwork_url   TEXT,
+    date          TEXT,
+    data          JSONB NOT NULL,             -- full metadata as JSON
+    last_updated  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
-CREATE UNIQUE INDEX internetarchive_cache_track_id_idx ON internetarchive_cache.track (track_id);
-CREATE INDEX internetarchive_cache_track_artist_idx ON internetarchive_cache.track (artist);
+CREATE UNIQUE INDEX internetarchive_cache_track_track_id_idx ON internetarchive_cache.track (track_id);
+CREATE INDEX internetarchive_cache_track_creator_idx ON internetarchive_cache.track (creator);
 CREATE INDEX internetarchive_cache_track_title_idx ON internetarchive_cache.track (title);
+CREATE INDEX internetarchive_cache_track_album_idx ON internetarchive_cache.track (album);
+CREATE INDEX internetarchive_cache_track_year_idx ON internetarchive_cache.track (year);
+CREATE INDEX internetarchive_cache_track_notes_idx ON internetarchive_cache.track (notes);
+CREATE INDEX internetarchive_cache_track_topics_idx ON internetarchive_cache.track (topics);
 
 COMMIT;


### PR DESCRIPTION
This PR introduces a new schema (`internetarchive_cache`) and table (`track`) to support caching of Internet Archive metadata.

- Adds schema and table creation to SQL migration scripts
- Creates indexes for efficient querying by `track_id`, `artist`, and `title`
- Updates related schema and table definition files

These changes will help efficiently store and retrieve Internet Archive metadata in the database.