### PR TITLE
Use SQLAlchemy connection pooling

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -114,6 +114,17 @@ MBID_MAPPING_DATABASE_URI = "dbname=musicbrainz_json_dump user=musicbrainz host=
 MBID_MAPPING_DATABASE_URI = ""
 {{end}}
 
+# SQLAlchemy connection pool sizing (per uwsgi worker). Each engine uses a
+# QueuePool sized for concurrent requests within a worker. Total connections
+# to the upstream = processes * (pool_size + max_overflow). Tune based on
+# pgbouncer max_client_conn and postgres max_connections for the target host.
+DB_POOL_SIZE = {{template "KEY" "db_pool_size"}}
+DB_POOL_MAX_OVERFLOW = {{template "KEY" "db_pool_max_overflow"}}
+TIMESCALE_POOL_SIZE = {{template "KEY" "timescale_pool_size"}}
+TIMESCALE_POOL_MAX_OVERFLOW = {{template "KEY" "timescale_pool_max_overflow"}}
+MEB_POOL_SIZE = {{template "KEY" "meb_pool_size"}}
+MEB_POOL_MAX_OVERFLOW = {{template "KEY" "meb_pool_max_overflow"}}
+
 {{if service "typesense-listenbrainz-new"}}
 {{with index (service "typesense-listenbrainz-new") 0}}
 TYPESENSE_HOST = "{{.Address}}"

--- a/docker/services/api_compat/uwsgi-api-compat.ini
+++ b/docker/services/api_compat/uwsgi-api-compat.ini
@@ -7,7 +7,10 @@ module = listenbrainz.api_compat
 callable = application
 chdir = /code/listenbrainz
 enable-threads = true
-processes = 50
+processes = 10
+; each worker imports the app after fork so the SQLAlchemy QueuePools are
+; created per-worker (sharing a pool across forks corrupts sockets)
+lazy-apps = true
 log-x-forwarded-for=true
 disable-logging = true
 ; quit uwsgi if the python app fails to load

--- a/docker/services/labs_api/uwsgi-labs-api.ini
+++ b/docker/services/labs_api/uwsgi-labs-api.ini
@@ -8,6 +8,9 @@ callable = app
 chdir = /code/listenbrainz
 enable-threads = true
 processes = 10
+; each worker imports the app after fork so the timescale connection pool
+; is created per-worker (sharing a pool across forks corrupts sockets)
+lazy-apps = true
 log-x-forwarded-for=true
 disable-logging = true
 ; quit uwsgi if the python app fails to load

--- a/docker/services/uwsgi/uwsgi.ini.ctmpl
+++ b/docker/services/uwsgi/uwsgi.ini.ctmpl
@@ -12,6 +12,9 @@ chdir = /code/listenbrainz
 enable-threads = true
 processes = {{template "KEY" "processes"}}
 threads = {{template "KEY" "threads"}}
+; each worker imports the app after fork so the SQLAlchemy QueuePools are
+; created per-worker (sharing a pool across forks corrupts sockets)
+lazy-apps = true
 listen = 2048
 log-x-forwarded-for=true
 disable-logging = true

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -29,6 +29,17 @@ TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@lb_db/listenbrainz_ts"
 # MetaBrainz - used for retrieving donation info from metabrainz.org
 SQLALCHEMY_METABRAINZ_URI = ""
 
+# SQLAlchemy connection pool sizing (per uwsgi worker). Each engine uses a
+# QueuePool sized for concurrent requests within a worker. Total connections
+# to the upstream = processes * (pool_size + max_overflow). Tune based on
+# pgbouncer max_client_conn and postgres max_connections for the target host.
+DB_POOL_SIZE = 5
+DB_POOL_MAX_OVERFLOW = 2
+TIMESCALE_POOL_SIZE = 5
+TIMESCALE_POOL_MAX_OVERFLOW = 2
+MEB_POOL_SIZE = 2
+MEB_POOL_MAX_OVERFLOW = 2
+
 # MusicBrainz & others
 IS_MUSICBRAINZ_UP = True  # if set to False, login page will be blocked
 MBID_MAPPING_DATABASE_URI = ""

--- a/listenbrainz/db/__init__.py
+++ b/listenbrainz/db/__init__.py
@@ -13,17 +13,20 @@ engine: Optional[sqlalchemy.engine.Engine] = None
 psycopg2.extras.register_uuid()
 
 
-def init_db_connection(connect_str):
+def init_db_connection(connect_str, poolclass=NullPool, **engine_kwargs):
     """Initializes database connection using the specified Flask app.
 
     Configuration file must contain `SQLALCHEMY_DATABASE_URI` key. See
     https://pythonhosted.org/Flask-SQLAlchemy/config.html#configuration-keys
     for more info.
+
+    Pass poolclass=QueuePool (and pool_size, max_overflow, pool_pre_ping via
+    engine_kwargs) for long-running services where connection reuse matters.
     """
     global engine
     while True:
         try:
-            engine = create_engine(connect_str, poolclass=NullPool)
+            engine = create_engine(connect_str, poolclass=poolclass, **engine_kwargs)
             break
         except psycopg2.OperationalError as e:
             print("Couldn't establish connection to db: {}".format(str(e)))

--- a/listenbrainz/db/donation.py
+++ b/listenbrainz/db/donation.py
@@ -16,12 +16,16 @@ RECENT_DONOR_CACHE_KEY = "recent_donors"
 DONOR_CACHE_TIMEOUT = 10 * 60
 
 
-def init_meb_db_connection(connect_str):
-    """Initializes database connection using the specified Flask app."""
+def init_meb_db_connection(connect_str, poolclass=NullPool, **engine_kwargs):
+    """Initializes database connection using the specified Flask app.
+
+    Pass poolclass=QueuePool (and pool_size, max_overflow, pool_pre_ping via
+    engine_kwargs) for long-running services where connection reuse matters.
+    """
     global engine
     while True:
         try:
-            engine = create_engine(connect_str, poolclass=NullPool)
+            engine = create_engine(connect_str, poolclass=poolclass, **engine_kwargs)
             break
         except psycopg2.OperationalError as e:
             print("Couldn't establish connection to db: {}".format(str(e)))

--- a/listenbrainz/db/timescale.py
+++ b/listenbrainz/db/timescale.py
@@ -19,12 +19,15 @@ engine: Optional[sqlalchemy.engine.Engine] = None
 DUMP_DEFAULT_THREAD_COUNT = 4
 
 
-def init_db_connection(connect_str):
+def init_db_connection(connect_str, poolclass=NullPool, **engine_kwargs):
     """Initializes timescale connection using the specified Flask app.
 
     Configuration file must contain `SQLALCHEMY_DATABASE_URI` key. See
     https://pythonhosted.org/Flask-SQLAlchemy/config.html#configuration-keys
     for more info.
+
+    Pass poolclass=QueuePool (and pool_size, max_overflow, pool_pre_ping via
+    engine_kwargs) for long-running services where connection reuse matters.
     """
     global engine
     if not connect_str:
@@ -32,7 +35,7 @@ def init_db_connection(connect_str):
 
     while True:
         try:
-            engine = create_engine(connect_str, poolclass=NullPool)
+            engine = create_engine(connect_str, poolclass=poolclass, **engine_kwargs)
             break
         except psycopg2.OperationalError as e:
             print("Couldn't establish connection to timescale: {}".format(str(e)))

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -8,6 +8,7 @@ from brainzutils import cache, metrics, sentry
 from brainzutils.flask import CustomFlask
 from flask import request, url_for, redirect, g
 from flask_login import current_user
+from sqlalchemy.pool import QueuePool
 from werkzeug.local import LocalProxy
 from flask_htmx import HTMX
 
@@ -90,13 +91,24 @@ def check_ratelimit_token_whitelist(auth_token):
     return auth_token in current_app.config["WHITELISTED_AUTH_TOKENS"]
 
 
-def create_app(debug=None, bypass_pgbouncer=False):
+def create_app(debug=None, bypass_pgbouncer=False, use_pool=False, pool_size_overrides=None):
     """ Generate a Flask app for LB with all configurations done and connections established.
 
     In the Flask app returned, blueprints are not registered.
 
     When `bypass_pgbouncer` is True, the timescale engine connects directly to the
     timescale database instead of going through pgbouncer.
+
+    When `use_pool` is True, the LB postgres, timescale, and metabrainz engines
+    use SQLAlchemy QueuePools sized from config. This is intended for the uwsgi
+    entry points (webserver, api_compat) where many requests share a worker.
+    Other callers (manage.py, mbid_mapping_writer, background_tasks, etc.) keep
+    the NullPool default since they're single-purpose, often short-lived, and
+    don't benefit from a long-lived pool.
+
+    `pool_size_overrides` (only used when `use_pool=True`) lets entry points
+    shrink the per-worker pool below the consul-configured size. Keys: "db",
+    "ts", "meb". Each value is a (pool_size, max_overflow) tuple.
     """
 
     app = CustomFlask(import_name=__name__)
@@ -133,6 +145,44 @@ def create_app(debug=None, bypass_pgbouncer=False):
         ts_connect = create_test_timescale_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])
         timescale.init_db_connection(ts_connect["DB_CONNECT"])
+    elif use_pool:
+        overrides = pool_size_overrides or {}
+        db_size, db_overflow = overrides.get(
+            "db",
+            (app.config.get("DB_POOL_SIZE"), app.config.get("DB_POOL_MAX_OVERFLOW"))
+        )
+        ts_size, ts_overflow = overrides.get(
+            "ts",
+            (app.config.get("TIMESCALE_POOL_SIZE"), app.config.get("TIMESCALE_POOL_MAX_OVERFLOW"))
+        )
+        meb_size, meb_overflow = overrides.get(
+            "meb",
+            (app.config.get("MEB_POOL_SIZE"), app.config.get("MEB_POOL_MAX_OVERFLOW"))
+        )
+
+        db.init_db_connection(
+            app.config["SQLALCHEMY_DATABASE_URI"],
+            poolclass=QueuePool,
+            pool_size=db_size,
+            max_overflow=db_overflow,
+            pool_pre_ping=True,
+        )
+        timescale_uri_config = "SQLALCHEMY_TIMESCALE_URI" if bypass_pgbouncer else "SQLALCHEMY_TIMESCALE_PGBOUNCER_URI"
+        timescale.init_db_connection(
+            app.config[timescale_uri_config],
+            poolclass=QueuePool,
+            pool_size=ts_size,
+            max_overflow=ts_overflow,
+            pool_pre_ping=True,
+        )
+        if app.config.get("SQLALCHEMY_METABRAINZ_URI", None):
+            donation.init_meb_db_connection(
+                app.config["SQLALCHEMY_METABRAINZ_URI"],
+                poolclass=QueuePool,
+                pool_size=meb_size,
+                max_overflow=meb_overflow,
+                pool_pre_ping=True,
+            )
     else:
         db.init_db_connection(app.config["SQLALCHEMY_DATABASE_URI"])
         timescale_uri_config = "SQLALCHEMY_TIMESCALE_URI" if bypass_pgbouncer else "SQLALCHEMY_TIMESCALE_PGBOUNCER_URI"
@@ -255,7 +305,7 @@ def init_admin(app):
 
 def create_web_app(debug=None):
     """ Generate a Flask app for LB with all configurations done, connections established and endpoints added."""
-    app = create_app(debug=debug)
+    app = create_app(debug=debug, use_pool=True)
     htmx = HTMX(app)
 
     # Static files
@@ -310,7 +360,18 @@ def create_api_compat_app(debug=None):
     need to create a different app and only register the api_compat blueprints
     """
 
-    app = create_app(debug=debug)
+    # api_compat uwsgi runs many single-threaded processes (no `threads = N`),
+    # so each worker only ever needs one connection at a time. Cap the per-worker
+    # pool tightly so we don't blow past pgbouncer's max_client_conn.
+    app = create_app(
+        debug=debug,
+        use_pool=True,
+        pool_size_overrides={
+            "db": (1, 1),
+            "ts": (1, 1),
+            "meb": (1, 1),
+        },
+    )
 
     import listenbrainz.webserver.static_manager as static_manager
     static_manager.read_manifest()


### PR DESCRIPTION
We recently set up pgbouncer for connection pooling across containers.

The application level code currently doesn't do client side connection pooling. In the NullPool mode, ListenBrainz clients are opening a fresh TCP connection to pgbouncer for every single transaction. This caused host-level ephemeral port exhaustion on gaga, with some services seeing "Cannot assign requested address when connecting to other pgbouncer instances" error.

To address this issue, use queue pools for web services to reuse connections to pgbouncer and reduce dramatic churns.