### PR TITLE
LB-1944: Implement SoundCloud OAuth 2.1 PKCE support

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -410,6 +410,7 @@ export default function MusicServices() {
     const funkwhaleSuccess = params.get("success");
     const navidromeError = params.get("navidrome_error");
     const navidromeSuccess = params.get("navidrome_success");
+    const soundcloudError = params.get("soundcloud_error");
 
     if (funkwhaleSuccess === "Successfully connected to Funkwhale") {
       toast.success(
@@ -445,12 +446,22 @@ export default function MusicServices() {
       );
     }
 
+    if (soundcloudError) {
+      toast.error(
+        <ToastMsg
+          title="SoundCloud Connection Error"
+          message={decodeURIComponent(soundcloudError)}
+        />
+      );
+    }
+
     // Clear the query parameters from the URL for both success and error cases
     if (
       funkwhaleSuccess ||
       funkwhaleError ||
       navidromeSuccess ||
-      navidromeError
+      navidromeError ||
+      soundcloudError
     ) {
       window.history.replaceState(
         {},

--- a/listenbrainz/domain/soundcloud.py
+++ b/listenbrainz/domain/soundcloud.py
@@ -1,5 +1,10 @@
+import base64
+import hashlib
+import secrets
+
 import requests
 from flask import current_app
+from requests_oauthlib import OAuth2Session
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.domain.brainz_service import BaseBrainzService
@@ -17,12 +22,34 @@ class SoundCloudService(BaseBrainzService):
             client_id=current_app.config["SOUNDCLOUD_CLIENT_ID"],
             client_secret=current_app.config["SOUNDCLOUD_CLIENT_SECRET"],
             redirect_uri=current_app.config["SOUNDCLOUD_REDIRECT_URI"],
-            authorize_url="https://api.soundcloud.com/connect",
-            token_url="https://api.soundcloud.com/oauth2/token",
+            authorize_url="https://secure.soundcloud.com/authorize",
+            token_url="https://secure.soundcloud.com/oauth/token",
             scopes=SOUNDCLOUD_SCOPES
         )
 
+    @staticmethod
+    def generate_pkce_pair():
+        """Return (code_verifier, code_challenge) for OAuth 2.1 PKCE."""
+        code_verifier = secrets.token_urlsafe(32)
+        code_challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode('utf-8')).digest()
+        ).rstrip(b"=").decode('utf-8')
+        return code_verifier, code_challenge
+
+    def fetch_access_token(self, code: str, code_verifier: str = None):
+        oauth = OAuth2Session(
+            client_id=self.client_id,
+            redirect_uri=self.redirect_uri
+        )
+        return oauth.fetch_token(
+            self.token_url,
+            client_secret=self.client_secret,
+            code=code,
+            code_verifier=code_verifier,
+            include_client_id=True
+        )
+
     def get_user_info(self, token: str):
-        response = requests.get(SOUNDCLOUD_USER_INFO_URL, headers={"Authorization": f"Bearer {token}"})
+        response = requests.get(SOUNDCLOUD_USER_INFO_URL, headers={"Authorization": f"OAuth {token}"})
         response.raise_for_status()
         return response.json()

--- a/listenbrainz/metadata_cache/soundcloud/client.py
+++ b/listenbrainz/metadata_cache/soundcloud/client.py
@@ -31,7 +31,7 @@ class SoundCloud:
     def get(self, url, params=None):
         with self._get_requests_session() as http:
             for _ in range(self.retries):
-                response = http.get(url, params=params, headers={"Authorization": f"Bearer {self.developer_token}"})
+                response = http.get(url, params=params, headers={"Authorization": f"OAuth {self.developer_token}"})
                 if response.status_code == 200:
                     return response.json()
 

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -281,6 +281,14 @@ def music_services_callback(service_name: str):
     # Check for error parameter first
     error = request.args.get("error")
     if error:
+        if isinstance(service, SoundCloudService):
+            session.pop("soundcloud_code_verifier", None)
+            session.pop("soundcloud_state", None)
+            return redirect(url_for(
+                "settings.index",
+                path="music-services/details",
+                soundcloud_error="SoundCloud authorization was denied"
+            ))
         return redirect(url_for("settings.index", path="music-services/details"))
 
     code = request.args.get("code")
@@ -329,7 +337,38 @@ def music_services_callback(service_name: str):
             session.pop("funkwhale_host_url", None)
             session.pop("funkwhale_user_id", None)
 
-    token = service.fetch_access_token(code)
+    if isinstance(service, SoundCloudService):
+        state = request.args.get("state")
+        stored_state = session.pop("soundcloud_state", None)
+        if not state or state != stored_state:
+            current_app.logger.error("SoundCloud OAuth state mismatch. Expected: %s, Got: %s", stored_state, state)
+            session.pop("soundcloud_code_verifier", None)
+            return redirect(url_for(
+                "settings.index",
+                path="music-services/details",
+                soundcloud_error="SoundCloud authorization failed: invalid state"
+            ))
+
+        code_verifier = session.pop("soundcloud_code_verifier", None)
+        if not code_verifier:
+            current_app.logger.error("SoundCloud PKCE code verifier missing from session for user %s", current_user.id)
+            return redirect(url_for(
+                "settings.index",
+                path="music-services/details",
+                soundcloud_error="SoundCloud authorization failed: please try again"
+            ))
+
+        try:
+            token = service.fetch_access_token(code, code_verifier=code_verifier)
+        except Exception:
+            current_app.logger.error("SoundCloud token exchange failed for user %s", current_user.id, exc_info=True)
+            return redirect(url_for(
+                "settings.index",
+                path="music-services/details",
+                soundcloud_error="SoundCloud authorization failed: could not exchange token"
+            ))
+    else:
+        token = service.fetch_access_token(code)
 
     service.add_new_user(current_user.id, token)
     return redirect(url_for("settings.index", path="music-services/details"))
@@ -552,7 +591,16 @@ def music_services_disconnect(service_name: str):
             if permissions:
                 return jsonify({"url": service.get_authorize_url(permissions)})
         elif service_name == 'soundcloud':
-            return jsonify({"url": service.get_authorize_url([])})
+            code_verifier, code_challenge = SoundCloudService.generate_pkce_pair()
+            state = base64.b64encode(os.urandom(32)).decode("utf-8")
+            session["soundcloud_code_verifier"] = code_verifier
+            session["soundcloud_state"] = state
+            return jsonify({"url": service.get_authorize_url(
+                [],
+                state=state,
+                code_challenge=code_challenge,
+                code_challenge_method="S256"
+            )})
         elif service_name == 'critiquebrainz':
             if action:
                 return jsonify({"url": service.get_authorize_url(CRITIQUEBRAINZ_SCOPES)})


### PR DESCRIPTION
[LB-1944](https://tickets.metabrainz.org/browse/LB-1944)

We're migrating to Soundcloud OAuth 2.1. We've added PKCE (Proof Key for Code Exchange) support for secure authorization.


Ref: https://developers.soundcloud.com/blog/oauth-migration