### PR TITLE
Reinstate /settings/import page

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -383,6 +383,13 @@ export default function AddData() {
             </Link>
           </em>
         </li>
+        <li>
+          <em>
+            <Link to="/settings/import/">
+              Import your listening history (file uploads)
+            </Link>
+          </em>
+        </li>
       </ul>
 
       <h3>Playlist management</h3>

--- a/frontend/js/src/routes/redirectRoutes.tsx
+++ b/frontend/js/src/routes/redirectRoutes.tsx
@@ -20,10 +20,6 @@ const getRedirectRoutes = (): RouteObject[] => {
           path: "huesound/",
           element: <Navigate to="/explore/huesound/" replace />,
         },
-        {
-          path: "import/",
-          element: <Navigate to="/settings/import/" replace />,
-        },
       ],
     },
   ];

--- a/frontend/js/src/settings/import/ImportListens.tsx
+++ b/frontend/js/src/settings/import/ImportListens.tsx
@@ -1,0 +1,86 @@
+import * as React from "react";
+
+import { Link, useLoaderData } from "react-router";
+import { Helmet } from "react-helmet";
+import ReactTooltip from "react-tooltip";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPersonDigging } from "@fortawesome/free-solid-svg-icons";
+
+type ImportListensLoaderData = {
+  user_has_email: boolean;
+};
+
+export default function ImportListens() {
+  const data = useLoaderData() as ImportListensLoaderData;
+  const { user_has_email: userHasEmail } = data;
+
+  return (
+    <>
+      <Helmet>
+        <title>Import listening history</title>
+      </Helmet>
+      <h2 className="page-title">Import your listening history</h2>
+      {!userHasEmail && (
+        <div className="alert alert-danger">
+          You have not provided an email address. Please provide an{" "}
+          <a href="https://musicbrainz.org/account/edit">email address</a> and{" "}
+          <em>verify it</em> to submit listens. Read this{" "}
+          <a href="https://blog.metabrainz.org/?p=8915">blog post</a> to
+          understand why we need your email. You can provide us with an email on
+          your{" "}
+          <a href="https://musicbrainz.org/account/edit">MusicBrainz account</a>{" "}
+          page.
+        </div>
+      )}
+      <p>
+        This page allows you to import your{" "}
+        <span className="strong" data-tip data-for="info-tooltip">
+          listens
+        </span>{" "}
+        from third-party music services by uploading backup files.
+      </p>
+      <p className="alert alert-info">
+        To connect to a music service and track{" "}
+        <strong>
+          <em>new</em>
+        </strong>{" "}
+        listens, head to the{" "}
+        <Link to="/settings/music-services/details/">Connect services</Link>{" "}
+        page .<br />
+        For submitting listens from your music player or devices, check out the{" "}
+        <Link to="/add-data/">Submitting data</Link> page.
+      </p>
+      <p>
+        <ReactTooltip id="info-tooltip" place="top">
+          Fun Fact: The term <strong>scrobble</strong> is a trademarked term by
+          Last.fm, and we cannot use it.
+          <br />
+          Instead, we use the term <strong>listen</strong> for our data.
+        </ReactTooltip>
+        For example if you{" "}
+        <Link to="/settings/music-services/details/">connect to Spotify</Link>{" "}
+        we are limited to retrieving your last 50 listens.
+        <br />
+        You can however request your{" "}
+        <a
+          href="https://www.spotify.com/us/account/privacy/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          extended streaming history
+        </a>
+        , which contains your entire listening history, and upload it here. To
+        avoid duplicates, be sure to set the appropriate limit date and time.
+      </p>
+
+      <h3>
+        Coming soon
+        <FontAwesomeIcon icon={faPersonDigging} size="sm" className="ms-2" />
+      </h3>
+      <p>
+        We are currently working on this feature as a matter of high priority,
+        please stay tuned.
+      </p>
+    </>
+  );
+}

--- a/frontend/js/src/settings/layout.tsx
+++ b/frontend/js/src/settings/layout.tsx
@@ -18,6 +18,7 @@ const sections: Section[] = [
     links: [
       { to: "music-services/details/", label: "Connect services" },
       { to: "brainzplayer/", label: "Music player" },
+      { to: "import/", label: "Import listens" },
       { to: "link-listens/", label: "Link listens" },
       { to: "../add-data/", label: "Submitting data" },
     ],

--- a/frontend/js/src/settings/routes/index.tsx
+++ b/frontend/js/src/settings/routes/index.tsx
@@ -38,6 +38,14 @@ const getSettingsRoutes = (): RouteObject[] => {
           },
         },
         {
+          path: "import/",
+          loader: RouteLoader,
+          lazy: async () => {
+            const ImportListens = await import("../import/ImportListens");
+            return { Component: ImportListens.default };
+          },
+        },
+        {
           path: "brainzplayer/",
           lazy: async () => {
             const BrainzPlayerSettings = await import(

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -79,15 +79,8 @@ def import_data():
     else:
         user_has_email = True
 
-    # Return error if LIBREFM_API_KEY is not given in config.py
-    if 'LIBREFM_API_KEY' not in current_app.config or current_app.config['LIBREFM_API_KEY'] == "":
-        return jsonify({"error": "LIBREFM_API_KEY not specified."}), 404
-
     data = {
         "user_has_email": user_has_email,
-        "profile_url": url_for('user.index', path="", user_name=current_user.musicbrainz_id),
-        "librefm_api_url": current_app.config["LIBREFM_API_URL"],
-        "librefm_api_key": current_app.config["LIBREFM_API_KEY"],
     }
 
     return jsonify(data)


### PR DESCRIPTION
This page was removed in [#3301](https://github.com/metabrainz/listenbrainz-server/issues/3301) as we moved the last feature out of that page.
However we have an ongoing GSOC project for importing backup files, which will need a place to live. This is the page,.

Since the removal has not been deployed to prod yet, rather than re-adding it at a later date when we have the feature, we are opting for re-adding it now with a "coming soon" placeholder so the page never officially went away for users.

I also modified the page content to make it a bit clearer and clearly point to other relevant pages.

![image](https://github.com/user-attachments/assets/55ad7889-8d23-42c5-b7b0-d35cc1a85c74)
