### PR TITLE
LB-1970  Add standalone Create Playlist button next to Import 

### DIFF
--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -345,101 +345,123 @@ export default class UserPlaylists extends React.Component<
                 <option value={SortOption.RANDOM}>Random</option>
               </select>
             </div>
+
             {this.isCurrentUserPage() && (
-              <div className="dropdown">
+              <div
+                className="d-flex align-items-center"
+                style={{ gap: "10px" }}
+              >
                 <button
-                  className="btn btn-info dropdown-toggle"
+                  className="btn btn-info"
                   type="button"
-                  id="ImportPlaylistDropdown"
-                  data-bs-toggle="dropdown"
-                  aria-haspopup="true"
+                  style={{ borderRadius: "5px" }}
+                  onClick={() => {
+                    NiceModal.show<JSPFPlaylist, any>(
+                      CreateOrEditPlaylistModal
+                    ).then((playlist) => {
+                      this.onPlaylistCreated(playlist);
+                    });
+                  }}
                 >
-                  <FontAwesomeIcon icon={faPlusCircle} title="Import" />
-                  &nbsp;Import&nbsp;
+                  <FontAwesomeIcon icon={faPlusCircle} />
+                  &nbsp;Create Playlist
                 </button>
-                <ul
-                  className="dropdown-menu dropdown-menu-right"
-                  aria-labelledby="ImportPlaylistDropdown"
-                >
+                <div className="dropdown">
                   <button
+                    className="btn btn-info dropdown-toggle"
                     type="button"
-                    onClick={() => {
-                      NiceModal.show<JSPFPlaylist | JSPFPlaylist[], any>(
-                        ImportSpotifyPlaylistModal
-                      ).then((playlist) => {
-                        if (Array.isArray(playlist)) {
-                          playlist.forEach((p: JSPFPlaylist) => {
-                            this.onPlaylistCreated(p);
-                          });
-                        } else {
-                          this.onPlaylistCreated(playlist);
-                        }
-                      });
-                    }}
-                    className="dropdown-item"
+                    id="ImportPlaylistDropdown"
+                    data-bs-toggle="dropdown"
+                    aria-haspopup="true"
                   >
-                    <FontAwesomeIcon icon={faSpotify} />
-                    &nbsp;Spotify
+                    <FontAwesomeIcon icon={faPlusCircle} title="Import" />
+                    &nbsp;Import&nbsp;
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      NiceModal.show<JSPFPlaylist | JSPFPlaylist[], any>(
-                        ImportAppleMusicPlaylistModal
-                      ).then((playlist) => {
-                        if (Array.isArray(playlist)) {
-                          playlist.forEach((p: JSPFPlaylist) => {
-                            this.onPlaylistCreated(p);
-                          });
-                        } else {
-                          this.onPlaylistCreated(playlist);
-                        }
-                      });
-                    }}
-                    className="dropdown-item"
+                  <ul
+                    className="dropdown-menu dropdown-menu-right"
+                    aria-labelledby="ImportPlaylistDropdown"
                   >
-                    <FontAwesomeIcon icon={faItunesNote} />
-                    &nbsp;Apple Music
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      NiceModal.show<JSPFPlaylist[], any>(
-                        ImportSoundCloudPlaylistModal
-                      ).then((newPlaylists) => {
-                        newPlaylists.forEach(this.onPlaylistCreated);
-                      });
-                    }}
-                    className="dropdown-item"
-                  >
-                    <FontAwesomeIcon icon={faSoundcloud} />
-                    &nbsp;SoundCloud
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      NiceModal.show<JSPFPlaylist | JSPFPlaylist[], any>(
-                        ImportPlaylistModal
-                      ).then((playlist) => {
-                        if (Array.isArray(playlist)) {
-                          playlist.forEach((p: JSPFPlaylist) => {
-                            this.onPlaylistCreated(p);
-                          });
-                        } else {
-                          this.onPlaylistCreated(playlist);
-                        }
-                      });
-                    }}
-                    className="dropdown-item"
-                  >
-                    <FontAwesomeIcon icon={faFileImport} />
-                    &nbsp;Upload JSPF file
-                  </button>
-                </ul>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        NiceModal.show<JSPFPlaylist | JSPFPlaylist[], any>(
+                          ImportSpotifyPlaylistModal
+                        ).then((playlist) => {
+                          if (Array.isArray(playlist)) {
+                            playlist.forEach((p: JSPFPlaylist) => {
+                              this.onPlaylistCreated(p);
+                            });
+                          } else {
+                            this.onPlaylistCreated(playlist);
+                          }
+                        });
+                      }}
+                      className="dropdown-item"
+                    >
+                      <FontAwesomeIcon icon={faSpotify} />
+                      &nbsp;Spotify
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        NiceModal.show<JSPFPlaylist | JSPFPlaylist[], any>(
+                          ImportAppleMusicPlaylistModal
+                        ).then((playlist) => {
+                          if (Array.isArray(playlist)) {
+                            playlist.forEach((p: JSPFPlaylist) => {
+                              this.onPlaylistCreated(p);
+                            });
+                          } else {
+                            this.onPlaylistCreated(playlist);
+                          }
+                        });
+                      }}
+                      className="dropdown-item"
+                    >
+                      <FontAwesomeIcon icon={faItunesNote} />
+                      &nbsp;Apple Music
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        NiceModal.show<JSPFPlaylist[], any>(
+                          ImportSoundCloudPlaylistModal
+                        ).then((newPlaylists) => {
+                          newPlaylists.forEach(this.onPlaylistCreated);
+                        });
+                      }}
+                      className="dropdown-item"
+                    >
+                      <FontAwesomeIcon icon={faSoundcloud} />
+                      &nbsp;SoundCloud
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        NiceModal.show<JSPFPlaylist | JSPFPlaylist[], any>(
+                          ImportPlaylistModal
+                        ).then((playlist) => {
+                          if (Array.isArray(playlist)) {
+                            playlist.forEach((p: JSPFPlaylist) => {
+                              this.onPlaylistCreated(p);
+                            });
+                          } else {
+                            this.onPlaylistCreated(playlist);
+                          }
+                        });
+                      }}
+                      className="dropdown-item"
+                    >
+                      <FontAwesomeIcon icon={faFileImport} />
+                      &nbsp;Upload JSPF file
+                    </button>
+                  </ul>
+                </div>
               </div>
             )}
           </div>
         </div>
+
         <PlaylistsList
           onCopiedPlaylist={this.onCopiedPlaylist}
           playlists={playlists}


### PR DESCRIPTION
# Problem

currently users have to scroll down to the bottom of the playlists grid to find the "Create new playlist" card this creates a bad user experience, especially for users who have a large number of existing playlists

# Solution

This PR improves the UX by adding a  "Create Playlist" button directly to the top  navigation bar, placing it conveniently next to the "Import" 
* [x] I have run the code and manually tested the changes

# AI usage
* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [x] I understand all the changes made in this PR
