### PR TITLE
Add Data: Longplay for Mac

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -71,7 +71,7 @@ export default function AddData() {
           <em>
             <a href="https://longplay.app/">Longplay</a>
           </em>
-          , an album-based music player for iOS
+          , an album-based music player for iOS and macOS
         </li>
         <li>
           <em>


### PR DESCRIPTION
Longplay is now also available on Mac, where ListenBrainz is supported, too.
