### PR TITLE
LB-1865: Add ability to unlink a listen from MusicBrainz

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -72,7 +72,8 @@ CREATE TABLE mbid_manual_mapping(
     recording_msid UUID NOT NULL,
     recording_mbid UUID NOT NULL,
     user_id        INTEGER NOT NULL,
-    created        TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+    created        TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    is_unlinked    BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE mbid_mapping (

--- a/admin/timescale/create_views.sql
+++ b/admin/timescale/create_views.sql
@@ -9,6 +9,7 @@ CREATE MATERIALIZED VIEW mbid_manual_mapping_top AS (
            recording_msid
          , recording_mbid
       FROM mbid_manual_mapping
+     WHERE is_unlinked = FALSE
   GROUP BY recording_msid
          , recording_mbid
     HAVING count(DISTINCT user_id) >= 3

--- a/admin/timescale/updates/2025-02-14-add-unlink-mapping.sql
+++ b/admin/timescale/updates/2025-02-14-add-unlink-mapping.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE mbid_manual_mapping ADD COLUMN is_unlinked BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -15,6 +15,7 @@ import {
   faExternalLinkAlt,
   faImage,
   faLink,
+  faLinkSlash,
   faMusic,
   faPaperPlane,
   faPencilAlt,
@@ -275,6 +276,40 @@ export default function ListenCard(props: ListenCardProps) {
     Boolean(trackMBID) ||
     Boolean(releaseGroupMBID);
 
+  const unlinkListenFromMB = React.useCallback(async () => {
+    if (!currentUser?.auth_token || !recordingMSID) return;
+    try {
+      const result = await APIService.unlinkMapping(
+        currentUser.auth_token,
+        recordingMSID
+      );
+      if (result.status === "ok") {
+        setDisplayListen((prev) => ({
+          ...prev,
+          track_metadata: {
+            ...prev.track_metadata,
+            mbid_mapping: undefined,
+          },
+        }));
+        toast.success(
+          <ToastMsg
+            title="Listen unlinked"
+            message={`${getTrackName(displayListen)} has been unlinked from MusicBrainz`}
+          />,
+          { toastId: "unlink-success" }
+        );
+      }
+    } catch (error) {
+      toast.error(
+        <ToastMsg
+          title="Error unlinking listen"
+          message={typeof error === "object" ? (error as Error).message : String(error)}
+        />,
+        { toastId: "unlink-error" }
+      );
+    }
+  }, [currentUser, APIService, recordingMSID, displayListen]);
+
   const hasActionOptions =
     additionalMenuItems?.length ||
     hasInfoAndMBID ||
@@ -517,6 +552,13 @@ export default function ListenCard(props: ListenCardProps) {
                       text="Link with MusicBrainz"
                       icon={faLink}
                       action={openMBIDMappingModal}
+                    />
+                  )}
+                  {isLoggedIn && Boolean(recordingMSID) && hasRecordingMBID && (
+                    <ListenControl
+                      text="Unlink from MusicBrainz"
+                      icon={faLinkSlash}
+                      action={unlinkListenFromMB}
                     />
                   )}
                   {isLoggedIn && isListenReviewable && (

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1368,6 +1368,25 @@ export default class APIService {
     return response.json();
   };
 
+  unlinkMapping = async (
+    userToken: string,
+    recordingMSID: string
+  ): Promise<{ status: string }> => {
+    const url = `${this.APIBaseURI}/metadata/unlink_mapping/`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${userToken}`,
+        "Content-Type": "application/json;charset=UTF-8",
+      },
+      body: JSON.stringify({
+        recording_msid: recordingMSID,
+      }),
+    });
+    await this.checkStatus(response);
+    return response.json();
+  };
+
   unpinRecording = async (userToken: string): Promise<number> => {
     const url = `${this.APIBaseURI}/pin/unpin`;
     const response = await fetch(url, {


### PR DESCRIPTION
## LB-1865: Add ability to unlink a listen from MusicBrainz

### Changes
- Added `is_unlinked` boolean column to [mbid_manual_mapping](cci:1://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/listenbrainz/db/mbid_manual_mapping.py:60:0-96:19) table
- New `POST /metadata/unlink_mapping/` API endpoint
- Modified [fetch_listens](cci:1://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/listenbrainz/listenstore/timescale_listenstore.py:203:4-379:48) to suppress MB metadata when unlinked
- Excluded unlinked entries from `mbid_manual_mapping_top` materialized view
- Added "Unlink from MusicBrainz" option in ListenCard dropdown menu
- Re-linking via "Link with MusicBrainz" automatically resets the unlink state

### Files Changed (8)
- [admin/timescale/create_tables.sql](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/admin/timescale/create_tables.sql:0:0-0:0) — added `is_unlinked` column
- [admin/timescale/create_views.sql](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/admin/timescale/create_views.sql:0:0-0:0) — filter unlinked from materialized view
- [admin/timescale/updates/2025-02-14-add-unlink-mapping.sql](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/admin/timescale/updates/2025-02-14-add-unlink-mapping.sql:0:0-0:0) — migration
- [listenbrainz/db/mbid_manual_mapping.py](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/listenbrainz/db/mbid_manual_mapping.py:0:0-0:0) — new [create_mbid_manual_unlink()](cci:1://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/listenbrainz/db/mbid_manual_mapping.py:30:0-57:20) function
- [listenbrainz/listenstore/timescale_listenstore.py](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/listenbrainz/listenstore/timescale_listenstore.py:0:0-0:0) — CASE WHEN for unlink
- [listenbrainz/webserver/views/metadata_api.py](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/listenbrainz/webserver/views/metadata_api.py:0:0-0:0) — new unlink endpoint
- [frontend/js/src/utils/APIService.ts](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/frontend/js/src/utils/APIService.ts:0:0-0:0) — new `unlinkMapping()` method
- [frontend/js/src/common/listens/ListenCard.tsx](cci:7://file://wsl$/Ubuntu/home/ashwaniyadav/listenbrainz-server/frontend/js/src/common/listens/ListenCard.tsx:0:0-0:0) — unlink button in dropdown