### PR TITLE
LB-1965 : smooth progress bar animation with drag-to-seek

### DIFF
--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -408,6 +408,7 @@ $youtube-expanded-width: 1280px;
   transition: height, 0.2s;
 
   .progress-bar {
+    width: 100%;
     height: 100%;
     background-color: $primary-color;
   }

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -405,7 +405,9 @@ $youtube-expanded-width: 1280px;
   width: 100%;
   cursor: pointer;
   z-index: 5;
+  overflow: visible;
   transition: height, 0.2s;
+
 
   .progress-bar {
     width: 100%;

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -429,7 +429,7 @@ $youtube-expanded-width: 1280px;
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background-color: white;
+    background-color: $primary-color;
     transform: translate(-50%, -50%) scaleX(0);
     transition: transform 0.15s ease;
     will-change: transform;

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -408,7 +408,6 @@ $youtube-expanded-width: 1280px;
   overflow: visible;
   transition: height, 0.2s;
 
-
   .progress-bar {
     width: 100%;
     height: 100%;

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -426,8 +426,8 @@ $youtube-expanded-width: 1280px;
   .progress-handle {
     position: absolute;
     top: 50%;
-    width: 10px;
-    height: 10px;
+    width: 14px;
+    height: 14px;
     border-radius: 50%;
     background-color: $primary-color;
     transform: translate(-50%, -50%) scaleX(0);

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -410,7 +410,6 @@ $youtube-expanded-width: 1280px;
   .progress-bar {
     height: 100%;
     background-color: $primary-color;
-    border-right: 2px solid $dark-turquoise;
   }
   &:hover {
     height: $progress-bar-hover-height;

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -417,6 +417,26 @@ $youtube-expanded-width: 1280px;
     top: -$progress-bar-hover-height;
   }
 
+  &.dragging {
+    height: $progress-bar-hover-height;
+    top: -$progress-bar-hover-height;
+    cursor: grabbing;
+  }
+
+  .progress-handle {
+    position: absolute;
+    top: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: white;
+    transform: translate(-50%, -50%) scaleX(0);
+    transition: transform 0.15s ease;
+    will-change: transform;
+    pointer-events: none;
+    left: var(--handle-x, 0px);
+  }
+
   .progress-tooltip {
     background: $primary-color;
     margin-top: -4px;

--- a/frontend/css/sass/stats-art-creator.scss
+++ b/frontend/css/sass/stats-art-creator.scss
@@ -66,7 +66,9 @@ $color-selector-size: 24px;
   .settings-navbar {
     margin-left: auto;
     max-width: 320px;
+    height: calc(100vh - 72px);
     overflow-y: scroll;
+    overscroll-behavior: contain;
 
     /* prettier-ignore */
     @supports not selector(::-webkit-scrollbar) {

--- a/frontend/css/sass/stats-art-creator.scss
+++ b/frontend/css/sass/stats-art-creator.scss
@@ -66,9 +66,7 @@ $color-selector-size: 24px;
   .settings-navbar {
     margin-left: auto;
     max-width: 320px;
-    height: calc(100vh - 72px);
     overflow-y: scroll;
-    overscroll-behavior: contain;
 
     /* prettier-ignore */
     @supports not selector(::-webkit-scrollbar) {

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -27,6 +27,7 @@ const MOUSE_THROTTLE_DELAY: number = 300;
 
 const TOOLTIP_INITIAL_CONTENT: string = "0:00";
 const TOOLTIP_TOP_OFFSET: number = 39;
+const HANDLE_RADIUS = 5; // px — handle is 10×10px
 
 // Originally by ford04 - https://stackoverflow.com/a/62017005
 const useThrottle = (callback: any, delay: number | undefined) => {
@@ -51,6 +52,7 @@ function ProgressBar(props: ProgressBarProps) {
   const [tipContent, setTipContent] = React.useState(TOOLTIP_INITIAL_CONTENT);
   const progressBarRef = React.useRef<HTMLDivElement>(null);
   const progressBarInnerRef = React.useRef<HTMLDivElement>(null);
+  const handleRef = React.useRef<HTMLDivElement>(null);
   const rafRef = React.useRef<number>(0);
 
   React.useEffect(() => {
@@ -60,6 +62,13 @@ function ProgressBar(props: ProgressBarProps) {
       const ratio = Math.min(liveProgressMs / durationMs, 1) || 0;
       if (progressBarInnerRef.current) {
         progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
+      }
+      if (handleRef.current) {
+        const barWidth =
+          progressBarInnerRef.current?.parentElement?.getBoundingClientRect()
+            .width ?? 0;
+        const handleX = ratio * barWidth;
+        handleRef.current.style.setProperty("--handle-x", `${handleX}px`);
       }
       rafRef.current = requestAnimationFrame(tick);
     };
@@ -133,6 +142,18 @@ function ProgressBar(props: ProgressBarProps) {
         onClick={mouseEventHandler}
         onMouseMove={mouseEventHandler}
         onKeyDown={onKeyPressHandler}
+        onMouseEnter={() => {
+          if (handleRef.current) {
+            handleRef.current.style.transform =
+              "translate(-50%, -50%) scaleX(1)";
+          }
+        }}
+        onMouseLeave={() => {
+          if (handleRef.current) {
+            handleRef.current.style.transform =
+              "translate(-50%, -50%) scaleX(0)";
+          }
+        }}
         aria-label="Audio progress control"
         role="progressbar"
         aria-valuemin={0}
@@ -146,6 +167,24 @@ function ProgressBar(props: ProgressBarProps) {
           className="progress-bar bg-info"
           ref={progressBarInnerRef}
           style={{ transform: "scaleX(0)", transformOrigin: "left" }}
+        />
+        <div
+          ref={handleRef}
+          className="progress-handle"
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "var(--handle-x, 0px)",
+            width: `${HANDLE_RADIUS * 2}px`,
+            height: `${HANDLE_RADIUS * 2}px`,
+            borderRadius: "50%",
+            backgroundColor: "white",
+            transform: "translate(-50%, -50%) scaleX(0)",
+            transformOrigin: "center",
+            transition: "transform 0.15s ease",
+            willChange: "transform",
+            pointerEvents: "none",
+          }}
         />
         <ReactTooltip
           className="progress-tooltip"

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -3,7 +3,12 @@ import * as React from "react";
 import ReactTooltip from "react-tooltip";
 import { useAtomValue } from "jotai";
 import { millisecondsToStr } from "../../playlists/utils";
-import { durationMsAtom, progressMsAtom } from "./BrainzPlayerAtoms";
+import {
+  durationMsAtom,
+  progressMsAtom,
+  playerPausedAtom,
+  updateTimeAtom,
+} from "./BrainzPlayerAtoms";
 
 type ProgressBarProps = {
   seekToPositionMs: (msTimeCode: number) => void;
@@ -39,13 +44,28 @@ const useThrottle = (callback: any, delay: number | undefined) => {
 function ProgressBar(props: ProgressBarProps) {
   const progressMs = useAtomValue(progressMsAtom);
   const durationMs = useAtomValue(durationMsAtom);
+  const playerPaused = useAtomValue(playerPausedAtom);
+  const updateTime = useAtomValue(updateTimeAtom);
 
   const { seekToPositionMs, showNumbers } = props;
   const [tipContent, setTipContent] = React.useState(TOOLTIP_INITIAL_CONTENT);
   const progressBarRef = React.useRef<HTMLDivElement>(null);
-  const progressPercentage = Number(
-    ((progressMs * 100) / durationMs).toFixed()
-  );
+  const progressBarInnerRef = React.useRef<HTMLDivElement>(null);
+  const rafRef = React.useRef<number>(0);
+
+  React.useEffect(() => {
+    const tick = () => {
+      const elapsed = performance.now() - updateTime;
+      const liveProgressMs = playerPaused ? progressMs : progressMs + elapsed;
+      const ratio = Math.min(liveProgressMs / durationMs, 1) || 0;
+      if (progressBarInnerRef.current) {
+        progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [progressMs, durationMs, playerPaused, updateTime]);
 
   const mouseEventHandler = useThrottle(
     (event: React.MouseEvent<HTMLInputElement>): void => {
@@ -105,13 +125,6 @@ function ProgressBar(props: ProgressBarProps) {
     }
   };
 
-  const progressBarStyle: React.CSSProperties = {
-    width: `${progressPercentage || 0}%`,
-  };
-  if (!progressPercentage || progressPercentage === 0) {
-    // Hide little nubbin' appearing when at 0, for those with mild OCD.
-    progressBarStyle.borderRight = "none";
-  }
 
   return (
     <div className="progress-bar-wrapper">
@@ -124,12 +137,16 @@ function ProgressBar(props: ProgressBarProps) {
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={progressPercentage || 0}
+        aria-valuenow={0}
         tabIndex={0}
         data-tip={tipContent}
         ref={progressBarRef}
       >
-        <div className="progress-bar bg-info" style={progressBarStyle} />
+        <div
+          className="progress-bar bg-info"
+          ref={progressBarInnerRef}
+          style={{ transform: "scaleX(0)", transformOrigin: "left" }}
+        />
         <ReactTooltip
           className="progress-tooltip"
           arrowColor="inherit"

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -54,11 +54,18 @@ function ProgressBar(props: ProgressBarProps) {
   const progressBarInnerRef = React.useRef<HTMLDivElement>(null);
   const handleRef = React.useRef<HTMLDivElement>(null);
   const rafRef = React.useRef<number>(0);
+  const isDraggingRef = React.useRef<boolean>(false);
+  const rectCacheRef = React.useRef<DOMRect | null>(null);
+  const pendingSeekMsRef = React.useRef<number>(-1);
+  const seekVisualMsRef = React.useRef<number>(-1);
 
   React.useEffect(() => {
     const tick = () => {
-      const elapsed = performance.now() - updateTime;
-      const liveProgressMs = playerPaused ? progressMs : progressMs + elapsed;
+      if (isDraggingRef.current) return;
+      const base =
+        pendingSeekMsRef.current >= 0 ? pendingSeekMsRef.current : progressMs;
+      const elapsed = playerPaused ? 0 : performance.now() - updateTime;
+      const liveProgressMs = base + elapsed;
       const ratio = Math.min(liveProgressMs / durationMs, 1) || 0;
       if (progressBarInnerRef.current) {
         progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
@@ -75,6 +82,70 @@ function ProgressBar(props: ProgressBarProps) {
     rafRef.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafRef.current);
   }, [progressMs, durationMs, playerPaused, updateTime]);
+
+  const getMsFromClientX = (clientX: number): number => {
+    const rect = rectCacheRef.current;
+    if (!rect || durationMs <= 0) return 0;
+    const ratio = Math.max(0, Math.min((clientX - rect.left) / rect.width, 1));
+    return ratio * durationMs;
+  };
+
+  const flushVisuals = (msPosition: number): void => {
+    const ratio = Math.min(msPosition / durationMs, 1) || 0;
+    const barWidth = rectCacheRef.current?.width ?? 0;
+    const handleX = ratio * barWidth;
+    if (progressBarInnerRef.current) {
+      progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
+    }
+    if (handleRef.current) {
+      handleRef.current.style.setProperty("--handle-x", `${handleX}px`);
+    }
+  };
+
+  React.useEffect(() => {
+    const onPointerMove = (e: PointerEvent) => {
+      if (!isDraggingRef.current) return;
+      const msPos = getMsFromClientX(e.clientX);
+      seekVisualMsRef.current = msPos;
+      flushVisuals(msPos);
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+      const msPos = getMsFromClientX(e.clientX);
+      pendingSeekMsRef.current = msPos;
+      seekToPositionMs(msPos);
+      document
+        .querySelectorAll(".progress.dragging")
+        .forEach((el) => el.classList.remove("dragging"));
+    };
+
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("pointerup", onPointerUp);
+    return () => {
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerup", onPointerUp);
+    };
+  }, [seekToPositionMs, durationMs]);
+
+  React.useEffect(() => {
+    if (pendingSeekMsRef.current < 0) return;
+    if (Math.abs(progressMs - pendingSeekMsRef.current) < 500) {
+      pendingSeekMsRef.current = -1;
+    }
+  }, [progressMs]);
+
+  React.useEffect(() => {
+    const onResize = () => {
+      if (isDraggingRef.current && progressBarRef.current) {
+        rectCacheRef.current =
+          progressBarRef.current.getBoundingClientRect();
+      }
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   const mouseEventHandler = useThrottle(
     (event: React.MouseEvent<HTMLInputElement>): void => {
@@ -137,11 +208,34 @@ function ProgressBar(props: ProgressBarProps) {
 
   return (
     <div className="progress-bar-wrapper">
+      <style>{`
+        #brainz-player .progress.dragging,
+        .music-player .progress.dragging {
+          height: var(--progress-bar-hover-height, 6px);
+          top: calc(-1 * var(--progress-bar-hover-height, 6px));
+          cursor: grabbing;
+        }
+      `}</style>
       <div
         className="progress"
         onClick={mouseEventHandler}
         onMouseMove={mouseEventHandler}
         onKeyDown={onKeyPressHandler}
+        onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => {
+          e.preventDefault();
+          isDraggingRef.current = true;
+          rectCacheRef.current = (
+            e.currentTarget as HTMLDivElement
+          ).getBoundingClientRect();
+          if (handleRef.current) {
+            handleRef.current.style.transform =
+              "translate(-50%, -50%) scaleX(1)";
+          }
+          (e.currentTarget as HTMLDivElement).classList.add("dragging");
+          const msPos = getMsFromClientX(e.clientX);
+          seekVisualMsRef.current = msPos;
+          flushVisuals(msPos);
+        }}
         onMouseEnter={() => {
           if (handleRef.current) {
             handleRef.current.style.transform =

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -27,7 +27,7 @@ const MOUSE_THROTTLE_DELAY: number = 300;
 
 const TOOLTIP_INITIAL_CONTENT: string = "0:00";
 const TOOLTIP_TOP_OFFSET: number = 39;
-const HANDLE_RADIUS = 5; // px — handle is 10×10px
+const HANDLE_RADIUS = 7; // px — handle is 14×14px
 
 // Originally by ford04 - https://stackoverflow.com/a/62017005
 const useThrottle = (callback: any, delay: number | undefined) => {
@@ -141,8 +141,7 @@ function ProgressBar(props: ProgressBarProps) {
   React.useEffect(() => {
     const onResize = () => {
       if (isDraggingRef.current && progressBarRef.current) {
-        rectCacheRef.current =
-          progressBarRef.current.getBoundingClientRect();
+        rectCacheRef.current = progressBarRef.current.getBoundingClientRect();
       }
     };
     window.addEventListener("resize", onResize);
@@ -210,7 +209,6 @@ function ProgressBar(props: ProgressBarProps) {
     }
   };
 
-
   return (
     <div className="progress-bar-wrapper">
       <div
@@ -222,9 +220,7 @@ function ProgressBar(props: ProgressBarProps) {
           e.preventDefault();
           isDraggingRef.current = true;
           document.body.style.cursor = "grabbing";
-          rectCacheRef.current = (
-            e.currentTarget as HTMLDivElement
-          ).getBoundingClientRect();
+          rectCacheRef.current = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
           if (handleRef.current) {
             handleRef.current.style.transform =
               "translate(-50%, -50%) scaleX(1)";

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -91,6 +91,7 @@ function ProgressBar(props: ProgressBarProps) {
   };
 
   const flushVisuals = (msPosition: number): void => {
+    setTipContent(millisecondsToStr(msPosition));
     const ratio = Math.min(msPosition / durationMs, 1) || 0;
     const barWidth = rectCacheRef.current?.width ?? 0;
     const handleX = ratio * barWidth;
@@ -113,6 +114,7 @@ function ProgressBar(props: ProgressBarProps) {
     const onPointerUp = (e: PointerEvent) => {
       if (!isDraggingRef.current) return;
       isDraggingRef.current = false;
+      document.body.style.cursor = "";
       const msPos = getMsFromClientX(e.clientX);
       pendingSeekMsRef.current = msPos;
       seekToPositionMs(msPos);
@@ -190,7 +192,9 @@ function ProgressBar(props: ProgressBarProps) {
       } else {
         oneStepEarlier = progressMs - KEYBOARD_BIG_STEP_MS;
       }
-      seekToPositionMs(oneStepEarlier > 0 ? oneStepEarlier : 0);
+      const newPos = oneStepEarlier > 0 ? oneStepEarlier : 0;
+      pendingSeekMsRef.current = newPos;
+      seekToPositionMs(newPos);
     }
     if (event.key === EVENT_KEY_ARROWRIGHT) {
       let oneStepLater;
@@ -200,6 +204,7 @@ function ProgressBar(props: ProgressBarProps) {
         oneStepLater = progressMs + KEYBOARD_STEP_MS;
       }
       if (oneStepLater <= durationMs - 500) {
+        pendingSeekMsRef.current = oneStepLater;
         seekToPositionMs(oneStepLater);
       }
     }
@@ -208,14 +213,6 @@ function ProgressBar(props: ProgressBarProps) {
 
   return (
     <div className="progress-bar-wrapper">
-      <style>{`
-        #brainz-player .progress.dragging,
-        .music-player .progress.dragging {
-          height: var(--progress-bar-hover-height, 6px);
-          top: calc(-1 * var(--progress-bar-hover-height, 6px));
-          cursor: grabbing;
-        }
-      `}</style>
       <div
         className="progress"
         onClick={mouseEventHandler}
@@ -224,6 +221,7 @@ function ProgressBar(props: ProgressBarProps) {
         onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => {
           e.preventDefault();
           isDraggingRef.current = true;
+          document.body.style.cursor = "grabbing";
           rectCacheRef.current = (
             e.currentTarget as HTMLDivElement
           ).getBoundingClientRect();
@@ -266,18 +264,8 @@ function ProgressBar(props: ProgressBarProps) {
           ref={handleRef}
           className="progress-handle"
           style={{
-            position: "absolute",
-            top: "50%",
-            left: "var(--handle-x, 0px)",
-            width: `${HANDLE_RADIUS * 2}px`,
-            height: `${HANDLE_RADIUS * 2}px`,
-            borderRadius: "50%",
-            backgroundColor: "white",
             transform: "translate(-50%, -50%) scaleX(0)",
-            transformOrigin: "center",
-            transition: "transform 0.15s ease",
-            willChange: "transform",
-            pointerEvents: "none",
+            left: "var(--handle-x, 0px)",
           }}
         />
         <ReactTooltip

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -27,7 +27,6 @@ const MOUSE_THROTTLE_DELAY: number = 300;
 
 const TOOLTIP_INITIAL_CONTENT: string = "0:00";
 const TOOLTIP_TOP_OFFSET: number = 39;
-const HANDLE_RADIUS = 7; // px — handle is 14×14px
 
 // Originally by ford04 - https://stackoverflow.com/a/62017005
 const useThrottle = (callback: any, delay: number | undefined) => {
@@ -53,13 +52,14 @@ function ProgressBar(props: ProgressBarProps) {
   const progressBarRef = React.useRef<HTMLDivElement>(null);
   const progressBarInnerRef = React.useRef<HTMLDivElement>(null);
   const handleRef = React.useRef<HTMLDivElement>(null);
-  const rafRef = React.useRef<number>(0);
   const isDraggingRef = React.useRef<boolean>(false);
   const rectCacheRef = React.useRef<DOMRect | null>(null);
   const pendingSeekMsRef = React.useRef<number>(-1);
+  const draggingElementRef = React.useRef<Element | null>(null);
   const seekVisualMsRef = React.useRef<number>(-1);
 
   React.useEffect(() => {
+    let rafId: number;
     const tick = () => {
       if (isDraggingRef.current) return;
       const base =
@@ -77,10 +77,10 @@ function ProgressBar(props: ProgressBarProps) {
         const handleX = ratio * barWidth;
         handleRef.current.style.setProperty("--handle-x", `${handleX}px`);
       }
-      rafRef.current = requestAnimationFrame(tick);
+      rafId = requestAnimationFrame(tick);
     };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafRef.current);
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
   }, [progressMs, durationMs, playerPaused, updateTime]);
 
   const getMsFromClientX = (clientX: number): number => {
@@ -118,9 +118,8 @@ function ProgressBar(props: ProgressBarProps) {
       const msPos = getMsFromClientX(e.clientX);
       pendingSeekMsRef.current = msPos;
       seekToPositionMs(msPos);
-      document
-        .querySelectorAll(".progress.dragging")
-        .forEach((el) => el.classList.remove("dragging"));
+      draggingElementRef.current?.classList.remove("dragging");
+      draggingElementRef.current = null;
     };
 
     document.addEventListener("pointermove", onPointerMove);
@@ -226,6 +225,7 @@ function ProgressBar(props: ProgressBarProps) {
               "translate(-50%, -50%) scaleX(1)";
           }
           (e.currentTarget as HTMLDivElement).classList.add("dragging");
+          draggingElementRef.current = e.currentTarget as HTMLDivElement;
           const msPos = getMsFromClientX(e.clientX);
           seekVisualMsRef.current = msPos;
           flushVisuals(msPos);
@@ -246,7 +246,7 @@ function ProgressBar(props: ProgressBarProps) {
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={0}
+        aria-valuenow={durationMs > 0 ? Math.round((progressMs * 100) / durationMs) : 0}
         tabIndex={0}
         data-tip={tipContent}
         ref={progressBarRef}

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -60,21 +60,20 @@ function ProgressBar(props: ProgressBarProps) {
   React.useEffect(() => {
     let rafId: number;
     const tick = () => {
-      if (isDraggingRef.current) return;
-      const base =
-        pendingSeekMsRef.current >= 0 ? pendingSeekMsRef.current : progressMs;
-      const elapsed = playerPaused ? 0 : performance.now() - updateTime;
-      const liveProgressMs = base + elapsed;
-      const ratio = Math.min(liveProgressMs / durationMs, 1) || 0;
-      if (progressBarInnerRef.current) {
-        progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
-      }
-      if (!isDraggingRef.current && handleRef.current) {
-        const barWidth =
-          progressBarInnerRef.current?.parentElement?.getBoundingClientRect()
-            .width ?? 0;
-        const handleX = ratio * barWidth;
-        handleRef.current.style.setProperty("--handle-x", `${handleX}px`);
+      if (!isDraggingRef.current) {
+        const base =
+          pendingSeekMsRef.current >= 0 ? pendingSeekMsRef.current : progressMs;
+        const elapsed = playerPaused ? 0 : performance.now() - updateTime;
+        const liveProgressMs = base + elapsed;
+        const ratio = Math.min(liveProgressMs / durationMs, 1) || 0;
+        if (progressBarInnerRef.current) {
+          progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
+        }
+        if (handleRef.current) {
+          const barWidth = rectCacheRef.current?.width ?? 0;
+          const handleX = ratio * barWidth;
+          handleRef.current.style.setProperty("--handle-x", `${handleX}px`);
+        }
       }
       rafId = requestAnimationFrame(tick);
     };
@@ -113,7 +112,7 @@ function ProgressBar(props: ProgressBarProps) {
     };
 
     // On drag release: fire the actual seek and let pendingSeekMsRef hold the optimistic position
-    const onPointerUp = (e: PointerEvent) => {
+    const endDrag = (e: PointerEvent) => {
       if (!isDraggingRef.current) return;
       isDraggingRef.current = false;
       document.body.style.cursor = "";
@@ -125,10 +124,12 @@ function ProgressBar(props: ProgressBarProps) {
     };
 
     document.addEventListener("pointermove", onPointerMove);
-    document.addEventListener("pointerup", onPointerUp);
+    document.addEventListener("pointerup", endDrag);
+    document.addEventListener("pointercancel", endDrag);
     return () => {
       document.removeEventListener("pointermove", onPointerMove);
-      document.removeEventListener("pointerup", onPointerUp);
+      document.removeEventListener("pointerup", endDrag);
+      document.removeEventListener("pointercancel", endDrag);
     };
   }, [seekToPositionMs, durationMs]);
 

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -56,7 +56,6 @@ function ProgressBar(props: ProgressBarProps) {
   const rectCacheRef = React.useRef<DOMRect | null>(null);
   const pendingSeekMsRef = React.useRef<number>(-1);
   const draggingElementRef = React.useRef<Element | null>(null);
-  const seekVisualMsRef = React.useRef<number>(-1);
 
   React.useEffect(() => {
     let rafId: number;
@@ -70,7 +69,7 @@ function ProgressBar(props: ProgressBarProps) {
       if (progressBarInnerRef.current) {
         progressBarInnerRef.current.style.transform = `scaleX(${ratio})`;
       }
-      if (handleRef.current) {
+      if (!isDraggingRef.current && handleRef.current) {
         const barWidth =
           progressBarInnerRef.current?.parentElement?.getBoundingClientRect()
             .width ?? 0;
@@ -83,6 +82,7 @@ function ProgressBar(props: ProgressBarProps) {
     return () => cancelAnimationFrame(rafId);
   }, [progressMs, durationMs, playerPaused, updateTime]);
 
+  // Converts a pointer clientX coordinate to a millisecond position using the cached bar rect
   const getMsFromClientX = (clientX: number): number => {
     const rect = rectCacheRef.current;
     if (!rect || durationMs <= 0) return 0;
@@ -90,6 +90,7 @@ function ProgressBar(props: ProgressBarProps) {
     return ratio * durationMs;
   };
 
+  // Synchronously writes progress bar transform and handle position to the DOM during drag
   const flushVisuals = (msPosition: number): void => {
     setTipContent(millisecondsToStr(msPosition));
     const ratio = Math.min(msPosition / durationMs, 1) || 0;
@@ -104,13 +105,14 @@ function ProgressBar(props: ProgressBarProps) {
   };
 
   React.useEffect(() => {
+    // During drag: update visuals on every pointer move without firing seek
     const onPointerMove = (e: PointerEvent) => {
       if (!isDraggingRef.current) return;
       const msPos = getMsFromClientX(e.clientX);
-      seekVisualMsRef.current = msPos;
       flushVisuals(msPos);
     };
 
+    // On drag release: fire the actual seek and let pendingSeekMsRef hold the optimistic position
     const onPointerUp = (e: PointerEvent) => {
       if (!isDraggingRef.current) return;
       isDraggingRef.current = false;
@@ -130,6 +132,7 @@ function ProgressBar(props: ProgressBarProps) {
     };
   }, [seekToPositionMs, durationMs]);
 
+  // Clear pendingSeek once the player atom catches up (within 500ms tolerance)
   React.useEffect(() => {
     if (pendingSeekMsRef.current < 0) return;
     if (Math.abs(progressMs - pendingSeekMsRef.current) < 500) {
@@ -137,9 +140,13 @@ function ProgressBar(props: ProgressBarProps) {
     }
   }, [progressMs]);
 
+  // Cache bar rect on mount and keep it fresh on resize
   React.useEffect(() => {
+    if (progressBarRef.current) {
+      rectCacheRef.current = progressBarRef.current.getBoundingClientRect();
+    }
     const onResize = () => {
-      if (isDraggingRef.current && progressBarRef.current) {
+      if (progressBarRef.current) {
         rectCacheRef.current = progressBarRef.current.getBoundingClientRect();
       }
     };
@@ -227,7 +234,6 @@ function ProgressBar(props: ProgressBarProps) {
           (e.currentTarget as HTMLDivElement).classList.add("dragging");
           draggingElementRef.current = e.currentTarget as HTMLDivElement;
           const msPos = getMsFromClientX(e.clientX);
-          seekVisualMsRef.current = msPos;
           flushVisuals(msPos);
         }}
         onMouseEnter={() => {


### PR DESCRIPTION
## Problem

The BrainzPlayer progress bar had some problems. LB-1965

It had two issues.

The first issue with the BrainzPlayer progress bar was that the playback animation did not move smoothly. Also BrainzPlayer progress bar animation was controlled by React state updates that happened every 300 milliseconds, which made the BrainzPlayer progress bar jump in steps of moving smoothly.
The second issue with the BrainzPlayer progress bar was that you could not drag the BrainzPlayer progress bar to change the position of the playback.
You could only click on a position, on the BrainzPlayer progress bar to change the playback position.

## Solution

Replaced the React state-driven `width%` approach with a
`requestAnimationFrame` loop that writes `transform: scaleX()` directly
to the DOM via a ref. This gives true 60fps animation with zero React
re-renders per frame.

Added a circular scrubber handle that appears on hover and follows the
playhead. Users can now click and drag anywhere on the bar to seek.

## What changed

**ProgressBar.tsx**
- rAF loop reads `performance.now() - updateTime` to interpolate live
  playhead position between atom updates
- `progressBarInnerRef` receives direct `scaleX` writes — no setState
  in the animation path
- Added `isDraggingRef`, `rectCacheRef`, `pendingSeekMsRef` to coordinate
  drag state without touching React
- Document-level `pointermove` / `pointerup` listeners so drag works
  even if mouse leaves the bar
- `pendingSeekMsRef` holds the optimistic position after seek fires,
  preventing the bar from snapping back while the player catches up
- Keyboard ArrowLeft/Right seek also goes through `pendingSeekMsRef`
  for the same snap-free behaviour
- `cursor: grabbing` on `document.body` during active drag

**brainzplayer.scss**
- Added `width: 100%` to `.progress-bar` (required for scaleX base)
- Added `overflow: visible` to `.progress` to unclip the handle
- Added `.dragging` rule to pin bar height during drag
- Added `.progress-handle` styles (14px circle, `$primary-color`,
  hover-only via `scaleX` transition)
- Removed legacy `border-right` nubbin — the handle replaces it

## Testing

Tested locally with a YouTube-backed track:
- Bar animates smoothly at 60fps during playback
- Handle appears on hover, disappears on mouse leave
- Drag works across the full bar width, including when mouse
  leaves the element
- No snap-back after releasing drag
- Keyboard seek (ArrowLeft/Right) works correctly
- `.music-player` fullscreen view unaffected

## Notes

Handle color and hover-only behaviour confirmed with @Aerozol . No new colours introduced.

AI usage: 
If you did use AI:
[ ] I used AI tools for communication
[ ] I used AI tools for coding
[☑️] I did not use AI
[☑️] I understand all the changes made in this PR


https://github.com/user-attachments/assets/66c95acd-fc2c-4def-9b2c-6a9f2d4c672f


