### PR TITLE
Reload the static assets manifest file in development

### DIFF
--- a/listenbrainz/webserver/static_manager.py
+++ b/listenbrainz/webserver/static_manager.py
@@ -1,19 +1,32 @@
 import os.path
 import json
+import time
+from flask import current_app
 
 MANIFEST_PATH = os.path.join("/", "static", "dist", "manifest.json")
 
 manifest_content = {}
-
+last_reload_time = 0
+debounce_delay_seconds = 5
 
 def read_manifest():
+    global manifest_content
     if os.path.isfile(MANIFEST_PATH):
         with open(MANIFEST_PATH) as manifest_file:
-            global manifest_content
             manifest_content = json.load(manifest_file)
 
 
 def get_static_path(resource_name):
+    global last_reload_time
+    current_time = time.time()
+    # In development, reload the manifest file when requesting assets,
+    # limiting to one call every 5 seconds
+    if current_app.config["DEBUG"] == True:
+        if current_time - last_reload_time >= debounce_delay_seconds:
+            current_app.logger.info("Reloading manifest file")
+            read_manifest()
+            last_reload_time = current_time
+
     if resource_name not in manifest_content:
         return "/static/%s" % resource_name
     return manifest_content[resource_name]


### PR DESCRIPTION
We have an issue with the manifest file for static assets, which gets read once on startup and never again.
This causes an issue as the static_builder containers will be compiling resources and emitting that file after the flask app has already read the previous version of the file, requiring to reload the web container after successful static assets build.

Changed that to reload the manifest file when the get_static_path function is called, but debouncing the call to only once every 5 seconds, to avoid opening the file 15 times in a second when we load a page's assets (we get many requests for static assets in bursts)