### PR TITLE
Integrating Internet Archive recordings into Brainzplayer 

### DIFF
--- a/frontend/js/src/common/brainzplayer/InternetArchivePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/InternetArchivePlayer.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { faArchive } from "@fortawesome/free-solid-svg-icons";
+import { DataSourceProps, DataSourceType } from "./BrainzPlayer";
+
+// Hardcoded track for now
+const HARDCODED_TRACK = {
+  track_id: "https://archive.org/details/00TtuloInttrprete66",
+  name:
+    "Los Norteños / Cuando Canta La Lluvia - Perez Prado y Hermanas Montoya (Very Rare Recordings)",
+  artist: ["Pérez Prado y Orquesta con Hermanas Montoya"],
+  album: "RCA Victor #70-9428",
+  stream_urls: [
+    "https://archive.org/download/00TtuloInttrprete66/Cuando%20Canta%20La%20Lluvia.m4a",
+    "https://archive.org/download/00TtuloInttrprete66/Cuando%20Canta%20La%20Lluvia.mp3",
+  ],
+  artwork_url:
+    "https://archive.org/download/00TtuloInttrprete66/Cuando%20Canta%20La%20Lluvia.png",
+};
+
+export default class InternetArchivePlayer
+  extends React.Component<DataSourceProps>
+  implements DataSourceType {
+  public name = "internetArchive";
+  public domainName = "archive.org";
+  public icon = faArchive;
+  public iconColor = "#6c757d";
+  audioRef: React.RefObject<HTMLAudioElement>;
+
+  constructor(props: DataSourceProps) {
+    super(props);
+    this.audioRef = React.createRef();
+  }
+
+  playListen = () => {
+    const {
+      onPlayerPausedChange,
+      onTrackInfoChange,
+      onDurationChange,
+    } = this.props;
+    if (this.audioRef.current) {
+      this.audioRef.current.currentTime = 0;
+      this.audioRef.current.play();
+      onPlayerPausedChange(false);
+      onTrackInfoChange(
+        HARDCODED_TRACK.name,
+        HARDCODED_TRACK.track_id,
+        HARDCODED_TRACK.artist.join(", "),
+        HARDCODED_TRACK.album,
+        [{ src: HARDCODED_TRACK.artwork_url }]
+      );
+      onDurationChange(this.audioRef.current.duration * 1000 || 0);
+    }
+  };
+
+  togglePlay = () => {
+    const { playerPaused, onPlayerPausedChange } = this.props;
+    if (!this.audioRef.current) return;
+    if (playerPaused) {
+      this.audioRef.current.play();
+      onPlayerPausedChange(false);
+    } else {
+      this.audioRef.current.pause();
+      onPlayerPausedChange(true);
+    }
+  };
+
+  seekToPositionMs = (ms: number) => {
+    const { onProgressChange } = this.props;
+    if (this.audioRef.current) {
+      this.audioRef.current.currentTime = ms / 1000;
+      onProgressChange(ms);
+    }
+  };
+
+  canSearchAndPlayTracks = () => false; // For now, no search
+
+  datasourceRecordsListens = () => false;
+
+  handleAudioEnded = () => {
+    const { onTrackEnd } = this.props;
+    onTrackEnd();
+  };
+
+  handleTimeUpdate = () => {
+    const { onProgressChange } = this.props;
+    if (this.audioRef.current) {
+      onProgressChange(this.audioRef.current.currentTime * 1000);
+    }
+  };
+
+  handleLoadedMetadata = () => {
+    const { onDurationChange } = this.props;
+    if (this.audioRef.current) {
+      onDurationChange(this.audioRef.current.duration * 1000);
+    }
+  };
+
+  render() {
+    const { show, playerPaused } = this.props;
+    if (!show) return null;
+    return (
+      <div className="internet-archive-player">
+        <img
+          src={HARDCODED_TRACK.artwork_url}
+          alt={HARDCODED_TRACK.name}
+          width={60}
+          style={{ marginRight: 10 }}
+        />
+        <audio
+          ref={this.audioRef}
+          src={HARDCODED_TRACK.stream_urls[0]}
+          onEnded={this.handleAudioEnded}
+          onTimeUpdate={this.handleTimeUpdate}
+          onLoadedMetadata={this.handleLoadedMetadata}
+          autoPlay={!playerPaused}
+        >
+          <track kind="captions" />
+        </audio>
+        <div>
+          <strong>{HARDCODED_TRACK.artist.join(", ")}</strong> –{" "}
+          {HARDCODED_TRACK.name}
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -5,13 +5,13 @@ import {
   faSoundcloud,
   faYoutube,
 } from "@fortawesome/free-brands-svg-icons";
+import { faArchive, faGripLines } from "@fortawesome/free-solid-svg-icons";
 import { Helmet } from "react-helmet";
 import { Link } from "react-router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { toast } from "react-toastify";
 import ReactTooltip from "react-tooltip";
 import { ReactSortable } from "react-sortablejs";
-import { faGripLines } from "@fortawesome/free-solid-svg-icons";
 import { IconDefinition, IconProp } from "@fortawesome/fontawesome-svg-core";
 import Switch from "../../components/Switch";
 import GlobalAppContext from "../../utils/GlobalAppContext";
@@ -42,6 +42,11 @@ export const dataSourcesInfo = {
     icon: faApple,
     color: "#000000",
   },
+  internetArchive: {
+    name: "Internet Archive",
+    icon: faArchive,
+    color: "#6c757d",
+  },
 } as const;
 
 export type DataSourceKey = keyof typeof dataSourcesInfo;
@@ -52,6 +57,7 @@ export const defaultDataSourcesPriority = [
   "appleMusic",
   "soundcloud",
   "youtube",
+  "internetArchive",
 ] as DataSourceKey[];
 
 function BrainzPlayerSettings() {
@@ -165,6 +171,8 @@ function BrainzPlayerSettings() {
     currentUser?.auth_token,
     userPreferences,
   ]);
+
+  const internetArchivePlayerRef = React.useRef<any>(null);
 
   return (
     <>

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -695,7 +695,7 @@ declare type BrainzPlayerSettings = {
   appleMusicEnabled?: boolean;
   brainzplayerEnabled?: boolean;
   dataSourcesPriority?: Array<
-    "spotify" | "youtube" | "soundcloud" | "appleMusic"
+    "spotify" | "youtube" | "soundcloud" | "appleMusic" | "internetArchive"
   >;
 };
 


### PR DESCRIPTION
## Summary

This PR adds support for Internet Archive as a new data source in BrainzPlayer. Users can now play tracks from the Internet Archive, see the IA icon, and set its priority alongside other music services in the player settings.

## Key Changes

- Added Internet Archive player component with hardcoded track (for now).
- Integrated Internet Archive into BrainzPlayer and settings UI.
- Added Internet Archive icon for better visual distinction not an official one will add it later .
- Users can set the priority/order of Internet Archive in the player settings.


## Demo

I have attached a video of the player see below 

https://github.com/user-attachments/assets/536ae6e2-bfea-4732-a4e5-b1f3f41a6155


