### PR TITLE
Show queue buttons even if not currently playing a track

### DIFF
--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -477,31 +477,26 @@ $youtube-resize-transition: height 0.25s ease-out;
     min-width: 3em;
   }
 
-  // First header with negative top margin to remove gap with buttons above
-  > :nth-child(1 of .queue-headers) {
-    margin-top: -30px;
-  }
   .queue-headers {
-    font-size: 16px;
     margin-top: 4px;
     margin-bottom: 4px;
-    display: flex;
-    justify-content: space-between;
     border-bottom: 1px solid #ccc;
 
     h4 {
-      font-size: 18px;
       margin: 0;
       padding: 10px;
       padding-left: 0;
-      width: 100%;
     }
-
-    .queue-buttons {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
+  }
+  .queue-buttons {
+    display: flex;
+    justify-content: end;
+    align-items: center;
+    gap: 1em;
+  }
+  // Negative top margin to remove gap with buttons above
+  .queue-buttons + .queue-headers {
+    margin-top: -30px;
   }
 }
 

--- a/frontend/js/src/common/brainzplayer/Queue.tsx
+++ b/frontend/js/src/common/brainzplayer/Queue.tsx
@@ -108,26 +108,28 @@ function Queue(props: BrainzPlayerQueueProps) {
         title="Hide queue"
         onClick={onHide}
       />
+      {queueNextUp.length > 0 && (
+        <div className="queue-buttons d-flex justify-content-end gap-3">
+          <button
+            className="btn btn-info btn-sm"
+            onClick={addQueueToPlaylist}
+            type="button"
+          >
+            <FontAwesomeIcon icon={faSave} fixedWidth /> Save to Playlist
+          </button>
+          <button
+            className="btn btn-info btn-sm"
+            onClick={clearQueue}
+            type="button"
+          >
+            Clear Queue
+          </button>
+        </div>
+      )}
       {currentListen && (
         <>
           <div className="queue-headers">
             <h4>Now Playing:</h4>
-            <div className="queue-buttons">
-              <button
-                className="btn btn-info btn-sm"
-                onClick={addQueueToPlaylist}
-                type="button"
-              >
-                <FontAwesomeIcon icon={faSave} fixedWidth /> Save to Playlist
-              </button>
-              <button
-                className="btn btn-info btn-sm"
-                onClick={clearQueue}
-                type="button"
-              >
-                Clear Queue
-              </button>
-            </div>
           </div>
           <ListenCard
             key={`queue-listening-now-${getListenCardKey(currentListen)}}`}
@@ -175,9 +177,8 @@ function Queue(props: BrainzPlayerQueueProps) {
           </div>
         )}
       </div>
-      <div className="queue-headers">
-        <h4>On this page:</h4>
-        {ambientQueue.length > 0 && (
+      {ambientQueue.length > 0 && (
+        <>
           <div className="queue-buttons">
             <button
               className="btn btn-info btn-sm"
@@ -187,8 +188,11 @@ function Queue(props: BrainzPlayerQueueProps) {
               Move to Queue
             </button>
           </div>
-        )}
-      </div>
+          <div className="queue-headers">
+            <h4>On this page:</h4>
+          </div>
+        </>
+      )}
       <div className="queue-list" data-testid="ambient-queue">
         {ambientQueue.length > 0
           ? ambientQueue


### PR DESCRIPTION
The buttons to modify the play queue are not shown when there is currently no track playing, which is annoying if you want to prepare your play queue before playing.
There's no reason why the two should be tied together, it was implemented like this for CSS/layout reasons.
Refactoring the markup and styles to allow that.
