### PR TITLE
fix daily activity heatmap

### DIFF
--- a/frontend/js/src/user/stats/components/UserDailyActivity.tsx
+++ b/frontend/js/src/user/stats/components/UserDailyActivity.tsx
@@ -81,13 +81,15 @@ export default function UserDailyActivity(props: UserDailyActivityProps) {
       const dayData = unProcessedData.payload.daily_activity[day];
       let hourData: any = [];
 
-      hourData = dayData.map((elem) => {
-        const hour = (elem.hour + tzOffset + 24) % 24;
-        return {
-          x: hour,
-          y: elem.listen_count,
-        };
-      });
+      hourData = dayData
+        .map((elem) => {
+          const hour = (elem.hour + tzOffset + 24) % 24;
+          return {
+            x: hour,
+            y: elem.listen_count,
+          };
+        })
+        .sort((a, b) => a.x - b.x);
 
       result.push({
         id: day,
@@ -103,13 +105,15 @@ export default function UserDailyActivity(props: UserDailyActivityProps) {
     });
 
     let averageData: any = [];
-    averageData = average.map((elem, index) => {
-      const hour = (index + tzOffset + 24) % 24;
-      return {
-        x: hour,
-        y: Math.ceil(elem / 7),
-      };
-    });
+    averageData = average
+      .map((elem, index) => {
+        const hour = (index + tzOffset + 24) % 24;
+        return {
+          x: hour,
+          y: Math.ceil(elem / 7),
+        };
+      })
+      .sort((a, b) => a.x - b.x);
 
     result.unshift({
       id: "Average",


### PR DESCRIPTION
# Problem

This PR solves the problem of the daily heatmap not being sorted on the user's timezone, and instead being sorted on UTC.

Ticket: [LB-1818](https://tickets.metabrainz.org/projects/LB/issues/LB-1818)

# Solution
The solution was quite straightforward, as the x values were according to the timezone already, just needed to sort the data on the x value.

*Before:*
![Screenshot 2025-09-04 at 18 23 45](https://github.com/user-attachments/assets/a54970d6-bc42-4050-b7d0-3af9bc817358)

*After:*
![Screenshot 2025-09-04 at 18 24 05](https://github.com/user-attachments/assets/39eddcac-7b44-4052-ae8f-8016ed24a25f)


# Action

No further action required!


