### PR TITLE
Import XSPF playlist files

### DIFF
--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -8,6 +8,7 @@ declare module "time-ago";
 declare module "debounce-async";
 // declaration typescript file doesn't exist for react-datetime-picker/dist/entry.nostyle.js so had to declare a dummy declaration.
 declare module "react-datetime-picker/dist/entry.nostyle";
+declare module "xspf-js";
 
 // TODO: Remove "| null" when backend stops sending fields with null
 interface AdditionalInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,8 @@
         "swiper": "^11.2.6",
         "time-ago": "^0.2.1",
         "tinycolor2": "^1.4.2",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "xspf-js": "^0.1.1"
       },
       "devDependencies": {
         "@babel/core": "^7.20.5",
@@ -17568,6 +17569,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -20072,6 +20079,18 @@
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
@@ -20095,6 +20114,15 @@
       "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xspf-js": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/xspf-js/-/xspf-js-0.1.1.tgz",
+      "integrity": "sha512-/2lUkOvMkjBLrHqk9zts0Hn589nfG07MakYIGhI4lseDsXi8YDvsFDCX8iAE2Dsm7lkZnyS7CkaYfRSlkS+oyw==",
+      "license": "WTFPL",
+      "dependencies": {
+        "xml-js": "^1.6.11"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "swiper": "^11.2.6",
     "time-ago": "^0.2.1",
     "tinycolor2": "^1.4.2",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "xspf-js": "^0.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",


### PR DESCRIPTION
A user on Mastodon was looking for a way to export their playlists, and someone recommended Soundiiz.
Since XSPF is a playlist interchange format (that we support exporting to), we should have a way to support importing XSPF playlists.

I refactored the existing playlist file import modal to support XSPF, parsing the file client-side with the [xspf-js library](https://github.com/hawyar/xspf-js) before sending a JSPF document to the server.

Unfortunately, currently upon playlist creation, every track's identifier field **must be a MusicBrainz recording URL**, making is less useful for the use-case described above (we can still import our own exported playlist xspf file).
We should think about allowing importing JSPF with identifiers other than MB recordings, especially if it is an identifier we can potentially use for metadata, for example a Spotify URL (https://soundiiz.com/tutorial/export-spotify-to-xspf).

Also added a checkbox to make the playlist private, as we need to set that to a value before sending the JSPF to the server, for some reason.
<img width="554" height="302" alt="image" src="https://github.com/user-attachments/assets/cce4282a-afb3-4eba-a94c-42b23706e16b" />
