### PR TITLE
Feed: Load cover art  from release-group

### DIFF
--- a/frontend/js/src/utils/utils.tsx
+++ b/frontend/js/src/utils/utils.tsx
@@ -1245,10 +1245,11 @@ const getAlbumArtFromListenMetadataKey = (
     listen.track_metadata?.additional_info?.release_mbid;
   const caaId = listen.track_metadata?.mbid_mapping?.caa_id;
   const caaReleaseMbid = listen.track_metadata?.mbid_mapping?.caa_release_mbid;
+  const releaseGroupMbid = getReleaseGroupMBID(listen);
 
-  return `ca:${userSubmittedReleaseMBID ?? ""}:${caaId ?? ""}:${
-    caaReleaseMbid ?? ""
-  }`;
+  return `ca:${userSubmittedReleaseMBID ?? releaseGroupMbid ?? ""}:${
+    caaId ?? ""
+  }:${caaReleaseMbid ?? releaseGroupMbid ?? ""}`;
 };
 
 const getAlbumArtFromListenMetadata = async (
@@ -1282,6 +1283,8 @@ const getAlbumArtFromListenMetadata = async (
     listen.track_metadata?.additional_info?.release_group_mbid;
   const caaId = listen.track_metadata?.mbid_mapping?.caa_id;
   const caaReleaseMbid = listen.track_metadata?.mbid_mapping?.caa_release_mbid;
+  const mappingReleaseGroupMbid =
+    listen.track_metadata?.mbid_mapping?.release_group_mbid;
   if (userSubmittedReleaseMBID || userSubmittedReleaseGroupMBID) {
     // try getting the cover art using user submitted release mbid. if user submitted release mbid
     // does not have a cover art and the mapper matched to a different release, try to fallback to
@@ -1299,6 +1302,15 @@ const getAlbumArtFromListenMetadata = async (
   // user submitted release mbids not found, check if there is a match from mbid mapper.
   if (caaId && caaReleaseMbid) {
     return generateAlbumArtThumbnailLink(caaId, caaReleaseMbid);
+  }
+  // Fallback: use the release group MBID from the automatic mapping, if available
+  if (mappingReleaseGroupMbid) {
+    const releaseGroupAlbumArt = await getAlbumArtFromReleaseGroupMBID(
+      mappingReleaseGroupMbid
+    );
+    if (releaseGroupAlbumArt) {
+      return releaseGroupAlbumArt;
+    }
   }
   /* We are putting Youtube thumbnails as last resort fallback as the quality
   and format is usually not very good, user preferring proper cover art. */


### PR DESCRIPTION

# Problem

I am seeing cache key collisions on the feed page when release MBIDs are not available.
This cover art is not the cover for any of those three entries, but instead is the one loaded first with missing information:
<img width="550" height="256" alt="image" src="https://github.com/user-attachments/assets/3116b3af-b8ad-4da5-be1b-70eff1455705" />

<img width="621" height="668" alt="image" src="https://github.com/user-attachments/assets/8f36763e-7b88-4ca9-b60d-003f0dfa82b9" />

# Solution

Two issues here:
1. cache collision when missing some data: the cacke key end up being ` "ca:::"` for all of these entries, so they show data for the first loaded cover with that cache key
2. cover art is not loaded from release group even when an MBID is available (only loading from release MBID) 

* [ x ] I have run the code and manually tested the changes

Shown here: first cover loaded from RG data, others don't have the data to load cover art but don't reuse another cover
<img width="656" height="629" alt="image" src="https://github.com/user-attachments/assets/642008a8-5b36-4025-9abc-05734a18cdf1" />


# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

* [ x ] I did not use any AI
