### PR TITLE
LB-1964: Fix youtube player cross tab sync issue

### DIFF
--- a/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
@@ -159,16 +159,12 @@ export default class AppleMusicPlayer
     this.disconnectAppleMusicPlayer();
   }
 
+  pause = () => {
+    this.appleMusicPlayer?.pause();
+  };
+
   stop = () => {
-    if (
-      this.appleMusicPlayer?.playbackState &&
-      !(
-        this.appleMusicPlayer.playbackState in
-        [MusicKit.PlaybackStates.paused, MusicKit.PlaybackStates.stopped]
-      )
-    ) {
-      this.appleMusicPlayer?.pause();
-    }
+    this.pause();
   };
 
   playAppleMusicId = async (

--- a/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/AppleMusicPlayer.tsx
@@ -164,7 +164,7 @@ export default class AppleMusicPlayer
   };
 
   stop = () => {
-    this.pause();
+    this.appleMusicPlayer?.stop();
   };
 
   playAppleMusicId = async (

--- a/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/BrainzPlayer.tsx
@@ -80,6 +80,7 @@ export type DataSourceType = {
   playListen: (listen: Listen | JSPFTrack, streamingUrl?: string) => void;
   togglePlay: () => void;
   stop: () => void;
+  pause: () => void;
   seekToPositionMs: (msTimecode: number) => void;
   canSearchAndPlayTracks: () => boolean;
   datasourceRecordsListens: () => boolean;
@@ -461,7 +462,7 @@ export default function BrainzPlayer() {
   const pauseCurrentPlayback = async (): Promise<void> => {
     try {
       const dataSource = dataSourceRefs[getCurrentDataSourceIndex()]?.current;
-      dataSource?.stop();
+      dataSource?.pause();
     } catch (error) {
       handleError(error, "Could not pause playback");
     }

--- a/frontend/js/src/common/brainzplayer/FunkwhalePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/FunkwhalePlayer.tsx
@@ -122,8 +122,12 @@ export default class FunkwhalePlayer
     }
   }
 
-  stop = () => {
+  pause = () => {
     this.pauseAudio();
+  };
+
+  stop = () => {
+    this.pause();
   };
 
   setupAudioListeners = (): void => {

--- a/frontend/js/src/common/brainzplayer/InternetArchivePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/InternetArchivePlayer.tsx
@@ -96,10 +96,14 @@ export default class InternetArchivePlayer
     });
   };
 
-  stop = () => {
+  pause = () => {
     if (!this.audioRef?.current?.paused) {
       this.audioRef?.current?.pause();
     }
+  };
+
+  stop = () => {
+    this.pause();
   };
 
   handleAudioEnded = () => {

--- a/frontend/js/src/common/brainzplayer/NavidromePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/NavidromePlayer.tsx
@@ -88,10 +88,14 @@ export default class NavidromePlayer
     }
   }
 
-  stop = () => {
+  pause = () => {
     if (!this.audioRef?.current?.paused) {
       this.audioRef?.current?.pause();
     }
+  };
+
+  stop = () => {
+    this.pause();
   };
 
   setupAudioListeners = (): void => {

--- a/frontend/js/src/common/brainzplayer/SoundcloudPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SoundcloudPlayer.tsx
@@ -177,10 +177,12 @@ export default class SoundcloudPlayer
     );
   };
 
+  pause = () => {
+    this.soundcloudPlayer?.pause();
+  };
+
   stop = () => {
-    if (!this.soundcloudPlayer?.isPaused) {
-      this.soundcloudPlayer?.pause();
-    }
+    this.pause();
   };
 
   onReady = (): void => {

--- a/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/SpotifyPlayer.tsx
@@ -362,15 +362,13 @@ export default class SpotifyPlayer
     });
   };
 
+  pause = (): void => {
+    this.spotifyPlayer?.pause();
+  };
+
   stop = (): void => {
     this.setState({ currentSpotifyTrack: undefined });
-    this.spotifyPlayer
-      ?.getCurrentState()
-      .then((state: Spotify.PlaybackState) => {
-        if (state && !state.paused) {
-          this.spotifyPlayer?.pause();
-        }
-      });
+    this.pause();
   };
 
   handleTokenError = async (

--- a/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
@@ -183,9 +183,7 @@ export default class YoutubePlayer
   }
 
   stop = () => {
-    this.youtubePlayer?.stopVideo();
-    // Clear playlist
-    this.youtubePlayer?.cueVideoById("");
+    this.youtubePlayer?.pauseVideo();
   };
 
   onReady = (event: YT.PlayerEvent): void => {

--- a/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
+++ b/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx
@@ -183,6 +183,12 @@ export default class YoutubePlayer
   }
 
   stop = () => {
+    this.youtubePlayer?.stopVideo();
+    // Clear playlist
+    this.youtubePlayer?.cueVideoById("");
+  };
+
+  pause = () => {
     this.youtubePlayer?.pauseVideo();
   };
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->
Ticket: LB-1964

When a user starts playback in a new tab, `stopOtherBrainzPlayers()` triggers a localstorage event that calls `pauseCurrentPlayback()` with `dataSource.stop()` on the previous tab.

Issue arises due to the `stop()` method in [YoutubePlayer.tsx](https://github.com/metabrainz/listenbrainz-server/blob/master/frontend/js/src/common/brainzplayer/YoutubePlayer.tsx)

Also I found this same issue with spotify player as well, soundcloud appears to sync correctly. I haven't tested other music services. 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

<img width="1014" height="205" alt="image" src="https://github.com/user-attachments/assets/8c8e5f4d-6c3d-4b95-a463-00f11ef4cd7b" />

After going through [this](https://developers.google.com/youtube/iframe_api_reference), fix was simply replacing `stopVideo()` with `pauseVideo()` in the `stop()` method. 
Also removed the `cueVideoById("")` call since we no longer need to hard reset the player instead the video should stay loaded for potential resume.

* [x] I have run the code and manually tested the changes

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

* [x] I did not use any AI

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
No further actions needed beyond testing.
