### PR TITLE
LB-1986: Add URL relationship fallback for Spotify MBID lookup

### DIFF
--- a/listenbrainz/labs_api/labs/api/spotify/spotify_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/api/spotify/spotify_mbid_lookup.py
@@ -1,5 +1,8 @@
+from flask import current_app
+
 from listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_mbid_lookup import MetadataIndexFromMBIDQuery
 from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
+from listenbrainz.labs_api.labs.api.utils import lookup_spotify_track_ids_from_mb_url_rels
 
 
 class SpotifyIdFromMBIDQuery(MetadataIndexFromMBIDQuery):
@@ -13,7 +16,46 @@ class SpotifyIdFromMBIDQuery(MetadataIndexFromMBIDQuery):
 
     def introduction(self):
         return """Given a recording mbid, lookup its metadata using canonical metadata
-        tables and using that attempt to find a suitable match in Spotify."""
+        tables and using that attempt to find a suitable match in Spotify. Recordings
+        that are not matched by the metadata index fall back to MusicBrainz URL
+        relationships, which map recording MBIDs directly to curated Spotify track URLs."""
 
     def outputs(self):
         return SpotifyIdFromMBIDOutput
+
+    def fetch(self, params, source, offset=-1, count=-1):
+        results = super().fetch(params, source, offset, count)
+
+        # Fall back to MusicBrainz URL relationships for any recordings the metadata
+        # index did not resolve. This catches cases where the normalized text lookup
+        # fails (remaster suffixes, non-Latin scripts, featured-artist drift, etc.)
+        # and also cases where the input MBID is not present in the canonical
+        # metadata tables at all (in which case the base class drops it silently).
+        input_mbids = [str(p.recording_mbid) for p in params]
+        resolved_mbids = {str(r.recording_mbid) for r in results if r.spotify_track_ids}
+        unresolved = [m for m in input_mbids if m not in resolved_mbids]
+
+        if unresolved:
+            try:
+                url_rel_matches = lookup_spotify_track_ids_from_mb_url_rels(unresolved)
+            except Exception:
+                current_app.logger.error("URL relationship fallback failed, returning metadata index results only",
+                                         exc_info=True)
+                return results
+
+            # Update existing result rows (empty spotify_track_ids) where we now have a match
+            result_by_mbid = {str(r.recording_mbid): r for r in results}
+            for mbid, track_ids in url_rel_matches.items():
+                if mbid in result_by_mbid:
+                    result_by_mbid[mbid].spotify_track_ids = track_ids
+                else:
+                    # MBID was dropped by the base class (not in canonical metadata); construct a new row
+                    results.append(self.outputs()(
+                        recording_mbid=mbid,
+                        artist_name=None,
+                        release_name=None,
+                        track_name=None,
+                        spotify_track_ids=track_ids,
+                    ))
+
+        return results

--- a/listenbrainz/labs_api/labs/api/utils.py
+++ b/listenbrainz/labs_api/labs/api/utils.py
@@ -147,6 +147,46 @@ def lookup_using_metadata(params: list[dict], service, model: type[BaseModel], t
     return [model(**row) for row in metadata.values()]
 
 
+def lookup_spotify_track_ids_from_mb_url_rels(mbids: list[str]) -> dict[str, list[str]]:
+    """Look up Spotify track ids for the given recording MBIDs via MusicBrainz URL relationships.
+
+    Queries curated recording -> Spotify URL links maintained by MusicBrainz editors,
+    bypassing text-normalization failure modes of the metadata index.
+
+    Args:
+        mbids: Recording MBIDs to look up.
+
+    Returns:
+        Dict mapping recording_mbid to a list of Spotify track ids. Only MBIDs
+        with at least one matching URL relationship are present.
+    """
+    if not mbids:
+        return {}
+
+    query = """
+        WITH input_mbids (gid) AS (VALUES %s)
+        SELECT input_mbids.gid::text AS recording_mbid,
+               array_agg(DISTINCT substring(u.url FROM 'open\\.spotify\\.com/track/([A-Za-z0-9]+)')) AS track_ids
+          FROM input_mbids
+          JOIN musicbrainz.recording       r   ON r.gid = input_mbids.gid::uuid
+          JOIN musicbrainz.l_recording_url lru ON lru.entity0 = r.id
+          JOIN musicbrainz.url             u   ON u.id = lru.entity1
+          JOIN musicbrainz.link            l   ON l.id = lru.link
+          JOIN musicbrainz.link_type       lt  ON lt.id = l.link_type
+         WHERE lt.name IN ('free streaming', 'streaming')
+           AND u.url ~ '^https?://open\\.spotify\\.com/track/[A-Za-z0-9]+'
+      GROUP BY input_mbids.gid
+    """
+
+    with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as conn, conn.cursor() as curs:
+        execute_values(curs, query, [(mbid,) for mbid in mbids], page_size=len(mbids))
+        return {
+            row[0]: [tid for tid in row[1] if tid]
+            for row in curs.fetchall()
+            if row[1] and any(tid for tid in row[1])
+        }
+
+
 def lookup_recording_canonical_metadata(mbids: list[str]):
     """ Retrieve metadata from canonical tables for given mbids. All mbids are first looked up in MB redirects
     and then resolved to canonical mbids. Finally, the metadata for canonical mbids is retrieved. """

--- a/listenbrainz/labs_api/labs/tests/test_spotify_mbid_lookup.py
+++ b/listenbrainz/labs_api/labs/tests/test_spotify_mbid_lookup.py
@@ -1,0 +1,234 @@
+from unittest.mock import patch
+
+import flask_testing
+from datasethoster import RequestSource
+from datasethoster.main import create_app
+
+from listenbrainz.labs_api.labs.api.spotify import SpotifyIdFromMBIDOutput
+from listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_mbid_lookup import MetadataIdFromMBIDInput
+from listenbrainz.labs_api.labs.api.spotify.spotify_mbid_lookup import SpotifyIdFromMBIDQuery
+
+url_rel_mbids = [
+    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    "cccccccc-cccc-cccc-cccc-cccccccccccc",
+]
+
+url_rel_db_response = [
+    ("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", ["2nLtzopw4rPReszdYBJU6h"]),
+    ("cccccccc-cccc-cccc-cccc-cccccccccccc", ["5HCyWlXZPP0y6Gqq8TgA20", "3KkXRkHbMCARz0aVfEt68P"]),
+]
+
+fetch_params = [
+    MetadataIdFromMBIDInput(recording_mbid="11111111-1111-1111-1111-111111111111"),
+    MetadataIdFromMBIDInput(recording_mbid="22222222-2222-2222-2222-222222222222"),
+    MetadataIdFromMBIDInput(recording_mbid="33333333-3333-3333-3333-333333333333"),
+    MetadataIdFromMBIDInput(recording_mbid="44444444-4444-4444-4444-444444444444"),
+]
+
+
+def make_base_fetch_results():
+    """Build a fresh list each call so in-place mutations don't leak between tests."""
+    return [
+        SpotifyIdFromMBIDOutput(
+            recording_mbid="11111111-1111-1111-1111-111111111111",
+            artist_name="Artist One",
+            release_name="Album One",
+            track_name="Track One",
+            spotify_track_ids=["6rqhFgbbKwnb9MLmUQDhG6"],
+        ),
+        SpotifyIdFromMBIDOutput(
+            recording_mbid="22222222-2222-2222-2222-222222222222",
+            artist_name="Artist Two",
+            release_name="Album Two",
+            track_name="Track Two",
+            spotify_track_ids=[],
+        ),
+        SpotifyIdFromMBIDOutput(
+            recording_mbid="33333333-3333-3333-3333-333333333333",
+            artist_name="Artist Three",
+            release_name="Album Three",
+            track_name="Track Three",
+            spotify_track_ids=[],
+        ),
+    ]
+
+
+url_rel_fallback = {
+    "22222222-2222-2222-2222-222222222222": ["0VjIjW4GlUZAMYd2vXMi4a"],
+    "44444444-4444-4444-4444-444444444444": ["3KkXRkHbMCARz0aVfEt68P"],
+}
+
+URL_RELS_PATCH = 'listenbrainz.labs_api.labs.api.spotify.spotify_mbid_lookup.lookup_spotify_track_ids_from_mb_url_rels'
+SUPER_FETCH_PATCH = 'listenbrainz.labs_api.labs.api.metadata_index.metadata_index_from_mbid_lookup.MetadataIndexFromMBIDQuery.fetch'
+
+
+class MainTestCase(flask_testing.TestCase):
+
+    def create_app(self):
+        app = create_app()
+        app.config['MB_DATABASE_URI'] = 'yermom'
+        app.config['SQLALCHEMY_TIMESCALE_URI'] = 'yermom'
+        return app
+
+    def setUp(self):
+        self.maxDiff = None
+        flask_testing.TestCase.setUp(self)
+
+    def tearDown(self):
+        flask_testing.TestCase.tearDown(self)
+
+    def test_basics(self):
+        q = SpotifyIdFromMBIDQuery()
+        self.assertEqual(q.names()[0], "spotify-id-from-mbid")
+        self.assertEqual(q.names()[1], "Spotify Track ID Lookup using recording mbid")
+        self.assertNotEqual(q.introduction(), "")
+        self.assertCountEqual(q.inputs().__fields__.keys(), ['recording_mbid'])
+        self.assertCountEqual(q.outputs().__fields__.keys(), [
+            'recording_mbid', 'artist_name', 'release_name', 'track_name', 'spotify_track_ids'
+        ])
+
+    @patch('listenbrainz.labs_api.labs.api.utils.execute_values')
+    @patch('psycopg2.connect')
+    def test_url_rels_returns_matching_mbids(self, mock_connect, mock_execute_values):
+        mock_connect().__enter__().cursor().__enter__().fetchall.return_value = url_rel_db_response
+
+        from listenbrainz.labs_api.labs.api.utils import lookup_spotify_track_ids_from_mb_url_rels
+        result = lookup_spotify_track_ids_from_mb_url_rels(url_rel_mbids)
+
+        self.assertEqual(result, {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa": ["2nLtzopw4rPReszdYBJU6h"],
+            "cccccccc-cccc-cccc-cccc-cccccccccccc": ["5HCyWlXZPP0y6Gqq8TgA20", "3KkXRkHbMCARz0aVfEt68P"],
+        })
+        self.assertNotIn("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", result)
+
+    @patch('listenbrainz.labs_api.labs.api.utils.execute_values')
+    @patch('psycopg2.connect')
+    def test_url_rels_empty_input(self, mock_connect, mock_execute_values):
+        from listenbrainz.labs_api.labs.api.utils import lookup_spotify_track_ids_from_mb_url_rels
+        result = lookup_spotify_track_ids_from_mb_url_rels([])
+
+        self.assertEqual(result, {})
+        mock_connect.assert_not_called()
+
+    @patch('listenbrainz.labs_api.labs.api.utils.execute_values')
+    @patch('psycopg2.connect')
+    def test_url_rels_no_matches(self, mock_connect, mock_execute_values):
+        mock_connect().__enter__().cursor().__enter__().fetchall.return_value = []
+
+        from listenbrainz.labs_api.labs.api.utils import lookup_spotify_track_ids_from_mb_url_rels
+        result = lookup_spotify_track_ids_from_mb_url_rels(url_rel_mbids)
+
+        self.assertEqual(result, {})
+
+    @patch('listenbrainz.labs_api.labs.api.utils.execute_values')
+    @patch('psycopg2.connect')
+    def test_url_rels_filters_null_track_ids(self, mock_connect, mock_execute_values):
+        mock_connect().__enter__().cursor().__enter__().fetchall.return_value = [
+            ("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", [None]),
+            ("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", ["2nLtzopw4rPReszdYBJU6h", None]),
+        ]
+
+        from listenbrainz.labs_api.labs.api.utils import lookup_spotify_track_ids_from_mb_url_rels
+        result = lookup_spotify_track_ids_from_mb_url_rels(url_rel_mbids)
+
+        self.assertNotIn("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", result)
+        self.assertEqual(result["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"], ["2nLtzopw4rPReszdYBJU6h"])
+
+    @patch(URL_RELS_PATCH, return_value=url_rel_fallback)
+    @patch(SUPER_FETCH_PATCH)
+    def test_fallback_updates_existing_rows(self, mock_super_fetch, mock_url_rels):
+        mock_super_fetch.return_value = make_base_fetch_results()
+
+        q = SpotifyIdFromMBIDQuery()
+        results = q.fetch(fetch_params, RequestSource.json_post)
+
+        result_by_mbid = {str(r.recording_mbid): r for r in results}
+
+        self.assertEqual(
+            result_by_mbid["11111111-1111-1111-1111-111111111111"].spotify_track_ids,
+            ["6rqhFgbbKwnb9MLmUQDhG6"]
+        )
+        self.assertEqual(
+            result_by_mbid["22222222-2222-2222-2222-222222222222"].spotify_track_ids,
+            ["0VjIjW4GlUZAMYd2vXMi4a"]
+        )
+        self.assertEqual(result_by_mbid["22222222-2222-2222-2222-222222222222"].artist_name, "Artist Two")
+
+    @patch(URL_RELS_PATCH, return_value=url_rel_fallback)
+    @patch(SUPER_FETCH_PATCH)
+    def test_fallback_creates_new_row_for_dropped_mbid(self, mock_super_fetch, mock_url_rels):
+        mock_super_fetch.return_value = make_base_fetch_results()
+
+        q = SpotifyIdFromMBIDQuery()
+        results = q.fetch(fetch_params, RequestSource.json_post)
+
+        result_by_mbid = {str(r.recording_mbid): r for r in results}
+
+        self.assertIn("44444444-4444-4444-4444-444444444444", result_by_mbid)
+        self.assertEqual(
+            result_by_mbid["44444444-4444-4444-4444-444444444444"].spotify_track_ids,
+            ["3KkXRkHbMCARz0aVfEt68P"]
+        )
+        self.assertIsNone(result_by_mbid["44444444-4444-4444-4444-444444444444"].artist_name)
+
+    @patch(URL_RELS_PATCH, return_value=url_rel_fallback)
+    @patch(SUPER_FETCH_PATCH)
+    def test_fallback_leaves_unmatched_recordings_unchanged(self, mock_super_fetch, mock_url_rels):
+        mock_super_fetch.return_value = make_base_fetch_results()
+
+        q = SpotifyIdFromMBIDQuery()
+        results = q.fetch(fetch_params, RequestSource.json_post)
+
+        result_by_mbid = {str(r.recording_mbid): r for r in results}
+
+        self.assertEqual(
+            result_by_mbid["33333333-3333-3333-3333-333333333333"].spotify_track_ids,
+            []
+        )
+
+    @patch(URL_RELS_PATCH, return_value={})
+    @patch(SUPER_FETCH_PATCH)
+    def test_fallback_no_url_rel_matches(self, mock_super_fetch, mock_url_rels):
+        mock_super_fetch.return_value = make_base_fetch_results()
+
+        q = SpotifyIdFromMBIDQuery()
+        results = q.fetch(fetch_params, RequestSource.json_post)
+
+        self.assertEqual(len(results), len(make_base_fetch_results()))
+        for r in results:
+            if str(r.recording_mbid) == "11111111-1111-1111-1111-111111111111":
+                self.assertEqual(r.spotify_track_ids, ["6rqhFgbbKwnb9MLmUQDhG6"])
+            else:
+                self.assertEqual(r.spotify_track_ids, [])
+
+    @patch(URL_RELS_PATCH)
+    @patch(SUPER_FETCH_PATCH)
+    def test_all_resolved_skips_fallback(self, mock_super_fetch, mock_url_rels):
+        all_resolved = [
+            SpotifyIdFromMBIDOutput(
+                recording_mbid="11111111-1111-1111-1111-111111111111",
+                artist_name="Artist One",
+                release_name="Album One",
+                track_name="Track One",
+                spotify_track_ids=["6rqhFgbbKwnb9MLmUQDhG6"],
+            ),
+        ]
+        mock_super_fetch.return_value = all_resolved
+        params = [MetadataIdFromMBIDInput(recording_mbid="11111111-1111-1111-1111-111111111111")]
+
+        q = SpotifyIdFromMBIDQuery()
+        results = q.fetch(params, RequestSource.json_post)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].spotify_track_ids, ["6rqhFgbbKwnb9MLmUQDhG6"])
+        mock_url_rels.assert_not_called()
+
+    @patch(URL_RELS_PATCH)
+    @patch(SUPER_FETCH_PATCH, return_value=[])
+    def test_empty_params(self, mock_super_fetch, mock_url_rels):
+        q = SpotifyIdFromMBIDQuery()
+        results = q.fetch([], RequestSource.json_post)
+
+        self.assertEqual(results, [])
+        mock_url_rels.assert_not_called()


### PR DESCRIPTION
## Summary

When exporting ListenBrainz playlists to Spotify, roughly 20% of tracks get dropped because the metadata index text-matching fails. This adds a fallback that queries MusicBrainz's curated URL relationships (recording → Spotify track links) for any recordings the metadata index doesn't resolve.

- Adds `lookup_spotify_track_ids_from_mb_url_rels()` to query MB URL relationships for Spotify track IDs
- Overrides `SpotifyIdFromMBIDQuery.fetch()` to fall back to URL relationships when the metadata index misses
- Gracefully degrades: if the URL rel lookup fails, metadata index results are returned as before
- No schema changes, no external API calls — runs against existing MusicBrainz tables

Testing on a 50-track sample recovered 10 of 11 dropped tracks, reducing the drop rate from 22% to ~2%.

## References

- JIRA: https://tickets.metabrainz.org/browse/LB-1986
- Discourse discussion: https://community.metabrainz.org/t/improving-spotify-export-coverage-via-musicbrainz-url-relationships/814649

## AI disclosure

I used Claude Code as part of my workflow for understanding the codebase and the underlying issue, as well as drafting the initial fix and unit tests. I've reviewed all changes myself and went through several iterations where I gave feedback on style, test patterns, error handling, and consistency with existing code.

## Test plan

- [ ] New unit tests pass (`test_spotify_mbid_lookup.py` — 11 tests)
- [ ] Existing labs_api tests still pass
- [ ] Verify fallback resolves previously-dropped tracks in a real playlist export