### PR TITLE
Fixed: ERROR "500:Failed to fetch additional metadata of playlist"

### DIFF
--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -568,7 +568,7 @@ def get_playlist(playlist_mbid):
     if not playlist.is_visible_by(user_id):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if fetch_metadata and current_app.config.get("MB_DATABASE_URI"):
+    if fetch_metadata:
         fetch_playlist_recording_metadata(playlist)
 
     return jsonify(playlist.serialize_jspf())
@@ -613,7 +613,7 @@ def get_playlist_xspf(playlist_mbid):
         raise PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401)
 
     try:
-        if fetch_metadata and current_app.config.get("MB_DATABASE_URI"):
+        if fetch_metadata:
             fetch_playlist_recording_metadata(playlist)
 
         xspf_data = serialize_xspf(playlist)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -268,6 +268,11 @@ def fetch_playlist_recording_metadata(playlist: Playlist):
     """
         This interim function will soon be replaced with a more complete service layer
     """
+    if not current_app.config.get("MB_DATABASE_URI"):
+        current_app.logger.warning(
+            "Skipping playlist metadata fetch because MB_DATABASE_URI is not configured."
+        )
+        return
     mbids = [str(item.mbid) for item in playlist.recordings]
     if not mbids:
         return
@@ -562,7 +567,7 @@ def get_playlist(playlist_mbid):
     if not playlist.is_visible_by(user_id):
         raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
 
-    if fetch_metadata:
+    if fetch_metadata and current_app.config.get("MB_DATABASE_URI"):
         fetch_playlist_recording_metadata(playlist)
 
     return jsonify(playlist.serialize_jspf())
@@ -607,7 +612,7 @@ def get_playlist_xspf(playlist_mbid):
         raise PlaylistAPIXMLError("Invalid authorization to access playlist.", status_code=401)
 
     try:
-        if fetch_metadata:
+        if fetch_metadata and current_app.config.get("MB_DATABASE_URI"):
             fetch_playlist_recording_metadata(playlist)
 
         xspf_data = serialize_xspf(playlist)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -273,6 +273,7 @@ def fetch_playlist_recording_metadata(playlist: Playlist):
             "Skipping playlist metadata fetch because MB_DATABASE_URI is not configured."
         )
         return
+    
     mbids = [str(item.mbid) for item in playlist.recordings]
     if not mbids:
         return


### PR DESCRIPTION
# Problem
additional_metadata not saved when creating new playlist. [LB-1843]
The issue occurs because `fetch_playlist_recording_metadata()` attempts to query the MusicBrainz database using "MB_DATABASE_URI".This causes the server to attempt a connection to an empty URI and result in a 500 error when viewing playlists.

# Solution
This PR adds a guard so that metadata lookup is only performed when "MB_DATABASE_URI" is configured. When it is not configured, the server skips the metadata lookup and logs a warning instead.

* ✅ I have run the code and manually tested the changes


:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

*✅I did not use any AI
* [  ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [  ] I used AI tools for communication
* [  ] I used AI tools for coding
* [  ] I understand all the changes made in this PR

