### PR TITLE
Enable webpack default minimizer (terser)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,8 @@ module.exports = function (env, argv) {
     },
     optimization: {
       minimize: isProd,
+      // "..." is a shortcut to access the default Webpack minimizer config.
+      // see https://webpack.js.org/configuration/optimization/#optimizationminimizer
       minimizer: [new CssMinimizerPlugin(), "..."],
     },
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,7 +108,7 @@ module.exports = function (env, argv) {
     },
     optimization: {
       minimize: isProd,
-      minimizer: [new CssMinimizerPlugin()],
+      minimizer: [new CssMinimizerPlugin(), "..."],
     },
     resolve: {
       modules: [


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# Problem

`/static/dist/indexPage.*.js` is not minified and pretty big (8MB uncompressed, 2MB gzipped).

# Solution

Just (re-)enable JavaScript file minify. Webpack does by default, but override at https://github.com/metabrainz/listenbrainz-server/commit/d032dd8163c3f4ee9bc052822afd6357d5589a39#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL118 . according to commit message, I think they didn't mean to disable JS minify, they just want to replace CSS minifier.

`"..."` will be replaced with default config, see https://webpack.js.org/configuration/optimization/#optimizationminimizer for more information.

* [ ] I have run the code and manually tested the changes
  * I ran `docker build` and check output is minified now, but didn't test about actual application works (or not). probably does (since it just inherits webpack default configuration, I assume they have a relatively safe configuration), but you might be want to test it if you cared about that

# AI usage
* [x] I did not use any AI
