### PR TITLE
Add Unstream to add-data page

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -334,6 +334,13 @@ export default function AddData() {
           , a Mac menu bar utility for displaying the current track, submits
           Apple Music and Spotify listens
         </li>
+        <li>
+          <em>
+            <a href="https://unstream.stream/">Unstream</a>
+          </em>
+          , a MacOS app and browser extension that detects and submit your listens,
+          and shows the best ways to support your favorite artists
+        </li>
       </ul>
 
       <h4>Browser extensions</h4>


### PR DESCRIPTION
Unstream contacted us asking to be added to our list.
It is a great initiative with a view to support the artist in the fairest way possible, and as a bonus sends listens to LB