### PR TITLE
Update troi to 2025.8.6.3 and pass token to lb-radio

### DIFF
--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -7,7 +7,7 @@ import listenbrainz.db.fresh_releases
 from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.decorators import crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
-from listenbrainz.webserver.views.api_tools import _parse_int_arg, _parse_bool_arg
+from listenbrainz.webserver.views.api_tools import _parse_int_arg, _parse_bool_arg, validate_auth_header
 from listenbrainz.db.color import get_releases_for_color
 from troi.patches.lb_radio import LBRadioPatch
 from troi.patch import Patch
@@ -181,7 +181,17 @@ def lb_radio():
             f"The mode parameter must be one of 'easy', 'medium', 'hard'.")
 
     try:
-        patch = LBRadioPatch({ "mode": mode, "prompt": prompt, "quiet": True, "min_recordings": 1})
+        auth_token = request.headers.get("Authorization")
+        if auth_token is not None:
+            auth_token = auth_token.split(" ")[1]
+
+        patch = LBRadioPatch({
+            "mode": mode,
+            "prompt": prompt,
+            "quiet": True,
+            "min_recordings": 1,
+            "auth_token": auth_token
+        })
         playlist = patch.generate_playlist()
     except RuntimeError as err:
         raise APIBadRequest(f"LB Radio generation failed: {err}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ xmltodict==0.14.2
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v3.0.0
 spotipy==2.25.1
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@830ecb2b2120acbd5deed2dab4587784c7be04b6
-troi==2025.8.6.2
+troi==2025.8.6.3
 eventlet==0.39.1
 uWSGI==2.0.29
 sentry-sdk[flask]==2.27.0


### PR DESCRIPTION
Forward the token if any received in the LB Radio endpoint to the LB radio troi patch. This allows extended ratelimit for whitelisted users and regular ratelimits for normal users to prevent DDoS.
