### PR TITLE
Add detailed validation message for history imports 

### DIFF
--- a/frontend/js/src/settings/import/ImportListens.tsx
+++ b/frontend/js/src/settings/import/ImportListens.tsx
@@ -57,6 +57,7 @@ type ImportMetadata = {
   status: ImportStatus;
   attempted_count?: number;
   success_count?: number;
+  detailed_message?: string;
 };
 const serviceNames = Object.values(Services);
 const humanReadableServices = `${initial(serviceNames).join(", ")} and ${last(
@@ -81,11 +82,13 @@ type ValidationSummary = {
   attempted: number;
   success: number;
   description: string;
+  detailed_message?: string;
 };
 
 function getValidationSummary(metadata: ImportMetadata): ValidationSummary {
   const attempted = metadata.attempted_count ?? 0;
   const success = metadata.success_count ?? 0;
+  const { detailed_message } = metadata;
 
   if (attempted === 0) {
     return {
@@ -93,6 +96,7 @@ function getValidationSummary(metadata: ImportMetadata): ValidationSummary {
       attempted,
       success,
       description: "No listens were processed.",
+      detailed_message,
     };
   }
 
@@ -102,6 +106,7 @@ function getValidationSummary(metadata: ImportMetadata): ValidationSummary {
       attempted,
       success,
       description: "None of the listens were imported.",
+      detailed_message,
     };
   }
 
@@ -111,6 +116,7 @@ function getValidationSummary(metadata: ImportMetadata): ValidationSummary {
       attempted,
       success,
       description: "Some listens were rejected.",
+      detailed_message,
     };
   }
 
@@ -119,6 +125,7 @@ function getValidationSummary(metadata: ImportMetadata): ValidationSummary {
     attempted,
     success,
     description: "All listens imported successfully.",
+    detailed_message,
   };
 }
 
@@ -186,10 +193,18 @@ function renderImport(
         <h4 className="alert-heading">Import completed!</h4>
 
         {hasValidationData && (
-          <p className="mb-2" data-testid="validation-summary">
-            Imported {validationSummary.success} / {validationSummary.attempted}
-            &nbsp;listens. {validationSummary.description}
-          </p>
+          <>
+            <p className="mb-2" data-testid="validation-summary">
+              Imported {validationSummary.success} /{" "}
+              {validationSummary.attempted}
+              &nbsp;listens. {validationSummary.description}
+            </p>
+            {validationSummary.detailed_message && (
+              <p className="mb-2" data-testid="detailed-message">
+                {validationSummary.detailed_message}
+              </p>
+            )}
+          </>
         )}
         <p>
           <b>
@@ -237,10 +252,15 @@ function renderImport(
       </p>
       <p>Feel free to close this page while we import your listens.</p>
       {hasValidationData && (
-        <p className="mb-2">
-          Imported {validationSummary.success} / {validationSummary.attempted}
-          &nbsp;listens so far.
-        </p>
+        <>
+          <p className="mb-2">
+            Imported {validationSummary.success} / {validationSummary.attempted}
+            &nbsp;listens so far.
+          </p>
+          {validationSummary.detailed_message && (
+            <p className="mb-2">{validationSummary.detailed_message}</p>
+          )}
+        </>
       )}
       <form
         onSubmit={(e) => cancelImport(e, im.import_id)}

--- a/listenbrainz/background/listens_importer/base.py
+++ b/listenbrainz/background/listens_importer/base.py
@@ -136,15 +136,15 @@ class BaseListensImporter(ABC):
                     raise ExternalServiceError("ISE while trying to import listens")
 
     @staticmethod
-    def _initialize_validation_stats() -> dict[str, int]:
+    def _initialize_validation_stats() -> dict[str, Any]:
         """Return a fresh attempted/success counter dict."""
-        return {"attempted_count": 0, "success_count": 0}
+        return {"attempted_count": 0, "success_count": 0, "detailed_message": ""}
 
     def parse_and_validate_listen_items(
         self,
         batch: list[dict[str, Any]],
-        validation_stats: dict[str, int],
-    ) -> tuple[list[dict[str, Any]], dict[str, int]]:
+        validation_stats: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Parse raw entries and validate them while updating counters."""
         raw_attempts = len(batch)
         parsed_listens = self.parse_listen_batch(batch)
@@ -170,14 +170,21 @@ class BaseListensImporter(ABC):
 
         return validated_listens, validation_stats
 
-    def persist_validation_stats(self, import_id: int, validation_stats: dict[str, int]) -> None:
-        """Persist the current validation counters on the import task metadata."""
+
+    def persist_validation_stats(self, import_id: int, validation_stats: dict[str, Any]) -> None:
+        """Persist the current validation counters and message on the import task metadata."""
+        detailed_message = self.get_validation_detailed_message() or ""
         update_import_task(
             self.db_conn,
             import_id,
             attempted_count=validation_stats.get("attempted_count", 0),
             success_count=validation_stats.get("success_count", 0),
+            detailed_message=detailed_message,
         )
+
+    def get_validation_detailed_message(self) -> str:
+        """Get an optional service-specific message to show users in the import summary."""
+        return ""
 
     def update_import_progress_and_status(self, import_id: int, status: str, progress: str) -> None:
         """Update progress for user data import."""

--- a/listenbrainz/background/listens_importer/spotify.py
+++ b/listenbrainz/background/listens_importer/spotify.py
@@ -133,13 +133,13 @@ class SpotifyListensImporter(ZipBaseListensImporter):
     def get_validation_detailed_message(self) -> str:
         """Generate Spotify-specific message for import validation summary."""
         messages = []
-        if self.skipped_incognito_count > 0:
-            messages.append(f"{self.skipped_incognito_count} skipped (incognito mode)")
         if self.skipped_short_plays_count > 0:
-            messages.append(f"{self.skipped_short_plays_count} skipped (short duration)")
+            messages.append(f"{self.skipped_short_plays_count} manually skipped or interrupted")
+        if self.skipped_incognito_count > 0:
+            messages.append(f"{self.skipped_incognito_count} incognito mode")
         
         if messages:
-            return ", ".join(messages)
+            return "Discarded: " + ", ".join(messages)
         return ""
 
     def _get_spotify_data(self, spotify_track_ids: set[str]) -> dict[str, dict[str, Any]]:

--- a/listenbrainz/background/listens_importer/spotify.py
+++ b/listenbrainz/background/listens_importer/spotify.py
@@ -18,6 +18,11 @@ SKIP_REASONS = [
 class SpotifyListensImporter(ZipBaseListensImporter):
     """Spotify-specific listens importer."""
 
+    def __init__(self, db_conn, ts_conn):
+        super().__init__(db_conn, ts_conn)
+        self.skipped_incognito_count = 0
+        self.skipped_short_plays_count = 0
+
     def filter_zip_file(self, file: str) -> bool:
         filename = os.path.basename(file).lower()
         return filename.endswith(".json") and ("audio" in filename or "endsong" in filename)
@@ -30,11 +35,10 @@ class SpotifyListensImporter(ZipBaseListensImporter):
             entry["timestamp"] = timestamp
             yield timestamp, entry
 
-    @staticmethod
-    def _skip_item(item) -> bool:
+    def _skip_item(self, item) -> tuple[bool, str]:
         """ Whether a spotify play should not be imported. """
         if item.get("incognito_mode", False):
-            return True
+            return True, "incognito"
 
         if (
             item.get("ms_played", 0) < 30000 and
@@ -43,9 +47,9 @@ class SpotifyListensImporter(ZipBaseListensImporter):
                 ("reason_end" in item and item["reason_end"] in SKIP_REASONS)
             )
         ):
-            return True
+            return True, "short_play"
 
-        return False
+        return False, ""
 
     def parse_listen_batch(self, batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Parse Spotify listen batch.
@@ -56,7 +60,12 @@ class SpotifyListensImporter(ZipBaseListensImporter):
         items = []
         for item in batch:
             try:
-                if self._skip_item(item):
+                should_skip, skip_reason = self._skip_item(item)
+                if should_skip:
+                    if skip_reason == "incognito":
+                        self.skipped_incognito_count += 1
+                    elif skip_reason == "short_play":
+                        self.skipped_short_plays_count += 1
                     continue
 
                 items.append({
@@ -120,6 +129,18 @@ class SpotifyListensImporter(ZipBaseListensImporter):
                 "track_metadata": track_metadata,
             })
         return listens
+
+    def get_validation_detailed_message(self) -> str:
+        """Generate Spotify-specific message for import validation summary."""
+        messages = []
+        if self.skipped_incognito_count > 0:
+            messages.append(f"{self.skipped_incognito_count} skipped (incognito mode)")
+        if self.skipped_short_plays_count > 0:
+            messages.append(f"{self.skipped_short_plays_count} skipped (short duration)")
+        
+        if messages:
+            return ", ".join(messages)
+        return ""
 
     def _get_spotify_data(self, spotify_track_ids: set[str]) -> dict[str, dict[str, Any]]:
         """Get Spotify data from cache and API."""

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -480,7 +480,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         # More tracks were attempted but filtered during processing
         self.assertEqual(metadata["success_count"], 2)
         self.assertEqual(metadata["attempted_count"], 15)
-        self.assertEqual(metadata["detailed_message"], "1 skipped (incognito mode), 12 skipped (short duration)")
+        self.assertEqual(metadata["detailed_message"], "Discarded: 12 manually skipped or interrupted, 1 incognito mode")
 
 
     def test_import_listenbrainz(self):

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -476,9 +476,11 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         metadata = response.json["metadata"]
         self.assertIn("attempted_count", metadata)
         self.assertIn("success_count", metadata)
-        self.assertEqual(metadata["success_count"], 2)
+        self.assertIn("detailed_message", metadata)
         # More tracks were attempted but filtered during processing
-        self.assertGreaterEqual(metadata["attempted_count"], 2)
+        self.assertEqual(metadata["success_count"], 2)
+        self.assertEqual(metadata["attempted_count"], 15)
+        self.assertEqual(metadata["detailed_message"], "1 skipped (incognito mode), 12 skipped (short duration)")
 
 
     def test_import_listenbrainz(self):


### PR DESCRIPTION
# Problem

Spotify users have been left confused by the imported vs. attempted count we show on the importer page details.

The only listens we filter out are less-than-30-seconds plays and incognito mode listens, so we should clarify how many of either are the cause for the non-imported listens.

# Solution
This PR adds an optional detailed_message in import details that we can surface to the user.
The implementation details of what goes into that message are left to each importer and optional.
This allows for implementing something for Spotify now (keeping count of skips and incognito), and incrementally improve other services with their own logic.

* [x] I have run the code and manually tested the changes

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Used GH Copilot to make some of the changes, based on a detailed implementation plan I wrote first.
Reviewed each modified line manually (because I don't trust it) and made my own changes on top.

<img width="520" height="293" alt="image" src="https://github.com/user-attachments/assets/011e15c2-39db-4cad-9e7f-bb90127b0976" />
<img width="622" height="209" alt="image" src="https://github.com/user-attachments/assets/41396b52-d7b0-4b2e-a9df-070aa3b93f2e" />
