### PR TITLE
LB-1983 Showing Artist Name Relationship 

### DIFF
--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -142,6 +142,7 @@ CREATE TABLE mapping.mb_artist_metadata_cache (
     artist_data             JSONB NOT NULL,
     tag_data                JSONB NOT NULL,
     release_group_data      JSONB NOT NULL
+    artist_relationship_data JSONB NOT NULL
 );
 
 -- the various mapping columns should only be null if the match_type is no_match, otherwise the columns should be

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -141,7 +141,7 @@ CREATE TABLE mapping.mb_artist_metadata_cache (
     artist_mbid             UUID NOT NULL,
     artist_data             JSONB NOT NULL,
     tag_data                JSONB NOT NULL,
-    release_group_data      JSONB NOT NULL
+    release_group_data      JSONB NOT NULL,
     artist_relationship_data JSONB NOT NULL
 );
 

--- a/admin/timescale/updates/2026-04-20-add-artist-relationship-data-column.sql
+++ b/admin/timescale/updates/2026-04-20-add-artist-relationship-data-column.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE mapping.mb_artist_metadata_cache 
+ADD COLUMN IF NOT EXISTS artist_relationship_data JSONB NOT NULL DEFAULT '[]'::JSONB;
+
+COMMIT;

--- a/frontend/css/sass/entity-pages.scss
+++ b/frontend/css/sass/entity-pages.scss
@@ -159,7 +159,7 @@ $white-gradient: linear-gradient(to bottom, transparent, #fff 65%);
       }
     }
 
-       .artist-relationships {
+    .artist-relationships {
       width: 100%;
       .read-more {
         position: relative;

--- a/frontend/css/sass/entity-pages.scss
+++ b/frontend/css/sass/entity-pages.scss
@@ -159,6 +159,16 @@ $white-gradient: linear-gradient(to bottom, transparent, #fff 65%);
       }
     }
 
+       .artist-relationships {
+      width: 100%;
+      .read-more {
+        position: relative;
+        bottom: auto;
+        padding: 0.5em 0 0;
+        text-align: left;
+      }
+    }
+
     .stats {
       margin-top: 2em;
       display: flex;

--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -334,6 +334,13 @@ export default function AddData() {
           , a Mac menu bar utility for displaying the current track, submits
           Apple Music and Spotify listens
         </li>
+        <li>
+          <em>
+            <a href="https://unstream.stream/">Unstream</a>
+          </em>
+          , a MacOS app and browser extension that detects and submits your listens,
+          and shows the best ways to support your favorite artists
+        </li>
       </ul>
 
       <h4>Browser extensions</h4>

--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -334,13 +334,6 @@ export default function AddData() {
           , a Mac menu bar utility for displaying the current track, submits
           Apple Music and Spotify listens
         </li>
-        <li>
-          <em>
-            <a href="https://unstream.stream/">Unstream</a>
-          </em>
-          , a MacOS app and browser extension that detects and submits your listens,
-          and shows the best ways to support your favorite artists
-        </li>
       </ul>
 
       <h4>Browser extensions</h4>

--- a/frontend/js/src/artist/ArtistPage.tsx
+++ b/frontend/js/src/artist/ArtistPage.tsx
@@ -92,6 +92,7 @@ export type ArtistPageProps = {
 };
 
 export const COVER_ART_SINGLE_ROW_COUNT = 8;
+export const ARTIST_RELATIONSHIPS_DEFAULT_VISIBLE_COUNT = 3;
 export const typeOrder = [
   "Album",
   "EP",
@@ -183,6 +184,10 @@ export default function ArtistPage(): JSX.Element {
   const [expandDiscography, setExpandDiscography] = React.useState<boolean>(
     false
   );
+  const [
+    showAllArtistRelationships,
+    setShowAllArtistRelationships,
+  ] = React.useState<boolean>(false);
 
   // Sort by the more precise secondary type first to create categories like "Live", "Compilation" and "Remix" instead of
   // "Album + Live", "Single + Live", "EP + Live", "Broadcast + Live" and "Album + Remix", etc.
@@ -293,6 +298,14 @@ export default function ArtistPage(): JSX.Element {
   }, [artist?.artist_mbid]);
 
   const releaseGroupTypesNames = Object.entries(groupedReleaseGroups);
+  const artistRelationships = artist?.artist_relationships ?? [];
+  const visibleArtistRelationships = showAllArtistRelationships
+    ? artistRelationships
+    : artistRelationships.slice(0, ARTIST_RELATIONSHIPS_DEFAULT_VISIBLE_COUNT);
+  const hiddenArtistRelationshipsCount = Math.max(
+    0,
+    artistRelationships.length - ARTIST_RELATIONSHIPS_DEFAULT_VISIBLE_COUNT
+  );
 
   // Only show "full discography" button if there are more than 4 rows
   // in total across categories, after which we crop the container
@@ -303,6 +316,10 @@ export default function ArtistPage(): JSX.Element {
         rows + (curr[1].length > COVER_ART_SINGLE_ROW_COUNT ? 2 : 1),
       0
     ) > 4;
+
+  React.useEffect(() => {
+    setShowAllArtistRelationships(false);
+  }, [artist?.artist_mbid]);
 
   return (
     <div id="entity-page" className="artist-page" role="main">
@@ -418,6 +435,43 @@ export default function ArtistPage(): JSX.Element {
         />
       </div>
       <div className="entity-page-content">
+        {Boolean(artistRelationships.length) && (
+          <div className="artist-relationships">
+            <h3 className="header-with-line">Artist relationships</h3>
+            <div className="d-flex flex-column gap-1">
+              {visibleArtistRelationships.map((relationship) => (
+                <div
+                  className="d-flex gap-1 align-items-center"
+                  key={`${relationship.type}-${relationship.direction}-${relationship.artist_mbid}`}
+                >
+                  <span className="text-muted">
+                    {relationship.direction === "forward"
+                      ? "Also performs as:"
+                      : "Performance name of:"}
+                  </span>
+                  <Link to={`/artist/${relationship.artist_mbid}`}>
+                    {relationship.name}
+                  </Link>
+                </div>
+              ))}
+            </div>
+            {hiddenArtistRelationshipsCount > 0 && (
+              <div className="read-more mt-2">
+                <button
+                  type="button"
+                  className="btn btn-outline-info"
+                  onClick={() =>
+                    setShowAllArtistRelationships((prevValue) => !prevValue)
+                  }
+                >
+                  {showAllArtistRelationships
+                    ? "Show less"
+                    : `Show ${hiddenArtistRelationshipsCount} more`}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
         <div className={`tracks ${expandPopularTracks ? "expanded" : ""}`}>
           <div className="header">
             <h3 className="header-with-line">

--- a/frontend/js/src/metadata-viewer/types.d.ts
+++ b/frontend/js/src/metadata-viewer/types.d.ts
@@ -13,6 +13,12 @@ declare type MusicBrainzArtist = {
     artist: Array<ArtistTag>;
   };
   gender?: string;
+  artist_relationships?: Array<{
+    type: string;
+    direction: "forward" | "backward";
+    artist_mbid: string;
+    name: string;
+  }>;
 };
 
 declare type MusicBrainzArtistCredit = {

--- a/listenbrainz/db/model/metadata.py
+++ b/listenbrainz/db/model/metadata.py
@@ -74,3 +74,6 @@ class ArtistMetadata(BaseModel):
 
     # JSON which contains metadata about the release group of this artist
     release_group_data: List[Dict]
+
+    # JSON which contains metadata about linked artist identities
+    artist_relationship_data: List[Dict]

--- a/listenbrainz/db/model/metadata.py
+++ b/listenbrainz/db/model/metadata.py
@@ -76,4 +76,5 @@ class ArtistMetadata(BaseModel):
     release_group_data: List[Dict]
 
     # JSON which contains metadata about linked artist identities
-    artist_relationship_data: List[Dict]
+    # Backwards compatible default for databases/tests that may not have this column populated yet.
+    artist_relationship_data: List[Dict] = [] 

--- a/listenbrainz/db/model/metadata.py
+++ b/listenbrainz/db/model/metadata.py
@@ -76,5 +76,4 @@ class ArtistMetadata(BaseModel):
     release_group_data: List[Dict]
 
     # JSON which contains metadata about linked artist identities
-    # Backwards compatible default for databases/tests that may not have this column populated yet.
-    artist_relationship_data: List[Dict] = [] 
+    artist_relationship_data: List[Dict] = []

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -164,9 +164,14 @@ def artist_entity(artist_mbid: str):
         "artist_mbid": str(artist_data[0].artist_mbid),
         **artist_data[0].artist_data,
         "tag": artist_data[0].tag_data,
+        "artist_relationships": artist_data[0].artist_relationship_data,
     }
 
-    popular_recordings = popularity.get_top_recordings_for_artist(db_conn, ts_conn, artist_mbid, 10)
+    try:
+        popular_recordings = popularity.get_top_recordings_for_artist(db_conn, ts_conn, artist_mbid, 10)
+    except Exception:
+        current_app.logger.error("Error loading popular recordings for artist:", exc_info=True)
+        popular_recordings = []
 
     try:
         with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
@@ -180,19 +185,20 @@ def artist_entity(artist_mbid: str):
                 "session_based_days_7500_session_300_contribution_3_threshold_10_limit_100_filter_True_skip_30",
                 18
             )
-    except IndexError:
+    except Exception:
+        current_app.logger.error("Error loading similar artists:", exc_info=True)
         similar_artists = []
 
     try:
         top_release_group_color = popularity.get_top_release_groups_for_artist(
             db_conn, ts_conn, artist_mbid, 1
         )[0]["release_color"]
-    except IndexError:
+    except Exception:
         top_release_group_color = None
 
     try:
         top_recording_color = popularity.get_top_recordings_for_artist(db_conn, ts_conn, artist_mbid, 1)[0]["release_color"]
-    except IndexError:
+    except Exception:
         top_recording_color = None
 
     release_group_data = artist_data[0].release_group_data

--- a/mbid_mapping/mapping/mb_artist_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_artist_metadata_cache.py
@@ -38,6 +38,7 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
             ("artist_data ", "JSONB NOT NULL"),
             ("tag_data ", "JSONB NOT NULL"),
             ("release_group_data ", "JSONB NOT NULL"),
+            ("artist_relationship_data ", "JSONB NOT NULL"),
         ]
 
     def get_insert_queries_test_values(self):
@@ -112,7 +113,31 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                 tag["genre_mbid"] = genre_mbid
             artist_tags.append(tag)
 
-        return artist_mbid, ujson.dumps(artist), ujson.dumps({"artist": artist_tags}), ujson.dumps(release_groups)
+        artist_relationships = []
+        if row["artist_relationships"]:
+            for relation_type, direction, related_artist_mbid, related_artist_name in row["artist_relationships"]:
+                artist_relationships.append({
+                    "type": relation_type,
+                    "direction": direction,
+                    "artist_mbid": related_artist_mbid,
+                    "name": related_artist_name,
+                })
+
+        artist_relationships = sorted(
+            artist_relationships,
+            key=lambda relationship: (
+                relationship["type"] or "",
+                (relationship["name"] or "").lower()
+            )
+        )
+
+        return (
+            artist_mbid,
+            ujson.dumps(artist),
+            ujson.dumps({"artist": artist_tags}),
+            ujson.dumps(release_groups),
+            ujson.dumps(artist_relationships),
+        )
 
     def get_metadata_cache_query(self, with_values=False):
         values_cte = ""
@@ -137,6 +162,63 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                              WHERE lt.gid IN ({ARTIST_LINK_GIDS_SQL})
                                AND NOT l.ended
                           GROUP BY a.gid
+                   ), artist_relationships AS (
+                            SELECT artist_mbid
+                                 , array_agg(
+                                    jsonb_build_array(
+                                        relation_type,
+                                        relation_direction,
+                                        related_artist_mbid,
+                                        related_artist_name
+                                    )
+                                 ) AS artist_relationships
+                              FROM (
+                                     /* ----------------------------
+                                     HALF 1: FORWARD direction 
+                                     (primary artist) → (related artist / alias)
+                                      -------------------------------- */
+                                    SELECT a.gid::TEXT AS artist_mbid            -- "MBID of the primary artist"
+                                         , lt.name AS relation_type
+                                         , 'forward' AS relation_direction
+                                         , a2.gid::TEXT AS related_artist_mbid   --"MBID of related artist (stage/alias)"
+                                         , a2.name AS related_artist_name
+                                      FROM musicbrainz.artist a
+                                      JOIN musicbrainz.l_artist_artist laa
+                                        ON laa.entity0 = a.id
+                                      JOIN musicbrainz.artist a2
+                                        ON laa.entity1 = a2.id
+                                      JOIN musicbrainz.link l
+                                        ON l.id = laa.link
+                                      JOIN musicbrainz.link_type lt
+                                        ON l.link_type = lt.id
+                                      {values_join}
+                                     WHERE lt.name = 'performance name'
+                                       AND NOT l.ended
+                                    UNION ALL
+
+                                     /*------------------------------
+                                       HALF 2: BACKWARD direction
+                                       (alias) → (primary artist)
+                                      ------------------------------- */
+                                    SELECT a.gid::TEXT AS artist_mbid          
+                                         , lt.name AS relation_type
+                                         , 'backward' AS relation_direction
+                                         , a2.gid::TEXT AS related_artist_mbid
+                                         , a2.name AS related_artist_name
+                                      FROM musicbrainz.artist a
+                                      JOIN musicbrainz.l_artist_artist laa
+                                        ON laa.entity1 = a.id                 -- alias/stage name artist
+                                      JOIN musicbrainz.artist a2
+                                        ON laa.entity0 = a2.id                -- primary artist 
+                                      JOIN musicbrainz.link l
+                                        ON l.id = laa.link
+                                      JOIN musicbrainz.link_type lt
+                                        ON l.link_type = lt.id
+                                      {values_join}
+                                     WHERE lt.name = 'performance name'
+                                       AND NOT l.ended
+                                   ) relationships
+                          GROUP BY artist_mbid
                    ), artist_tags AS (
                             SELECT a.gid AS artist_mbid
                                  , array_agg(jsonb_build_array(t.name, count, a.gid, g.gid)) AS artist_tags
@@ -247,6 +329,7 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                  , ag.name AS gender
                                  , ar.name AS area
                                  , artist_links
+                                 , artist_relationships
                                  , artist_tags
                                  , array_agg(
                                         jsonb_build_array(
@@ -277,6 +360,8 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                 ON arl.artist_mbid = a.gid
                          LEFT JOIN artist_tags ats
                                 ON ats.artist_mbid = a.gid
+                         LEFT JOIN artist_relationships arr
+                                ON arr.artist_mbid = a.gid::TEXT
                          LEFT JOIN release_group_data rgd
                                 ON rgd.artist_mbid = a.gid
                               {values_join}
@@ -288,6 +373,7 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                                  , ag.name
                                  , ar.name
                                  , artist_links
+                                 , artist_relationships
                                  , artist_tags
         """
         return query
@@ -360,6 +446,45 @@ class MusicBrainzArtistMetadataCache(MusicBrainzEntityMetadataCache):
                 ON t.name = g.name
              WHERE at.last_updated > %(timestamp)s
                 OR  g.last_updated > %(timestamp)s
+        UNION
+
+        /*------------------------------------------
+        Fetches real artist who is on the left side of a "performance name"
+          relationship that has been updated after the given timestamp.
+        ---------------------------------------------*/
+            SELECT a.gid
+              FROM musicbrainz.artist a
+              JOIN musicbrainz.l_artist_artist laa
+                ON laa.entity0 = a.id
+              JOIN musicbrainz.link l
+                ON l.id = laa.link
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+             WHERE lt.name = 'performance name'
+               AND (
+                     laa.last_updated > %(timestamp)s
+                  OR l.last_updated > %(timestamp)s
+                  OR lt.last_updated > %(timestamp)s
+               )
+        UNION
+        /*------------------------------------------
+        Fetches stage name artist who is on the right side of a "performance name"
+          relationship that has been updated after the given timestamp.
+        ---------------------------------------------*/
+            SELECT a.gid
+              FROM musicbrainz.artist a
+              JOIN musicbrainz.l_artist_artist laa
+                ON laa.entity1 = a.id
+              JOIN musicbrainz.link l
+                ON l.id = laa.link
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+             WHERE lt.name = 'performance name'
+               AND (
+                     laa.last_updated > %(timestamp)s
+                  OR l.last_updated > %(timestamp)s
+                  OR lt.last_updated > %(timestamp)s
+               )
         UNION
             SELECT a.gid
               FROM musicbrainz.artist a


### PR DESCRIPTION


# Problem
[LB-1983](https://tickets.metabrainz.org/browse/LB-1983?jql=project%20%3D%20%2210101%22)

Musicbrainz shows the different stage names of a particular artist as `Performance name of ` or `Also performs as`,
But this section is missing in Listenbrainz . Sometimes we remember the Artist name but not the `stage/performance` name or we forget the real name.
So we wont be able to see the full work of the artist.

# Solution

We now fetch and display these "performance name" relationships directly on the artist page.
If artist has an aliases or a real name behind a stage name, we will see a new "Artist relationships" section showing who they're connected to. On clicking the artist name , we will be directed to the artist page of that connected artist.If an artist has more than 3 relationships, only the first 3 are shown by default — we can click "Show N more" to see the rest, and "Show less" to collapse again.

Stored the relationship data in the artist metadata cache so that the  new MusicBrainz API is not hit for every repeated search.

# Testing

Since full  MusicBrainz database is not available  in local dev environment, so I manually inserted test data directly into the cache table — two artists, one with 4 stage name links, the other with a single link back to the real person

Also The artist page was crashing entirely when the MusicBrainz database wasn't available, so added proper error handling so that sections (like popular tracks) just show up empty instead of taking down the entire page - changes were made in 
`entity_pages.py ` file.

<img width="2567" height="1394" alt="Screenshot 2026-04-17 045008" src="https://github.com/user-attachments/assets/9ec7ed32-ebd5-4c89-9ef0-2a6f21816091" />

  <img width="2552" height="1406" alt="Screenshot 2026-04-17 045018" src="https://github.com/user-attachments/assets/f9ea1db0-6dd6-4b94-bc7c-1a126b755dac" />




# AI usage
 I took help of AI to write the  SQL query for fetching performance name relationships in `mb_artist_metadata_cache.py`
