### PR TITLE
LB-1378: Respect newlines in playlist descriptions

### DIFF
--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -9,6 +9,10 @@ $long-description-lines: 8;
   gap: 1rem;
 }
 
+.playlist-info .description {
+  white-space: pre-line;
+}
+
 #playlists-container {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -470,7 +470,7 @@ export default function PlaylistPage() {
             )}
           </div>
           {playlist.annotation && (
-            <div>
+            <div className="description">
               <div
                 className={`${isLongDescription ? "text-summary long" : ""} ${
                   showMore ? "expanded" : ""


### PR DESCRIPTION
Newlines are not respected in playlist descriptions on the playlist page:
Before:
<img width="855" height="415" alt="image" src="https://github.com/user-attachments/assets/1971c8ed-efdf-41da-9b19-61cf91fc4f70" />

After:
<img width="813" height="475" alt="image" src="https://github.com/user-attachments/assets/86069855-719f-4894-9659-d5324be2a238" />
