### PR TITLE
Fix "Invalid video id" in YoutubePlayer

### DIFF
--- a/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
@@ -402,6 +402,7 @@ export default class YoutubePlayer extends React.Component<YoutubePlayerProps>
             onError={this.onError}
             onStateChange={this.handlePlayerStateChanged}
             onReady={this.onReady}
+            videoId=""
           />
         </div>
       </Draggable>


### PR DESCRIPTION
While using a debugger to trace the issue, I found the following line inside the Youtube's iFramePlayer code triggered the issue: 
```javascript
if((a=String(Y(a,"videoId")))&&(a.length!==11||!a.match(/^[a-zA-Z0-9\-_]+$/)))throw Error("Invalid video id");
```
I am guessing that code is basically stringifying the input videoId, `String(null)` evaluates to `"null"` and `String(undefined)` to `"undefined"` which leads to the error.

Empty string avoids the issue, hence using that as default videoId.
