### PR TITLE
Use retry/backoff mechanism for all API calls

### DIFF
--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1,13 +1,10 @@
 import { isNil, isUndefined, kebabCase, lowerCase, omit } from "lodash";
+import fetchBuilder from "fetch-retry";
 import { TagActionType } from "../tags/TagComponent";
 import type { SortOption } from "../explore/fresh-releases/FreshReleases";
 import APIError from "./APIError";
 import type { Flair } from "./constants";
 import { Modes } from "../explore/lb-radio/components/Prompt";
-
-const fetchWithRetry = require("fetch-retry")(
-  (...args: Parameters<typeof fetch>) => window.fetch(...args)
-);
 
 export interface LBRadioResponse {
   payload: { jspf: JSPFObject; feedback: string[] };
@@ -22,7 +19,7 @@ export default class APIService {
   MAX_LISTEN_SIZE: number = 10000; // Maximum size of listens that can be sent
   private fetchWithRetry: any;
   private retryParams = {
-    retries: 4,
+    retries: 3,
     retryOn: [429, 500, 502, 503, 504],
     retryDelay: (
       attempt: number,
@@ -54,7 +51,7 @@ export default class APIService {
   private static readonly SPOTIFY_TOKEN_CACHE_DURATION = 5 * 60 * 1000;
 
   constructor(APIBaseURI: string) {
-    this.fetchWithRetry = fetchWithRetry;
+    this.fetchWithRetry = fetchBuilder(window.fetch, this.retryParams);
     let finalUri = APIBaseURI;
     if (finalUri.endsWith("/")) {
       finalUri = finalUri.substring(0, APIBaseURI.length - 1);
@@ -104,7 +101,7 @@ export default class APIService {
       query += `?limit=${limit}`;
     }
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
     });
     await this.checkStatus(response);
@@ -143,7 +140,7 @@ export default class APIService {
       query += `?${queryParams.join("&")}`;
     }
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
     });
     await this.checkStatus(response);
@@ -189,7 +186,7 @@ export default class APIService {
       query += `?${queryParams.join("&")}`;
     }
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -238,7 +235,7 @@ export default class APIService {
       query += `?${queryParams.join("&")}`;
     }
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -282,7 +279,7 @@ export default class APIService {
       query += `?${queryParams.join("&")}`;
     }
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -303,7 +300,7 @@ export default class APIService {
       userName
     )}/listen-count`;
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
     });
     await this.checkStatus(response);
@@ -362,7 +359,7 @@ export default class APIService {
     if (!hostUrl) {
       throw new Error("Host URL is required for Funkwhale token refresh");
     }
-    const response = await fetch(
+    const response = await this.fetchWithRetry(
       `/settings/music-services/funkwhale/refresh/`,
       {
         method: "POST",
@@ -379,7 +376,7 @@ export default class APIService {
   };
 
   refreshAccessToken = async (service: string): Promise<string> => {
-    const response = await fetch(
+    const response = await this.fetchWithRetry(
       `/settings/music-services/${service}/refresh/`,
       {
         method: "POST",
@@ -400,7 +397,7 @@ export default class APIService {
     if (!userToken) {
       throw new SyntaxError("User token missing");
     }
-    const response = await fetch(
+    const response = await this.fetchWithRetry(
       `${this.APIBaseURI}/user/${encodeURIComponent(userName)}/follow`,
       {
         method: "POST",
@@ -422,7 +419,7 @@ export default class APIService {
     if (!userToken) {
       throw new SyntaxError("User token missing");
     }
-    const response = await fetch(
+    const response = await this.fetchWithRetry(
       `${this.APIBaseURI}/user/${encodeURIComponent(userName)}/unfollow`,
       {
         method: "POST",
@@ -440,7 +437,7 @@ export default class APIService {
     try {
       const url = new URL(`${this.APIBaseURI}/search/users/`);
       url.searchParams.append("search_term", userName);
-      const response = await fetch(url.toString(), {
+      const response = await this.fetchWithRetry(url.toString(), {
         method: "GET",
       });
 
@@ -465,7 +462,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/followers`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -480,7 +477,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/following`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -495,7 +492,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/playing-now`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     const result = await response.json();
     return result.payload.listens?.[0];
@@ -534,7 +531,7 @@ export default class APIService {
       // Now submitListens focused on payload handling
 
       return this.withRetry(async () => {
-        const response = await fetch(url, {
+        const response = await this.fetchWithRetry(url, {
           method: "POST",
           headers: {
             Authorization: `Token ${userToken}`,
@@ -575,7 +572,7 @@ export default class APIService {
     }/latest-import?user_name=${encodeURIComponent(
       userName
     )}&service=${service}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
     });
     await this.checkStatus(response);
@@ -593,7 +590,7 @@ export default class APIService {
     timestamp: number
   ): Promise<number> => {
     const url = `${this.APIBaseURI}/latest-import`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -615,7 +612,7 @@ export default class APIService {
           Authorization: `Token ${authToken}`,
         }
       : undefined;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers,
     });
@@ -641,7 +638,7 @@ export default class APIService {
     if (count !== null && count !== undefined) {
       url += `&count=${count}`;
     }
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     // if response code is 204, then statistics havent been calculated, send empty object
     if (response.status === 204) {
@@ -667,7 +664,7 @@ export default class APIService {
     } else {
       url = `${this.APIBaseURI}/stats/sitewide/listening-activity`;
     }
-    const response = await fetch(`${url}?range=${range}`);
+    const response = await this.fetchWithRetry(`${url}?range=${range}`);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -687,7 +684,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/stats/user/${encodeURIComponent(
       userName
     )}/daily-activity?range=${range}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -713,7 +710,7 @@ export default class APIService {
       url = `${this.APIBaseURI}/stats/sitewide/artist-activity`;
     }
     url += `?range=${range}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -737,7 +734,7 @@ export default class APIService {
       url = `${this.APIBaseURI}/stats/sitewide/era-activity`;
     }
     url += `?range=${range}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -763,7 +760,7 @@ export default class APIService {
       url = `${this.APIBaseURI}/stats/sitewide/artist-evolution-activity`;
     }
     url += `?range=${range}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -781,7 +778,7 @@ export default class APIService {
     range: UserStatsAPIRange = "all_time"
   ): Promise<UserGenreActivityResponse> => {
     const url = `${this.APIBaseURI}/stats/user/${userName}/genre-activity?range=${range}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -806,7 +803,7 @@ export default class APIService {
       url = `${this.APIBaseURI}/stats/sitewide/`;
     }
     url += `artist-map?range=${range}&force_recalculate=${forceRecalculate}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 204) {
       const error = new APIError(
@@ -849,7 +846,7 @@ export default class APIService {
     recordingMSID: string
   ): Promise<string | null> => {
     const url = `${this.APIBaseURI}/get-cover-art/?release_mbid=${releaseMBID}&recording_msid=${recordingMSID}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     if (response.status === 200) {
       const data = await response.json();
@@ -872,7 +869,7 @@ export default class APIService {
     if (recordingMBID) {
       body.recording_mbid = recordingMBID;
     }
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -909,7 +906,7 @@ export default class APIService {
       user_name: userName,
       service,
     };
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -946,7 +943,7 @@ export default class APIService {
     if (queryParams.length) {
       queryURL += `?${queryParams.join("&")}`;
     }
-    const response = await fetch(queryURL);
+    const response = await this.fetchWithRetry(queryURL);
     await this.checkStatus(response);
     return response.json();
   };
@@ -974,7 +971,6 @@ export default class APIService {
         "Content-Type": "application/json;charset=UTF-8",
       },
       body: JSON.stringify(requestBody),
-      ...this.retryParams,
     });
     await this.checkStatus(response);
     return response.json();
@@ -986,7 +982,7 @@ export default class APIService {
     listenedAt: number
   ): Promise<number> => {
     const url = `${this.APIBaseURI}/delete-listen`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1010,7 +1006,7 @@ export default class APIService {
     }
 
     const url = `${this.APIBaseURI}/playlist/create`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1033,7 +1029,7 @@ export default class APIService {
     }
 
     const url = `${this.APIBaseURI}/playlist/edit/${playlistMBID}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1075,7 +1071,7 @@ export default class APIService {
       collaborator ? "/collaborator" : ""
     }?offset=${offset}&count=${count}`;
 
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers,
     });
@@ -1096,7 +1092,7 @@ export default class APIService {
     }
 
     const url = `${this.APIBaseURI}/playlist/${playlistMBID}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers,
     });
@@ -1116,7 +1112,7 @@ export default class APIService {
     const optionalOffset =
       !isNil(offset) && Number.isSafeInteger(offset) ? `?offset=${offset}` : "";
     const url = `${this.APIBaseURI}/playlist/${playlistMBID}/item/add${optionalOffset}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1141,7 +1137,7 @@ export default class APIService {
       throw new SyntaxError("Playlist MBID is missing");
     }
     const url = `${this.APIBaseURI}/playlist/${playlistMBID}/item/delete`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1163,7 +1159,7 @@ export default class APIService {
     count: number
   ): Promise<number> => {
     const url = `${this.APIBaseURI}/playlist/${playlistMBID}/item/move`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1185,7 +1181,7 @@ export default class APIService {
     }
 
     const url = `${this.APIBaseURI}/playlist/${playlistMBID}/copy`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1205,7 +1201,7 @@ export default class APIService {
     }
 
     const url = `${this.APIBaseURI}/playlist/${playlistMBID}/delete`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1221,7 +1217,7 @@ export default class APIService {
     rating: RecommendationFeedBack
   ): Promise<number> => {
     const url = `${this.APIBaseURI}/recommendation/feedback/submit`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1238,7 +1234,7 @@ export default class APIService {
     recordingMBID: string
   ): Promise<number> => {
     const url = `${this.APIBaseURI}/recommendation/feedback/delete`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1263,7 +1259,7 @@ export default class APIService {
     }/recommendation/feedback/user/${encodeURIComponent(
       userName
     )}/recordings?mbids=${recordings}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -1276,7 +1272,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/timeline-event/create/recording`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${authToken}`,
@@ -1300,7 +1296,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/similar-users`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -1318,13 +1314,13 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/similar-to/${encodeURIComponent(otherUserName)}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
 
   reportUser = async (userName: string, optionalContext?: string) => {
-    const response = await fetch(
+    const response = await this.fetchWithRetry(
       `/user/${encodeURIComponent(userName)}/report-user/`,
       {
         method: "POST",
@@ -1344,7 +1340,7 @@ export default class APIService {
     blurb_content?: string
   ): Promise<{ status: string; data: PinnedRecording }> => {
     const url = `${this.APIBaseURI}/pin`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1366,7 +1362,7 @@ export default class APIService {
     blurbContent: string
   ): Promise<{ status: string }> => {
     const url = `${this.APIBaseURI}/pin/update/${rowId}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1386,7 +1382,7 @@ export default class APIService {
     recordingMBID: string
   ): Promise<{ status: string }> => {
     const url = `${this.APIBaseURI}/metadata/submit_manual_mapping/`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1403,7 +1399,7 @@ export default class APIService {
 
   unpinRecording = async (userToken: string): Promise<number> => {
     const url = `${this.APIBaseURI}/pin/unpin`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1416,7 +1412,7 @@ export default class APIService {
 
   deletePin = async (userToken: string, pinID: number): Promise<number> => {
     const url = `${this.APIBaseURI}/pin/delete/${pinID}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1436,7 +1432,7 @@ export default class APIService {
       userName
     )}/pins?offset=${offset}&count=${count}`;
 
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
     });
 
@@ -1452,7 +1448,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/timeline-event/create/review`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1482,14 +1478,14 @@ export default class APIService {
     if (inc) {
       url += `&inc=${inc}`;
     }
-    const response = await fetch(encodeURI(url));
+    const response = await this.fetchWithRetry(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
 
   importPlaylistFromSpotify = async (userToken?: string): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/import/spotify`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1502,7 +1498,7 @@ export default class APIService {
 
   importPlaylistFromAppleMusic = async (userToken?: string): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/import/apple_music`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1515,7 +1511,7 @@ export default class APIService {
 
   importPlaylistFromSoundCloud = async (userToken?: string): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/import/soundcloud`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1531,7 +1527,7 @@ export default class APIService {
     playlistID: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/spotify/${playlistID}/tracks`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1547,7 +1543,7 @@ export default class APIService {
     playlistID: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/apple_music/${playlistID}/tracks`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1563,7 +1559,7 @@ export default class APIService {
     playlistID: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/soundcloud/${playlistID}/tracks`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1579,7 +1575,7 @@ export default class APIService {
     inc = "artists"
   ): Promise<MusicBrainzRecording> => {
     const url = `${this.MBBaseURI}/recording/${recordingMBID}?fmt=json&inc=${inc}`;
-    const response = await fetch(encodeURI(url));
+    const response = await this.fetchWithRetry(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
@@ -1591,7 +1587,7 @@ export default class APIService {
     (MusicBrainzRelease & WithReleaseGroup) | (MusicBrainzRelease & WithMedia)
   > => {
     const url = `${this.MBBaseURI}/release/${releaseMBID}?fmt=json&inc=${inc}`;
-    const response = await fetch(encodeURI(url));
+    const response = await this.fetchWithRetry(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
@@ -1605,7 +1601,7 @@ export default class APIService {
       }
   > => {
     const url = `${this.MBBaseURI}/release-group/${releaseGroupMBID}?fmt=json&inc=releases+artists+media`;
-    const response = await fetch(encodeURI(url));
+    const response = await this.fetchWithRetry(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
@@ -1618,7 +1614,7 @@ export default class APIService {
     releases: Array<MusicBrainzRelease & WithMedia>;
   }> => {
     const url = `${this.MBBaseURI}/release?track=${trackMBID}&fmt=json`;
-    const response = await fetch(encodeURI(url));
+    const response = await this.fetchWithRetry(encodeURI(url));
     await this.checkStatus(response);
     return response.json();
   };
@@ -1629,7 +1625,7 @@ export default class APIService {
   ): Promise<any> => {
     let query = `${this.APIBaseURI}/explore/color/${color}`;
     if (!isUndefined(count)) query += `?count=${count}`;
-    const response = await fetch(query);
+    const response = await this.fetchWithRetry(query);
     await this.checkStatus(response);
     return response.json();
   };
@@ -1645,7 +1641,7 @@ export default class APIService {
     const query = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/feed/events/${eventId}`;
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1661,7 +1657,7 @@ export default class APIService {
       throw new SyntaxError("Pin ID not present");
     }
     const query = `${this.APIBaseURI}/pin/${pinId}`;
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "GET",
     });
     await this.checkStatus(response);
@@ -1681,7 +1677,7 @@ export default class APIService {
     const query = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/feed/events/delete`;
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1705,7 +1701,7 @@ export default class APIService {
     const query = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/feed/events/hide`;
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1729,7 +1725,7 @@ export default class APIService {
     const query = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/feed/events/unhide`;
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1754,7 +1750,7 @@ export default class APIService {
     const query = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/timeline-event/create/thanks`;
-    const response = await fetch(query, {
+    const response = await this.fetchWithRetry(query, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1799,7 +1795,7 @@ export default class APIService {
       url.searchParams.append("inc", "artist tag release");
     }
 
-    const response = await fetch(url.toString(), {
+    const response = await this.fetchWithRetry(url.toString(), {
       headers: {
         Authorization: `Token ${userToken}`,
       },
@@ -1823,7 +1819,7 @@ export default class APIService {
       url.searchParams.append("inc", "artist tag release");
     }
 
-    const response = await fetch(url.toString());
+    const response = await this.fetchWithRetry(url.toString());
     await this.checkStatus(response);
     return response.json();
   };
@@ -1833,7 +1829,7 @@ export default class APIService {
     zonename: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/settings/timezone`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1854,7 +1850,7 @@ export default class APIService {
     const url = `${this.APIBaseURI}/user/${encodeURIComponent(
       userName
     )}/timeline-event/create/recommend-personal`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1872,7 +1868,7 @@ export default class APIService {
     exportToSpotify: boolean
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/settings/troi`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1889,7 +1885,7 @@ export default class APIService {
     brainzPlayerSettings: BrainzPlayerSettings
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/settings/brainzplayer`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1906,7 +1902,7 @@ export default class APIService {
     flair: Flair
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/settings/flair`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1923,7 +1919,7 @@ export default class APIService {
     playlist_mbid: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/${playlist_mbid}/export/spotify`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1939,7 +1935,7 @@ export default class APIService {
     playlist_mbid: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/${playlist_mbid}/export/apple_music`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1955,7 +1951,7 @@ export default class APIService {
     playlist: JSPFPlaylist
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/export-jspf/apple_music`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1975,7 +1971,7 @@ export default class APIService {
       throw new Error("Expected a playlist");
     }
     const url = `${this.APIBaseURI}/playlist/export-jspf/spotify`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -1992,7 +1988,7 @@ export default class APIService {
     playlist_mbid: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/${playlist_mbid}/export/soundcloud`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -2011,7 +2007,7 @@ export default class APIService {
       throw new Error("Expected a playlist");
     }
     const url = `${this.APIBaseURI}/playlist/export-jspf/soundcloud`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "POST",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -2028,7 +2024,7 @@ export default class APIService {
     playlist_mbid: string
   ): Promise<Blob> => {
     const url = `${this.APIBaseURI}/playlist/${playlist_mbid}/xspf`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,
@@ -2068,7 +2064,7 @@ export default class APIService {
       url += `?${queryParams.join("&")}`;
     }
 
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2105,7 +2101,7 @@ export default class APIService {
     if (queryParams.length) {
       url += `?${queryParams.join("&")}`;
     }
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2161,7 +2157,7 @@ export default class APIService {
       const url = `${this.MBBaseURI}/tag?client=listenbrainz-listening-now`;
       const serializer = new XMLSerializer();
       const body = serializer.serializeToString(xmlDocument);
-      const response = await fetch(url, {
+      const response = await this.fetchWithRetry(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/xml; charset=utf-8",
@@ -2204,7 +2200,7 @@ export default class APIService {
     const url = `${this.MBBaseURI}/artist?query=${encodeURIComponent(
       searchQuery
     )}&fmt=json&offset=${offset}&limit=${count}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2217,7 +2213,7 @@ export default class APIService {
     const url = `${this.MBBaseURI}/release-group?query=${encodeURIComponent(
       searchQuery
     )}&fmt=json&offset=${offset}&limit=${count}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2230,7 +2226,7 @@ export default class APIService {
     const url = `${this.MBBaseURI}/recording?query=${encodeURIComponent(
       searchQuery
     )}&fmt=json&offset=${offset}&limit=${count}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2247,14 +2243,14 @@ export default class APIService {
     const url = `${this.MBBaseURI}/release?query=${encodeURIComponent(
       searchQuery
     )}&fmt=json`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
 
   getArtistWikipediaExtract = async (artistMBID: string): Promise<string> => {
     const url = `https://musicbrainz.org/artist/${artistMBID}/wikipedia-extract`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     const { wikipediaExtract } = await response.json();
 
     if (!wikipediaExtract || !wikipediaExtract.content) {
@@ -2275,7 +2271,7 @@ export default class APIService {
     artistMBID: string
   ): Promise<RecordingType[]> => {
     const url = `${this.APIBaseURI}/popularity/top-recordings-for-artist/${artistMBID}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2284,7 +2280,7 @@ export default class APIService {
     artistMBID: string
   ): Promise<ReleaseGroupType[]> => {
     const url = `${this.APIBaseURI}/popularity/top-release-groups-for-artist/${artistMBID}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2300,7 +2296,7 @@ export default class APIService {
     )}/playlists/search?query=${encodeURIComponent(
       searchQuery
     )}&count=${count}&offset=${offset}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2313,14 +2309,14 @@ export default class APIService {
     const url = `${this.APIBaseURI}/playlist/search?query=${encodeURIComponent(
       searchQuery
     )}&count=${count}&offset=${offset}`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
 
   getUserFlairs = async (): Promise<Record<string, Flair>> => {
     const url = `${this.APIBaseURI}/donors/all-flairs`;
-    const response = await fetch(url);
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };
@@ -2333,7 +2329,7 @@ export default class APIService {
     const url = `${
       this.APIBaseURI
     }/explore/lb-radio?prompt=${encodeURIComponent(prompt)}&mode=${mode}`;
-    const response = await fetch(url, {
+    const response = await this.fetchWithRetry(url, {
       method: "GET",
       headers: {
         Authorization: `Token ${userToken}`,

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -19,7 +19,7 @@ export default class APIService {
 
   MAX_LISTEN_SIZE: number = 10000; // Maximum size of listens that can be sent
   private fetchWithRetry: (
-    input: RequestInfo,
+    input: RequestInfo | URL,
     init?: RequestInitWithRetry
   ) => Promise<Response>;
 
@@ -56,7 +56,13 @@ export default class APIService {
   private static readonly SPOTIFY_TOKEN_CACHE_DURATION = 5 * 60 * 1000;
 
   constructor(APIBaseURI: string) {
-    this.fetchWithRetry = fetchBuilder(window.fetch, this.retryParams);
+    const fetchRetry = fetchBuilder(
+      (input, init) =>
+        init === undefined ? window.fetch(input) : window.fetch(input, init),
+      this.retryParams
+    );
+    this.fetchWithRetry = (input, init) =>
+      fetchRetry(input as RequestInfo, init);
     let finalUri = APIBaseURI;
     if (finalUri.endsWith("/")) {
       finalUri = finalUri.substring(0, APIBaseURI.length - 1);
@@ -442,7 +448,7 @@ export default class APIService {
     try {
       const url = new URL(`${this.APIBaseURI}/search/users/`);
       url.searchParams.append("search_term", userName);
-      const response = await this.fetchWithRetry(url.toString(), {
+      const response = await this.fetchWithRetry(url, {
         method: "GET",
       });
 
@@ -536,7 +542,7 @@ export default class APIService {
       // Now submitListens focused on payload handling
 
       return this.withRetry(async () => {
-        const response = await this.fetchWithRetry(url.toString(), {
+        const response = await this.fetchWithRetry(url, {
           method: "POST",
           headers: {
             Authorization: `Token ${userToken}`,
@@ -1800,7 +1806,7 @@ export default class APIService {
       url.searchParams.append("inc", "artist tag release");
     }
 
-    const response = await this.fetchWithRetry(url.toString(), {
+    const response = await this.fetchWithRetry(url, {
       headers: {
         Authorization: `Token ${userToken}`,
       },
@@ -1824,7 +1830,7 @@ export default class APIService {
       url.searchParams.append("inc", "artist tag release");
     }
 
-    const response = await this.fetchWithRetry(url.toString());
+    const response = await this.fetchWithRetry(url);
     await this.checkStatus(response);
     return response.json();
   };

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -1,5 +1,6 @@
 import { isNil, isUndefined, kebabCase, lowerCase, omit } from "lodash";
 import fetchBuilder from "fetch-retry";
+import type { RequestInitWithRetry } from "fetch-retry";
 import { TagActionType } from "../tags/TagComponent";
 import type { SortOption } from "../explore/fresh-releases/FreshReleases";
 import APIError from "./APIError";
@@ -17,7 +18,11 @@ export default class APIService {
   CBBaseURI: string = "https://critiquebrainz.org/ws/1";
 
   MAX_LISTEN_SIZE: number = 10000; // Maximum size of listens that can be sent
-  private fetchWithRetry: any;
+  private fetchWithRetry: (
+    input: RequestInfo,
+    init?: RequestInitWithRetry
+  ) => Promise<Response>;
+
   private retryParams = {
     retries: 3,
     retryOn: [429, 500, 502, 503, 504],
@@ -531,7 +536,7 @@ export default class APIService {
       // Now submitListens focused on payload handling
 
       return this.withRetry(async () => {
-        const response = await this.fetchWithRetry(url, {
+        const response = await this.fetchWithRetry(url.toString(), {
           method: "POST",
           headers: {
             Authorization: `Token ${userToken}`,

--- a/frontend/js/tests/user/Dashboard.test.tsx
+++ b/frontend/js/tests/user/Dashboard.test.tsx
@@ -271,7 +271,7 @@ describe("Dashboard page", () => {
   it("doesn't call removeListenFromListenList or update state if status code is not 200", async () => {
     server.use(
       http.post("/1/delete-listen", async (path) => {
-        return HttpResponse.json({}, { status: 500 });
+        return HttpResponse.json({}, { status: 418 });
       })
     );
     renderWithProviders(

--- a/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
+++ b/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
@@ -257,7 +257,7 @@ describe("<UserSocialNetwork />", () => {
     // Mock server to return error
     server.use(
       http.get("/1/user/*/followers", () => {
-        return HttpResponse.json({ error: "Server error" }, { status: 500 });
+        return HttpResponse.json({ error: "Server error" }, { status: 418 });
       })
     );
 
@@ -283,7 +283,7 @@ describe("<UserSocialNetwork />", () => {
   it("handles similar users API error gracefully", async () => {
     server.use(
       http.get("/1/user/*/similar", () => {
-        return HttpResponse.json({ error: "Server error" }, { status: 500 });
+        return HttpResponse.json({ error: "Server error" }, { status: 418 });
       })
     );
 

--- a/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
+++ b/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
@@ -256,7 +256,7 @@ describe("<UserSocialNetwork />", () => {
   it("handles API errors gracefully with toast notifications", async () => {
     // Mock server to return error
     server.use(
-      http.get("/1/user/*/followers", () => {
+      http.get("*/1/user/*/followers", () => {
         return HttpResponse.json({ error: "Server error" }, { status: 418 });
       })
     );
@@ -282,7 +282,7 @@ describe("<UserSocialNetwork />", () => {
 
   it("handles similar users API error gracefully", async () => {
     server.use(
-      http.get("/1/user/*/similar", () => {
+      http.get("*/1/user/*/similar-users", () => {
         return HttpResponse.json({ error: "Server error" }, { status: 418 });
       })
     );

--- a/frontend/js/tests/user/stats/UserArtistActivity.test.tsx
+++ b/frontend/js/tests/user/stats/UserArtistActivity.test.tsx
@@ -55,7 +55,7 @@ describe.each([
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),
@@ -69,7 +69,7 @@ describe.each([
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),

--- a/frontend/js/tests/user/stats/UserArtistEvolutionActivity.test.tsx
+++ b/frontend/js/tests/user/stats/UserArtistEvolutionActivity.test.tsx
@@ -33,7 +33,7 @@ describe("ArtistEvolutionActivityStreamGraph", () => {
           case "week":
             return HttpResponse.json(userArtistEvolutionActivityResponse);
           case "month":
-            return HttpResponse.json({ message: "Failed to fetch data" }, { status: 500 });
+            return HttpResponse.json({ message: "Failed to fetch data" }, { status: 418 });
           default:
             return HttpResponse.json(userArtistEvolutionActivityResponse);
         }

--- a/frontend/js/tests/user/stats/UserArtistMap.test.tsx
+++ b/frontend/js/tests/user/stats/UserArtistMap.test.tsx
@@ -56,7 +56,7 @@ describe.each([
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),
@@ -70,7 +70,7 @@ describe.each([
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),

--- a/frontend/js/tests/user/stats/UserEraActivity.test.tsx
+++ b/frontend/js/tests/user/stats/UserEraActivity.test.tsx
@@ -55,7 +55,7 @@ describe.each([
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),
@@ -69,7 +69,7 @@ describe.each([
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),

--- a/frontend/js/tests/user/stats/UserGenreActivity.test.tsx
+++ b/frontend/js/tests/user/stats/UserGenreActivity.test.tsx
@@ -48,7 +48,7 @@ describe("UserGenreActivity", () => {
           default:
             return HttpResponse.json(
               { error: "Failed to fetch data" },
-              { status: 500 }
+              { status: 418 }
             );
         }
       }),


### PR DESCRIPTION
Calls to MB and LB APIs are not respecting rate limits.
We do have a mechanism in place, implemented so that we could switch to it easily.
Implements basic retry strategy that takes 429 response + retry-after headers into account
