### PR TITLE
Use compression for exports zip files

### DIFF
--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -283,7 +283,7 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         archive_path = os.path.join(tmp_dir, archive_name)
-        with zipfile.ZipFile(archive_path, "w") as archive:
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             all_files = []
 
             user_file = export_info_for_user(export_id, db_conn, tmp_dir, user)


### PR DESCRIPTION
Reported in the LB matrix channel:
> huh, just tried using the listenbrainz zip export (which worked fine) but resulted in a huge (117MB) file.. because it does no compression (store mode)
making a zip with compression takes it down to 8.7MB
... is that intentional? seems like doing at least some level of compression would definitely save space

> looks like this is just the default of the python library for creating zip files that processes these background jobs

ZIP_DEFLATED compression mode uses zlib, which comes bundled with python, so does not require installing any other compression dependency. https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_DEFLATED

Tested locally, everything seems to be working and the resulting zip file is indeed smaller.