### PR TITLE
Allow caching immutable frontend assets

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -192,8 +192,20 @@ def create_app(debug=None):
 
     @app.after_request
     def add_cache_header(response):
-        response.cache_control.private = True
-        response.cache_control.public = False
+        if request.path.startswith('/static'):
+            # cache hashed assets (JS + CSS) for 1 year
+            hashed_assets_max_age = 31536000
+            # cache image assets for 1 week
+            image_assets_max_age = 604800
+            response.cache_control.public = True
+            response.cache_control.immutable = True
+            if request.path.startswith('/static/dist'):
+                response.cache_control.max_age = hashed_assets_max_age
+            elif request.path.startswith('/static/img'):
+                response.cache_control.max_age = image_assets_max_age
+        else:
+            response.cache_control.private = True
+            response.cache_control.public = False
         return response
 
     # Template utilities

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -198,8 +198,8 @@ def create_app(debug=None):
             # cache image assets for 1 week
             image_assets_max_age = 604800
             response.cache_control.public = True
-            response.cache_control.immutable = True
             if request.path.startswith('/static/dist'):
+                response.cache_control.immutable = True
                 response.cache_control.max_age = hashed_assets_max_age
             elif request.path.startswith('/static/img'):
                 response.cache_control.max_age = image_assets_max_age


### PR DESCRIPTION
Compiled frontend resources like JS and CSS files have a cache-busting hash in their name, so there is no reason why it should not be cached "indefinitely".
This was a cache misconfiguration hotfix in #3131, applied globally as what looks like the nuclear option, in retrospect.
I only modified cache control for compiled assets and images in this PR, but it would be good to investigate whether we could apply the cache control restrictions to specific paths instead to fix the issue describes in 3131.