### PR TITLE
Funkwhale player not submitting listens to LB

### DIFF
--- a/frontend/js/src/common/brainzplayer/FunkwhalePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/FunkwhalePlayer.tsx
@@ -506,7 +506,7 @@ export default class FunkwhalePlayer
   };
 
   datasourceRecordsListens = (): boolean => {
-    return true; // record listens
+    return false; // record listens
   };
 
   getAuthenticatedAudioUrl = async (

--- a/frontend/js/tests/common/brainzplayer/FunkwhalePlayer.test.tsx
+++ b/frontend/js/tests/common/brainzplayer/FunkwhalePlayer.test.tsx
@@ -261,7 +261,7 @@ describe("FunkwhalePlayer", () => {
       expect(playerRef.current?.canSearchAndPlayTracks()).toBe(false);
     });
 
-    it("should return true for datasourceRecordsListens", () => {
+    it("should return false for datasourceRecordsListens", () => {
       const playerRef = React.createRef<FunkwhalePlayer>();
       render(
         <GlobalAppContext.Provider value={defaultContext}>
@@ -269,7 +269,7 @@ describe("FunkwhalePlayer", () => {
         </GlobalAppContext.Provider>
       );
 
-      expect(playerRef.current?.datasourceRecordsListens()).toBe(true);
+      expect(playerRef.current?.datasourceRecordsListens()).toBe(false);
     });
   });
 });


### PR DESCRIPTION

`datasourceRecordsListens()` method return `true` which causing  BP to skip listen submission!


`datasourceRecordsListens()`  should return `false`

this will probably fix this issue!
  
 ```typescript
 datasourceRecordsListens = (): boolean => {
    return false; // record listens
  };
 ```


