### PR TITLE
Security: Stored/Reflected XSS via unescaped username in HTML Markup

### DIFF
--- a/listenbrainz/model/utils.py
+++ b/listenbrainz/model/utils.py
@@ -1,5 +1,9 @@
-from markupsafe import Markup
+from urllib.parse import quote
+
+from markupsafe import Markup, escape
 
 
 def generate_username_link(user_name):
-    return Markup(f"""<a href="https://listenbrainz.org/user/{user_name}">{user_name}</a>""")
+    quoted_user_name = quote(str(user_name), safe="")
+    escaped_user_name = escape(user_name)
+    return Markup(f"""<a href="https://listenbrainz.org/user/{quoted_user_name}">{escaped_user_name}</a>""")


### PR DESCRIPTION
## Problem

`generate_username_link` builds HTML with an f-string and wraps it in `Markup`, which disables escaping. If `user_name` contains attacker-controlled HTML/JS, it will be rendered directly in the browser.

**Severity**: `high`
**File**: `listenbrainz/model/utils.py`

## Solution

Avoid `Markup` with raw interpolation. Use `markupsafe.escape(user_name)` for both link text and URL segment (plus URL encoding for path components), or render links in Jinja templates where autoescaping applies.

## Changes

- `listenbrainz/model/utils.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
