### PR TITLE
Improved Navidrome Search for Tracks 

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -357,7 +357,7 @@ const performNavidromeSearch = async (
 ): Promise<NavidromeTrack | null> => {
   const searchUrl = `${instanceURL}/rest/search3?query=${encodeURIComponent(
     query
-  )}&songCount=5&${authParams}`;
+  )}&songCount=1&${authParams}`;
 
   const response = await fetch(searchUrl);
 


### PR DESCRIPTION
[problem](https://github.com/metabrainz/listenbrainz-server/pull/3331#pullrequestreview-3303907204) mentioned by @MonkeyDo 

i've improved the searching of track as mentioned above and also in community chat! 
<img width="626" height="324" alt="image" src="https://github.com/user-attachments/assets/218a1378-1880-41fd-b3ad-e78896d7f51c" />
<img width="916" height="480" alt="image" src="https://github.com/user-attachments/assets/3846ea39-d666-4363-bfae-b7ee01209959" />

Now the The `searchForNavidromeTrack()` function now tries multiple approaches:

- Track + main artist (featuring artists removed)
- Track + full artist name
- Track name only 
- Artist only (fallback)

<img width="900" height="66" alt="Screenshot 2025-10-07 at 11 29 41 PM" src="https://github.com/user-attachments/assets/ed8d51b6-6436-4c5f-bdea-cd98efa50473" />
<img width="900" height="66" alt="Screenshot 2025-10-07 at 11 32 15 PM" src="https://github.com/user-attachments/assets/bce98d1c-4379-4453-886c-c3dbaea6e47e" />

