### PR TITLE
Playlist metadata hidden when description is too long

### DIFF
--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -256,5 +256,3 @@ $long-description-lines: 8;
   align-items: center;
   gap: 1rem;
 }
-
-

--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -256,3 +256,5 @@ $long-description-lines: 8;
   align-items: center;
   gap: 1rem;
 }
+
+

--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -260,6 +260,6 @@ $long-description-lines: 8;
 }
 .playlist-card-list-view .text-summary,
 .playlist .text-summary {
-mask-image: none;
--webkit-mask-image: none;
+  mask-image: none;
+  -webkit-mask-image: none;
 }

--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -231,6 +231,8 @@ $long-description-lines: 8;
   -webkit-box-orient: vertical;
   padding-right: 2em;
   margin-top: 0.5rem;
+  mask-image: linear-gradient(180deg, #000 60%, transparent 98%);
+  -webkit-mask-image: linear-gradient(180deg, #000 60%, transparent 98%);
 
   &.long {
     max-height: $long-description-lines * 1.2em;
@@ -255,4 +257,9 @@ $long-description-lines: 8;
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+.playlist-card-list-view .text-summary,
+.playlist .text-summary {
+mask-image: none;
+-webkit-mask-image: none;
 }

--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -1,5 +1,5 @@
 $playlist-background-color: $body-tertiary-bg;
-$description-lines: 3;
+$description-lines: 2;
 $long-description-lines: 8;
 
 #playlists-page .playlist-view-options {
@@ -231,8 +231,6 @@ $long-description-lines: 8;
   -webkit-box-orient: vertical;
   padding-right: 2em;
   margin-top: 0.5rem;
-  mask-image: linear-gradient(180deg, #000 60%, transparent 98%);
-  -webkit-mask-image: linear-gradient(180deg, #000 60%, transparent 98%);
 
   &.long {
     max-height: $long-description-lines * 1.2em;

--- a/frontend/js/src/user/playlists/components/PlaylistCard.tsx
+++ b/frontend/js/src/user/playlists/components/PlaylistCard.tsx
@@ -131,7 +131,7 @@ export default function PlaylistCard({
               </div>
               {playlist.annotation && (
                 <div
-                  className="description"
+                  className="description text-summary"
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{ __html: playlist.annotation }}
                 />
@@ -236,7 +236,7 @@ export default function PlaylistCard({
         <h4>{playlist.title}</h4>
         {playlist.annotation && (
           <div
-            className="description"
+            className="description text-summary"
             // Sanitize the HTML string before passing it to dangerouslySetInnerHTML
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
# Problem
[LB-1980](https://tickets.metabrainz.org/browse/LB-1980)
Playlist metadata becomes hidden in grid views when playlist descriptions are too long. 
This happens because descriptions are rendered without proper truncation, causing layout overflow and pushing important information out of view. 

# Solution

- Applied the existing `.text-summary` class to playlist descriptions in both list and grid views to enable controlled multi-line truncation.
- Reduced description length to 2 lines for better layout balance.

* ✅ I have run the code and manually tested the changes

* ✅ I did not use any AI
* [ ] I have used AI in this PR (add more details below)

# Screenshot:

Before:

<img width="238" height="239" alt="Screenshot 2026-04-05 212237" src="https://github.com/user-attachments/assets/a041db80-d9a2-44cf-8f64-8ef2001b0df3" />

<img width="986" height="177" alt="Screenshot 2026-04-16 220502" src="https://github.com/user-attachments/assets/5aa653c0-fdcb-48b8-b9d7-ae99a8117c47" />


After:

<img width="240" height="243" alt="Screenshot 2026-04-16 205812" src="https://github.com/user-attachments/assets/03920512-2f24-42da-9aab-8414dfb68620" />

<img width="978" height="147" alt="Screenshot 2026-04-16 220127" src="https://github.com/user-attachments/assets/742220d8-464e-4ace-ad3f-c273ffa2090b" />



