### PR TITLE
LB-1809: add automatic LB /track URL recognition

### DIFF
--- a/frontend/js/src/utils/SearchAlbumOrMBID.tsx
+++ b/frontend/js/src/utils/SearchAlbumOrMBID.tsx
@@ -17,9 +17,9 @@ import GlobalAppContext from "./GlobalAppContext";
 import DropdownRef from "./Dropdown";
 import {
   LB_ALBUM_MBID_REGEXP,
-  RELEASE_GROUP_MBID_REGEXP,
-  RELEASE_MBID_REGEXP,
-  RECORDING_MBID_REGEXP,
+  MB_RELEASE_GROUP_MBID_REGEXP,
+  MB_RELEASE_MBID_REGEXP,
+  MB_RECORDING_MBID_REGEXP,
   UUID_REGEXP,
 } from "./constants";
 
@@ -117,10 +117,10 @@ const SearchAlbumOrMBID = forwardRef<
       throttle(
         async (input: string) => {
           const newReleaseMBID =
-            RELEASE_MBID_REGEXP.exec(input)?.[1] ??
+            MB_RELEASE_MBID_REGEXP.exec(input)?.[1] ??
             UUID_REGEXP.exec(input)?.[0];
           const newReleaseGroupMBID =
-            RELEASE_GROUP_MBID_REGEXP.exec(input)?.[1].toLowerCase() ??
+            MB_RELEASE_GROUP_MBID_REGEXP.exec(input)?.[1].toLowerCase() ??
             LB_ALBUM_MBID_REGEXP.exec(input)?.[1].toLowerCase();
           try {
             if (newReleaseMBID) {
@@ -168,10 +168,10 @@ const SearchAlbumOrMBID = forwardRef<
     setLoading(true);
     const isValidUUID = UUID_REGEXP.test(inputValue);
     const isValidAlbumUUID =
-      RELEASE_MBID_REGEXP.test(inputValue) ||
-      RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
+      MB_RELEASE_MBID_REGEXP.test(inputValue) ||
+      MB_RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
       LB_ALBUM_MBID_REGEXP.test(inputValue);
-    const isValidRecordingUUID = RECORDING_MBID_REGEXP.test(inputValue);
+    const isValidRecordingUUID = MB_RECORDING_MBID_REGEXP.test(inputValue);
     if (isValidRecordingUUID && isFunction(switchMode)) {
       switchMode(inputValue);
       return;

--- a/frontend/js/src/utils/SearchTrackOrMBID.tsx
+++ b/frontend/js/src/utils/SearchTrackOrMBID.tsx
@@ -17,9 +17,10 @@ import GlobalAppContext from "./GlobalAppContext";
 import DropdownRef from "./Dropdown";
 import {
   LB_ALBUM_MBID_REGEXP,
-  RECORDING_MBID_REGEXP,
-  RELEASE_GROUP_MBID_REGEXP,
-  RELEASE_MBID_REGEXP,
+  LB_RECORDING_MBID_REGEXP,
+  MB_RECORDING_MBID_REGEXP,
+  MB_RELEASE_GROUP_MBID_REGEXP,
+  MB_RELEASE_MBID_REGEXP,
   UUID_REGEXP,
 } from "./constants";
 
@@ -155,7 +156,8 @@ const SearchTrackOrMBID = forwardRef<
       throttle(
         async (input: string, canonicalReleaseMBID?: string) => {
           let newRecordingMBID =
-            RECORDING_MBID_REGEXP.exec(input)?.[1] ??
+            MB_RECORDING_MBID_REGEXP.exec(input)?.[1] ??
+            LB_RECORDING_MBID_REGEXP.exec(input)?.[1] ??
             UUID_REGEXP.exec(input)?.[0];
           if (!newRecordingMBID) {
             return;
@@ -242,10 +244,12 @@ const SearchTrackOrMBID = forwardRef<
     }
     setLoading(true);
     const isValidUUID = UUID_REGEXP.test(inputValue);
-    const isValidRecordingUUID = RECORDING_MBID_REGEXP.test(inputValue);
+    const isValidRecordingUUID =
+      MB_RECORDING_MBID_REGEXP.test(inputValue) ||
+      LB_RECORDING_MBID_REGEXP.test(inputValue);
     const isValidAlbumUUID =
-      RELEASE_MBID_REGEXP.test(inputValue) ||
-      RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
+      MB_RELEASE_MBID_REGEXP.test(inputValue) ||
+      MB_RELEASE_GROUP_MBID_REGEXP.test(inputValue) ||
       LB_ALBUM_MBID_REGEXP.test(inputValue);
     if (isValidAlbumUUID && isFunction(switchMode)) {
       switchMode(inputValue);

--- a/frontend/js/src/utils/constants.ts
+++ b/frontend/js/src/utils/constants.ts
@@ -41,7 +41,8 @@ const musicbrainz_website_regex = "^(?:https?:\/\/)?(?:beta\.)?musicbrainz\.org"
 const listenbrainz_website_regex = "^(?:https?:\/\/)?(?:beta\.)?listenbrainz\.org"
 // Note: adding a start-of-string and end-of-string character for UUID_REGEXP
 export const UUID_REGEXP = new RegExp(`^${uuid}$`,"i");
-export const RECORDING_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/recording\/${uuid}\/?`, "i");
-export const RELEASE_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/release\/${uuid}\/?`, "i");
-export const RELEASE_GROUP_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/release-group\/${uuid}\/?`, "i");
+export const MB_RECORDING_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/recording\/${uuid}\/?`, "i");
+export const MB_RELEASE_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/release\/${uuid}\/?`, "i");
+export const MB_RELEASE_GROUP_MBID_REGEXP = new RegExp(`${musicbrainz_website_regex}\/release-group\/${uuid}\/?`, "i");
 export const LB_ALBUM_MBID_REGEXP = new RegExp(`${listenbrainz_website_regex}\/album\/${uuid}\/?`, "i");
+export const LB_RECORDING_MBID_REGEXP = new RegExp(`${listenbrainz_website_regex}\/track\/${uuid}\/?`, "i");


### PR DESCRIPTION
In the same way we automatically recognize MusicBrainz recording URLs in the "Add listens" and "Link listen" modals, adding the new listenbrainz.org/track/$MBID route.
Also renamed existing regexps to avoid confusion.

<img width="1094" height="503" alt="image" src="https://github.com/user-attachments/assets/886d4401-71b9-43d5-98fb-d9534b104ad0" />