### PR TITLE
Format numbers in graph tooltips

### DIFF
--- a/frontend/js/src/user/charts/components/Bar.tsx
+++ b/frontend/js/src/user/charts/components/Bar.tsx
@@ -19,13 +19,14 @@ export default function Bar(props: BarProps) {
 
   const customTooltip = (tooltipProps: BarTooltipProps<BarDatum>) => {
     const { data: datum, value } = tooltipProps;
+    const formattedValue = new Intl.NumberFormat().format(value);
     return (
       <TooltipWrapper anchor="center" position={[0, 0]}>
         <div className="graph-tooltip" id={datum.entity.toString()}>
           <span className="badge bg-info">#{datum.idx}</span> {datum.entity}
           :&nbsp;
           <b>
-            {value} {Number(value) === 1 ? "listen" : "listens"}
+            {formattedValue} {Number(value) === 1 ? "listen" : "listens"}
           </b>
           {datum.artist && <div>{datum.artist}</div>}
         </div>

--- a/frontend/js/src/user/stats/components/BarDualTone.tsx
+++ b/frontend/js/src/user/stats/components/BarDualTone.tsx
@@ -147,26 +147,26 @@ export default function BarDualTone(props: BarDualToneProps) {
     const { id, data: datum, color, value } = elem;
 
     let dateString: string;
-    let listenCount: number;
     if (id === "lastRangeCount") {
       const lastRangeDate = new Date((datum.lastRangeTs ?? 0) * 1000);
       dateString = lastRangeDate.toLocaleString("en-us", {
         ...dateFormat,
         timeZone: "UTC",
       });
-      listenCount = datum.lastRangeCount!;
     } else {
       const thisRangeDate = new Date((datum?.thisRangeTs ?? 0) * 1000);
       dateString = thisRangeDate.toLocaleString("en-us", {
         ...dateFormat,
         timeZone: "UTC",
       });
-      listenCount = datum.thisRangeCount!;
     }
+    const formattedValue = new Intl.NumberFormat().format(value);
     return (
       <BasicTooltip
         id={dateString}
-        value={`${value} ${Number(value) === 1 ? "listen" : "listens"}`}
+        value={`${formattedValue} ${
+          Number(value) === 1 ? "listen" : "listens"
+        }`}
         color={color}
       />
     );

--- a/frontend/js/src/user/stats/components/Choropleth.tsx
+++ b/frontend/js/src/user/stats/components/Choropleth.tsx
@@ -292,9 +292,9 @@ export default function CustomChoropleth(props: ChoroplethProps) {
           >
             <Chip color={selectedCountry.color!} style={{ marginRight: 7 }} />
             <span>
-              {"My Listens: "}
+              Listens:
               <strong>
-                {value} {suffix}
+                {selectedCountry.formattedValue} {suffix}
               </strong>
             </span>
           </div>
@@ -319,7 +319,7 @@ export default function CustomChoropleth(props: ChoroplethProps) {
                         style={{ marginRight: "4px" }}
                         icon={faHeadphones as IconProp}
                       />
-                      {artist.listen_count}
+                      {new Intl.NumberFormat().format(artist.listen_count)}
                     </span>
                     <Link to={`/artist/${artist.artist_mbid}/`}>
                       {artist.artist_name}

--- a/frontend/js/src/user/stats/components/UserArtistActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserArtistActivity.tsx
@@ -29,6 +29,7 @@ function CustomTooltip({
   value: number;
   color: string;
 }) {
+  const formattedValue = new Intl.NumberFormat().format(value);
   return (
     <div
       style={{
@@ -40,7 +41,7 @@ function CustomTooltip({
       }}
     >
       <strong>
-        {id}: {value}
+        {id}: {formattedValue}
       </strong>
     </div>
   );

--- a/frontend/js/src/user/stats/components/UserEraActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserEraActivity.tsx
@@ -34,10 +34,11 @@ function CustomTooltip({
   value: number;
   formatLabel: (decade: number) => string;
 }) {
+  const formattedValue = new Intl.NumberFormat().format(value);
   return (
     <BasicTooltip
       id={formatLabel(Number(indexValue))}
-      value={`${value} ${Number(value) === 1 ? "listen" : "listens"}`}
+      value={`${formattedValue} ${Number(value) === 1 ? "listen" : "listens"}`}
     />
   );
 }

--- a/frontend/js/src/user/stats/components/UserGenreActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserGenreActivity.tsx
@@ -104,11 +104,12 @@ const groupDataByTimePeriod = (
 };
 
 function CustomTooltip({ datum }: { datum: any }) {
+  const formattedValue = new Intl.NumberFormat().format(datum.data.actualValue);
   return (
     <div className="custom-tooltip-genre-stats">
       <strong>{datum.data.displayName}</strong>
       <br />
-      {datum.data.actualValue} plays
+      {formattedValue} plays
       <br />
       {datum.data.timeRange}
     </div>

--- a/frontend/js/src/user/stats/components/UserListeningActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserListeningActivity.tsx
@@ -428,6 +428,8 @@ export default function UserListeningActivity(
   }, [rawData]);
 
   const { perRange } = rangeMap[range] || {};
+  const formattedTotalListens = new Intl.NumberFormat().format(totalListens);
+  const formattedAvgListens = new Intl.NumberFormat().format(avgListens);
 
   return (
     <Card
@@ -478,7 +480,7 @@ export default function UserListeningActivity(
                       fontWeight: "bold",
                     }}
                   >
-                    {totalListens}
+                    {formattedTotalListens}
                   </span>
                   <span>
                     <span style={{ fontSize: 24 }}>&nbsp;Listens</span>
@@ -491,7 +493,7 @@ export default function UserListeningActivity(
                       fontWeight: "bold",
                     }}
                   >
-                    {avgListens}
+                    {formattedAvgListens}
                   </span>
                   <span style={{ fontSize: 24 }}>
                     &nbsp;Listens per {perRange}
@@ -513,7 +515,7 @@ export default function UserListeningActivity(
                             fontWeight: "bold",
                           }}
                         >
-                          {totalListens}
+                          {formattedTotalListens}
                         </td>
                         <td>
                           <span style={{ fontSize: 22, textAlign: "start" }}>
@@ -530,7 +532,7 @@ export default function UserListeningActivity(
                             fontWeight: "bold",
                           }}
                         >
-                          {avgListens}
+                          {formattedAvgListens}
                         </td>
                         <td>
                           <span style={{ fontSize: 22, textAlign: "start" }}>

--- a/frontend/js/src/user/stats/components/UserTopEntity.tsx
+++ b/frontend/js/src/user/stats/components/UserTopEntity.tsx
@@ -103,6 +103,9 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                 };
                 const listenDetails = getChartEntityDetails(interchangeFormat);
                 const listen = userChartEntityToListen(interchangeFormat);
+                const formattedListenCount = new Intl.NumberFormat().format(
+                  artist.listen_count
+                );
                 return (
                   <ListenCard
                     key={`top-artist-${getListenCardKey(listen)}`}
@@ -112,7 +115,7 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                     showUsername={false}
                     additionalActions={
                       <span className="badge bg-info">
-                        {artist.listen_count}
+                        {formattedListenCount}
                       </span>
                     }
                     // no thumbnail for artist entities
@@ -148,6 +151,9 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                 };
                 const listenDetails = getChartEntityDetails(interchangeFormat);
                 const listen = userChartEntityToListen(interchangeFormat);
+                const formattedListenCount = new Intl.NumberFormat().format(
+                  release.listen_count
+                );
                 return (
                   <ListenCard
                     key={`top-release-${getListenCardKey(listen)}`}
@@ -157,7 +163,7 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                     showUsername={false}
                     additionalActions={
                       <span className="badge bg-info">
-                        {release.listen_count}
+                        {formattedListenCount}
                       </span>
                     }
                     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -202,6 +208,9 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                     },
                   },
                 };
+                const formattedListenCount = new Intl.NumberFormat().format(
+                  listen_count
+                );
                 return (
                   <ListenCard
                     key={`top-recording-${getListenCardKey(
@@ -211,7 +220,9 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                     showTimestamp={false}
                     showUsername={false}
                     additionalActions={
-                      <span className="badge bg-info">{listen_count}</span>
+                      <span className="badge bg-info">
+                        {formattedListenCount}
+                      </span>
                     }
                     // Disabling the feedback component here because of display issues with the badge
                     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -240,6 +251,9 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                 };
                 const listenDetails = getChartEntityDetails(interchangeFormat);
                 const listen = userChartEntityToListen(interchangeFormat);
+                const formattedListenCount = new Intl.NumberFormat().format(
+                  releaseGroup.listen_count
+                );
                 return (
                   <ListenCard
                     key={`top-release-group-${getListenCardKey(listen)}`}
@@ -249,7 +263,7 @@ export default function UserTopEntity(props: UserTopEntityProps) {
                     showUsername={false}
                     additionalActions={
                       <span className="badge bg-info">
-                        {releaseGroup.listen_count}
+                        {formattedListenCount}
                       </span>
                     }
                     // eslint-disable-next-line react/jsx-no-useless-fragment


### PR DESCRIPTION
Tired of seeing global stats/ all time personal stats with unreadable numbers...
Using the [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) API to format the numbers according to the user's locale, on all the graphs and tooltips on the stats page

Before:
<img width="1827" height="887" alt="image" src="https://github.com/user-attachments/assets/504aae36-42bb-4e51-87c0-bba9f28a1416" />

After:
<img width="1845" height="914" alt="image" src="https://github.com/user-attachments/assets/1d57de76-ba82-433c-9e73-4db1357d59eb" />

<img width="493" height="400" alt="image" src="https://github.com/user-attachments/assets/d5aa238e-a833-4f72-81b4-ffe4f6fdd372" />
