### PR TITLE
Fix[LB-1947]: Track listen count stuck

### DIFF
--- a/listenbrainz_spark/popularity/listens.py
+++ b/listenbrainz_spark/popularity/listens.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from listenbrainz_spark.path import LISTENBRAINZ_POPULARITY_DIRECTORY
 from listenbrainz_spark.popularity.common import get_popularity_per_artist_query, \
-    get_release_group_popularity_per_artist_query, get_popularity_query
+    get_release_group_popularity_per_artist_query, get_release_group_popularity_query, get_popularity_query
 from listenbrainz_spark.postgres.release import get_release_metadata_cache
 from listenbrainz_spark.stats.incremental.query_provider import QueryProvider
 from listenbrainz_spark.stats.incremental.range_selector import ListenRangeSelector
@@ -46,7 +46,7 @@ class PopularityProvider(QueryProvider):
             return get_popularity_per_artist_query("artist", table)
         elif self.entity == "release_group":
             rel_cache_table = get_release_metadata_cache()
-            return get_release_group_popularity_per_artist_query(table, rel_cache_table)
+            return get_release_group_popularity_query(table, rel_cache_table)
         else:
             return get_popularity_query(self.entity, table)
 

--- a/listenbrainz_spark/popularity/mlhd.py
+++ b/listenbrainz_spark/popularity/mlhd.py
@@ -37,7 +37,7 @@ class MlhdStatsEngine:
 
         hdfs_connection.client.makedirs(Path(metadata_path).parent)
         metadata_df = listenbrainz_spark.session.createDataFrame(
-            [(self.provider.from_date, self.provider.to_date, datetime.now())],
+            [(self.provider.from_date, self.provider.to_date, datetime.now(), None)],
             schema=BOOKKEEPING_SCHEMA
         )
         metadata_df.write.mode("overwrite").json(metadata_path)

--- a/listenbrainz_spark/schema.py
+++ b/listenbrainz_spark/schema.py
@@ -18,6 +18,7 @@ BOOKKEEPING_SCHEMA = StructType([
     StructField('from_date', TimestampType(), nullable=False),
     StructField('to_date', TimestampType(), nullable=False),
     StructField('updated_at', TimestampType(), nullable=False),
+    StructField('dump_location', StringType(), nullable=True),
 ])
 
 INCREMENTAL_BOOKKEEPING_SCHEMA = StructType([

--- a/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
+++ b/listenbrainz_spark/stats/incremental/incremental_stats_engine.py
@@ -76,6 +76,18 @@ class IncrementalStatsEngine:
             existing_from_date, existing_to_date = metadata["from_date"], metadata["to_date"]
             existing_aggregate_fresh = existing_from_date.date() == self.provider.from_date.date() \
                 and existing_to_date.date() <= self.provider.to_date.date()
+
+            # if the dump location changed, the partial aggregate is stale and must be rebuilt
+            stored_dump_location = metadata["dump_location"]
+            current_listens_metadata = get_listens_metadata()
+            if current_listens_metadata is not None:
+                current_dump_location = current_listens_metadata.location
+                if stored_dump_location is None or stored_dump_location != current_dump_location:
+                    logger.info(
+                        "Dump location changed (stored=%s, current=%s), partial aggregate is stale",
+                        stored_dump_location, current_dump_location
+                    )
+                    existing_aggregate_fresh = False
         except (AnalysisException, IndexError):
             existing_aggregate_fresh = False
 
@@ -114,9 +126,13 @@ class IncrementalStatsEngine:
         full_df = run_query(full_query)
         full_df.write.mode("overwrite").parquet(existing_aggregate_path)
 
+        # store current dump location so future runs can detect when it changes
+        current_listens_metadata = get_listens_metadata()
+        dump_location = current_listens_metadata.location if current_listens_metadata else None
+
         hdfs_connection.client.makedirs(Path(metadata_path).parent)
         metadata_df = listenbrainz_spark.session.createDataFrame(
-            [(self.provider.from_date, self.provider.to_date, datetime.now())],
+            [(self.provider.from_date, self.provider.to_date, datetime.now(), dump_location)],
             schema=BOOKKEEPING_SCHEMA
         )
         metadata_df.write.mode("overwrite").json(metadata_path)


### PR DESCRIPTION
# Description
This PR fixes an issue where the global track and album listen counts were actively getting stuck and not updating and also corrects a bug computing release group popularity.

Ticket: LB-1947

# Problem
Our background system  caches a large chunk of listen data so it doesn't have to recalculate it from scratch every day. The problem was that when fresh listen data was imported, the system didn't realize it had been updated so it kept using the old frozen cache forever. Because of this the final listen numbers shown to users never went up. There was also a small bug where the wrong math was being used for release group listen counts.

# Solution
Taught the caching system to remember exactly where it got its data from. Now, if it notices that the main data location has changed it knows to throw away the old cache and build a new one. We also pointed the release group counts to the correct calculation.

# Changes Made
1) `listenbrainz_spark/schema.py`: Added a `dump_location` field to keep track of where the data came from.
2) `listenbrainz_spark/stats/incremental/incremental_stats_engine.py`: Updated the system to check and save the  `dump_location` so it can detect when new data arrives.
3) `listenbrainz_spark/popularity/listens.py`: Corrected the query used for calculating release group popularity.
4) `listenbrainz_spark/popularity/mlhd.py`: Minor update to keep the old code compatible with the new `dump_location` tracking.

# AI Usage
- Received assistance with pinpointing the logical bug and writing out the fix.
- All code has been thoroughly reviewed, manually tested and fully understood prior to submission.
