### PR TITLE
LB-1141: Indicate which listens are marked for deletion

### DIFF
--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -160,8 +160,6 @@ class Listen(object):
                 track_metadata["mbid_mapping"]["caa_id"] = caa_id
                 track_metadata["mbid_mapping"]["caa_release_mbid"] = caa_release_mbid
 
-        track_metadata["staged_for_deletion"]= staged_for_deletion
-
         return cls(
             user_id=user_id,
             user_name=user_name,

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -76,7 +76,7 @@ class Listen(object):
         'release_name',
     )
 
-    def __init__(self, user_id=None, user_name=None, timestamp=None, recording_msid=None, inserted_timestamp=None, data=None):
+    def __init__(self, user_id=None, user_name=None, timestamp=None, recording_msid=None, inserted_timestamp=None, data=None, staged_for_deletion=False):
         self.user_id = user_id
         self.user_name = user_name
 
@@ -106,6 +106,7 @@ class Listen(object):
                 pass
 
             self.data = data
+            self.staged_for_deletion = staged_for_deletion
 
     @classmethod
     def from_json(cls, j):
@@ -131,7 +132,7 @@ class Listen(object):
     def from_timescale(cls, listened_at, user_id, created, recording_msid, track_metadata,
                        recording_mbid=None, recording_name=None, release_mbid=None, artist_mbids=None,
                        ac_names=None, ac_join_phrases=None, user_name=None,
-                       caa_id=None, caa_release_mbid=None):
+                       caa_id=None, caa_release_mbid=None, staged_for_deletion=False):
         """Factory to make Listen() objects from a timescale dict"""
         track_metadata["additional_info"]["recording_msid"] = recording_msid
         if recording_mbid is not None:
@@ -159,13 +160,16 @@ class Listen(object):
                 track_metadata["mbid_mapping"]["caa_id"] = caa_id
                 track_metadata["mbid_mapping"]["caa_release_mbid"] = caa_release_mbid
 
+        track_metadata["staged_for_deletion"]= staged_for_deletion
+
         return cls(
             user_id=user_id,
             user_name=user_name,
             timestamp=listened_at,
             recording_msid=recording_msid,
             inserted_timestamp=created,
-            data=track_metadata
+            data=track_metadata,
+            staged_for_deletion=staged_for_deletion
         )
 
     def to_api(self):

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -239,7 +239,15 @@ class TimescaleListenStore:
                              , l.data
                              -- prefer to use user submitted mbid, then user specified mapping, then mbid mapper's mapping, finally other user's specified mappings
                              , COALESCE((data->'additional_info'->>'recording_mbid')::uuid, user_mm.recording_mbid, mm.recording_mbid, other_mm.recording_mbid) AS recording_mbid
+                             -- flag the listens that are only staged for deletion but not deleted yet
+                             , (ldm.id IS NOT NULL) AS staged_for_deletion
+
                           FROM listen l
+                     LEFT JOIN listen_delete_metadata ldm
+                            ON l.user_id = ldm.user_id
+                           AND l.listened_at = ldm.listened_at
+                           AND l.recording_msid = ldm.recording_msid
+                           AND ldm.status = 'pending'
                      LEFT JOIN mbid_mapping mm
                             ON l.recording_msid = mm.recording_msid
                      LEFT JOIN mbid_manual_mapping user_mm
@@ -256,6 +264,7 @@ class TimescaleListenStore:
                         , created
                         , sl.recording_msid::TEXT
                         , data
+                        , sl.staged_for_deletion
                         , sl.recording_mbid
                         , mbc.recording_data->>'name' AS recording_name
                         , mbc.release_mbid
@@ -274,6 +283,7 @@ class TimescaleListenStore:
                         , user_id
                         , created
                         , data
+                        , sl.staged_for_deletion
                         , sl.recording_mbid
                         , recording_data->>'name'
                         , release_mbid
@@ -356,7 +366,8 @@ class TimescaleListenStore:
                     ac_join_phrases=result.ac_join_phrases,
                     user_name=user["musicbrainz_id"],
                     caa_id=result.caa_id,
-                    caa_release_mbid=result.caa_release_mbid
+                    caa_release_mbid=result.caa_release_mbid,
+                    staged_for_deletion= result.staged_for_deletion
                 ))
 
                 if len(listens) == limit:

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -259,7 +259,7 @@ class TimescaleListenStore:
                            AND l.listened_at > :from_ts
                            AND l.listened_at < :to_ts
                    )
-                   SELECT l.listened_at
+                   SELECT sl.listened_at
                         , user_id
                         , created
                         , sl.recording_msid::TEXT
@@ -278,7 +278,7 @@ class TimescaleListenStore:
                        ON sl.recording_mbid = mbc.recording_mbid
         LEFT JOIN LATERAL jsonb_array_elements(artist_data->'artists') WITH ORDINALITY artists(artist, position)
                        ON TRUE
-                 GROUP BY l.listened_at
+                 GROUP BY sl.listened_at
                         , sl.recording_msid
                         , user_id
                         , created
@@ -293,7 +293,7 @@ class TimescaleListenStore:
                         , release_data->>'name'
                         , release_data->>'caa_id'
                         , release_data->>'caa_release_mbid'
-                 ORDER BY l.listened_at """ + ORDER_TEXT[order] + " LIMIT :limit"
+                 ORDER BY sl.listened_at """ + ORDER_TEXT[order] + " LIMIT :limit"
 
         if from_ts and to_ts:
             to_dynamic = False

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -256,10 +256,10 @@ class TimescaleListenStore:
                      LEFT JOIN mbid_manual_mapping_top other_mm
                             ON l.recording_msid = other_mm.recording_msid
                          WHERE l.user_id = :user_id
-                           AND listened_at > :from_ts
-                           AND listened_at < :to_ts
+                           AND l.listened_at > :from_ts
+                           AND l.listened_at < :to_ts
                    )
-                   SELECT listened_at
+                   SELECT l.listened_at
                         , user_id
                         , created
                         , sl.recording_msid::TEXT
@@ -278,7 +278,7 @@ class TimescaleListenStore:
                        ON sl.recording_mbid = mbc.recording_mbid
         LEFT JOIN LATERAL jsonb_array_elements(artist_data->'artists') WITH ORDINALITY artists(artist, position)
                        ON TRUE
-                 GROUP BY listened_at
+                 GROUP BY l.listened_at
                         , sl.recording_msid
                         , user_id
                         , created
@@ -293,7 +293,7 @@ class TimescaleListenStore:
                         , release_data->>'name'
                         , release_data->>'caa_id'
                         , release_data->>'caa_release_mbid'
-                 ORDER BY listened_at """ + ORDER_TEXT[order] + " LIMIT :limit"
+                 ORDER BY l.listened_at """ + ORDER_TEXT[order] + " LIMIT :limit"
 
         if from_ts and to_ts:
             to_dynamic = False

--- a/listenbrainz/webserver/views/import_listens.py
+++ b/listenbrainz/webserver/views/import_listens.py
@@ -58,7 +58,7 @@ def create_import_task():
         raise APIBadRequest("No service selected!")
     service = service.lower()
 
-    allowed_services = ["spotify", "listenbrainz", "librefm", "maloja", "panoscrobbler", "audioscrobbler"]
+    allowed_services = ["spotify", "listenbrainz", "librefm", "maloja", "panoscrobbler", "audioscrobbler", "spinitron"]
     if service not in allowed_services:
         raise APIBadRequest("This service is not supported!")
 
@@ -88,6 +88,8 @@ def create_import_task():
         raise APIBadRequest("Only JSON files are allowed for this service!")
     if service == "audioscrobbler" and extension != ".log":
         raise APIBadRequest("Only .log files are allowed for this service!")
+    if service == "spinitron" and extension != ".csv":
+        raise APIBadRequest("Only csv files are allowed for this service!")
 
     # add a unique ID to the filename to avoid collisions
     saved_filename = str(uuid.uuid4()) + "-" + secure_filename(filename)
@@ -188,7 +190,7 @@ def delete_import_task(import_id):
     """ Cancel the specified import in progress """
     user = validate_auth_header()
     result = db_conn.execute(
-        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting', 'in progress') RETURNING file_path"),
+        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
         {"user_id": user["id"], "import_id": import_id}
     )
     row = result.first()

--- a/listenbrainz/webserver/views/import_listens.py
+++ b/listenbrainz/webserver/views/import_listens.py
@@ -188,7 +188,7 @@ def delete_import_task(import_id):
     """ Cancel the specified import in progress """
     user = validate_auth_header()
     result = db_conn.execute(
-        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
+        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting', 'in progress') RETURNING file_path"),
         {"user_id": user["id"], "import_id": import_id}
     )
     row = result.first()


### PR DESCRIPTION
**Problem**
The staged_for_deletion  listens on fetch_listens() don't actually show any indication of their state, so frontend cannot distinguish between regular and pending deletion listens.

**Solution**
Extend fetch_listens() to join against listen_delete_metadata with status = 'pending' and expose a boolean "staged_for_deletion" flag, passed via Listen.from_timescale() added to Listen object.

**Action**
For timescale_listenstore.py :
- Join listen_delete_metadata with status = 'pending in fetch_listens()
- Add boolean (ldm.id IS NOT  NULL) as staged_for_deletion in query
- Add "staged_for_deletion" in select and group by clauses
- pass flag to Listen.from_timescale()

For listen.py :
- Add "staged_for_deletion" attribute to Listen object

Ref: LB-1141