### PR TITLE
Fix Music Neighborhood page

### DIFF
--- a/frontend/js/src/explore/music-neighborhood/MusicNeighborhood.tsx
+++ b/frontend/js/src/explore/music-neighborhood/MusicNeighborhood.tsx
@@ -145,21 +145,31 @@ export default function MusicNeighborhood() {
   const fetchArtistInfo = React.useCallback(
     async (artistMBID: string): Promise<ArtistInfoType> => {
       const [
-        artistInformation,
-        wikipediaData,
-        topRecordingsForArtist,
-        topAlbumsForArtist,
-      ]: [
-        Array<MusicBrainzArtist>,
-        string,
-        Array<RecordingType>,
-        Array<ReleaseGroupType>
-      ] = await Promise.all([
+        artistInformationResult,
+        wikipediaDataResult,
+        topRecordingsResult,
+        topAlbumsResult,
+      ] = await Promise.allSettled([
         APIService.lookupMBArtist(artistMBID, ""),
         APIService.getArtistWikipediaExtract(artistMBID),
         APIService.getTopRecordingsForArtist(artistMBID),
         APIService.getTopReleaseGroupsForArtist(artistMBID),
       ]);
+
+      const artistInformation =
+        artistInformationResult.status === "fulfilled"
+          ? artistInformationResult.value
+          : [];
+      const wikipediaData =
+        wikipediaDataResult.status === "fulfilled"
+          ? wikipediaDataResult.value
+          : "";
+      const topRecordingsForArtist =
+        topRecordingsResult.status === "fulfilled"
+          ? topRecordingsResult.value
+          : [];
+      const topAlbumsForArtist =
+        topAlbumsResult.status === "fulfilled" ? topAlbumsResult.value : [];
 
       const birthAreaData = {
         born: artistInformation[0]?.begin_year || "Unknown",


### PR DESCRIPTION
Currently fetching wikipedia-extract from MB is failing, which seems to break the page because of our use of Promise.all (one failing promise = all fail).
This PR separates promises with [Promise.allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) which is a bit cumbersome to use, but maintains parallel requests.

Obviously this does not resolve the root issue, but the page should not break just because we can't load the wikipedia extract.
In the meantime, the gateway configuration was changed to allow incoming trafic from LB to MB without marking it as potential bot (and serving a proof-of-work page), solving the root issue.
We might still want to implement a proxy endpoint on LB server that calls MB internally before returning the response to the client.

Tested on test.LB, page loads even with the failing WP call
Before:
<img width="1666" height="1087" alt="image" src="https://github.com/user-attachments/assets/b522a922-3d5e-4c50-ad90-d2fedf9f9754" />

After:
<img width="1658" height="1066" alt="image" src="https://github.com/user-attachments/assets/cdd620ba-2a9a-4293-a156-c911fcdfe0d9" />
