### PR TITLE
LB-1815: "Open in MusicBrainz" sohuld open in MB

### DIFF
--- a/frontend/js/src/common/brainzplayer/MenuOptions.tsx
+++ b/frontend/js/src/common/brainzplayer/MenuOptions.tsx
@@ -85,7 +85,7 @@ function MenuOptions(props: MenuOptionsProps) {
           {recordingMBID && (
             <ListenControl
               icon={faExternalLinkAlt}
-              text="Open in MusicBrainz"
+              text="Go to track page"
               link={`/track/${recordingMBID}`}
             />
           )}

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -573,7 +573,11 @@ export class ListenCard extends React.Component<
                         title="Open in MusicBrainz"
                         text="Open in MusicBrainz"
                         key="Open in MusicBrainz"
-                        link={`/track/${recordingMBID}`}
+                        link={`https://musicbrainz.org/recording/${recordingMBID}`}
+                        anchorTagAttributes={{
+                          target: "_blank",
+                          rel: "noopener noreferrer",
+                        }}
                       />
                     )}
                     {renderBrainzplayer && (


### PR DESCRIPTION
We changed all links to recordings to point to the new track pages on ListenBrainz, but this one should definitely open in MusicBrainz instead, or be renamed or removed.
Opting to revert to previous functionality.

Also renamed the option in BrainzPlayer menu, as I think in this case it makes more sense to open the LB page.