### PR TITLE
fixed cover art image requests were blocked due to CORS

### DIFF
--- a/frontend/js/src/common/brainzplayer/FunkwhalePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/FunkwhalePlayer.tsx
@@ -585,7 +585,12 @@ export default class FunkwhalePlayer
         </audio>
         {artworkUrl && (
           <div>
-            <img alt="coverart" className="img-fluid" src={artworkUrl} />
+            <img
+              alt="coverart"
+              className="img-fluid"
+              src={artworkUrl}
+              crossOrigin="anonymous"
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
When fetching artwork from some public instance, the image requests were blocked due to CORS

added `crossOrigin="anonymous"` to cover art image to fix this!