### PR TITLE
LB-1675: Use production website URL root for art creator images

### DIFF
--- a/listenbrainz/webserver/templates/art/svg-templates/macros.j2
+++ b/listenbrainz/webserver/templates/art/svg-templates/macros.j2
@@ -1,11 +1,6 @@
 {% macro render_entity_link (entity, mbid, name) %}
   {%- if mbid is defined and mbid is not none -%}
-    {% if entity == 'recording' %}
-      {% set hostURL = 'https://musicbrainz.org' %}
-    {% else %}
-      {% set hostURL = 'https://listenbrainz.org' %}
-    {% endif %}
-    <a href="{{ host }}/{{ entity }}/{{ mbid }}" target="_blank">
+    <a href="https://listenbrainz.org/{{ entity }}/{{ mbid }}" target="_blank">
       {{ name|upper|e }}
     </a>
     <title>{{ name|e }}</title>


### PR DESCRIPTION
The Art Creator SVGs have links to entities, but are currently malformed if you open them directly in the API.
The link becomes a subpath of api.lb.org, which results in error "410 gone"

Using the prod URL root instead.

Before:
<img width="1348" height="325" alt="image" src="https://github.com/user-attachments/assets/686d0330-8a62-4c74-929f-2a0f7c038e52" />

After:
<img width="1351" height="322" alt="image" src="https://github.com/user-attachments/assets/1c5f3481-7f40-4b6c-8d64-bd878397faf5" />
