### PR TITLE
Allow pooling database connections

### DIFF
--- a/listenbrainz/db/timescale.py
+++ b/listenbrainz/db/timescale.py
@@ -32,7 +32,7 @@ def init_db_connection(connect_str):
 
     while True:
         try:
-            engine = create_engine(connect_str, poolclass=NullPool)
+            engine = create_engine(connect_str)
             break
         except psycopg2.OperationalError as e:
             print("Couldn't establish connection to timescale: {}".format(str(e)))


### PR DESCRIPTION
Timescale does not currently have pgbouncer managing connection pooling like some of our other DBs.
This is causing crashes of the app with the error:
> sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "10.10.10.31", port 13046 failed: FATAL:  remaining connection slots are reserved for non-replication superuser connections

In the LB app, sqlalchemy is set up with DB connection pooling disabled, most likely copied from other projects that assume the presence of pgbouncer:
https://github.com/metabrainz/listenbrainz-server/blob/2c54135b8b50d93dc3aa77ca4eb0e72679af0b9d/listenbrainz/db/timescale.py#L35

This PR changes the connection setup to use the default pooling configuration (QueuePool,  pool_size=5, max_overflow=10, timeout=30s).
>The [Engine](https://docs.sqlalchemy.org/en/21/core/connections.html#sqlalchemy.engine.Engine) returned by the [create_engine()](https://docs.sqlalchemy.org/en/21/core/engines.html#sqlalchemy.create_engine) function in most cases has a [QueuePool](https://docs.sqlalchemy.org/en/21/core/pooling.html#sqlalchemy.pool.QueuePool) integrated, pre-configured with reasonable pooling defaults.

Supporting doc:
https://docs.sqlalchemy.org/en/21/core/pooling.html
