### PR TITLE
GSoc-26  Feature-1  Add Playlist Search (Part 1)

### DIFF
--- a/frontend/js/src/search/types.d.ts
+++ b/frontend/js/src/search/types.d.ts
@@ -2,15 +2,7 @@ type PlaylistTypeSearchResult = {
   count: number;
   offset: number;
   playlist_count: number;
-  playlists: {
-    playlist: {
-      annotation?: string;
-      creator: string;
-      date: string;
-      identifier: string;
-      title: string;
-    };
-  }[];
+  playlists: JSPFObject[];
 };
 
 type TrackTypeSearchResult = {

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -282,7 +282,8 @@ export default class UserPlaylists extends React.Component<
         searchPageCount: pageCount,
       },
       () => {
-        this.setSortOption(sortBy || initialSort);
+        const activeSort = sortBy || initialSort;
+        this.setSortOption(activeSort);
       }
     );
   };
@@ -308,7 +309,8 @@ export default class UserPlaylists extends React.Component<
       },
       () => {
         // Use the current sort if it exists otherwise use default
-        this.setSortOption(sortBy || initialSort);
+        const activeSort = sortBy || initialSort;
+        this.setSortOption(activeSort);
       }
     );
   };

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -51,6 +51,7 @@ export type UserPlaylistsState = {
   sortBy: SortOption;
   view: PlaylistView;
   searchTerm: string;
+  activeSearchQuery: string;
   isSearching: boolean;
   searchPageCount: number;
 };
@@ -70,6 +71,7 @@ type UserPlaylistsClassProps = UserPlaylistsProps & {
   playlistType: PlaylistType;
   handleClickPrevious: () => void;
   handleClickNext: () => void;
+  resetToPageOne: () => void;
   handleSetPlaylistType: (newType: PlaylistType) => void;
   initialView: PlaylistView;
   setPersistentView: (view: PlaylistView) => void;
@@ -99,26 +101,51 @@ export default class UserPlaylists extends React.Component<
 
   constructor(props: UserPlaylistsClassProps) {
     super(props);
-    const { playlists, playlistCount, initialView, initialSort } = props;
+    const { playlists, pageCount, initialView, initialSort } = props;
     this.state = {
       playlists: playlists?.map((pl) => pl.playlist) ?? [],
       sortBy: initialSort,
       view: initialView,
       searchTerm: "",
+      activeSearchQuery: "",
       isSearching: false,
-      searchPageCount: playlistCount,
+      searchPageCount: pageCount,
     };
   }
 
   componentDidUpdate(prevProps: Readonly<UserPlaylistsClassProps>): void {
-    const { playlists, initialView, initialSort, playlistType } = this.props;
-    const { sortBy } = this.state;
+    const {
+      playlists,
+      initialView,
+      initialSort,
+      playlistType,
+      page,
+    } = this.props;
+    const { sortBy, activeSearchQuery } = this.state;
+    const pageChanged = prevProps.page !== page;
+    const isSearchActive = activeSearchQuery.length >= MIN_SEARCH_LENGTH;
+
+    if (pageChanged && isSearchActive) {
+      void this.performPlaylistSearch(activeSearchQuery, page).catch(() => {
+        this.setState({ isSearching: false, activeSearchQuery: "" });
+        toast.error(
+          <ToastMsg
+            title="Search failed"
+            message="Unable to search playlists. Please try again."
+          />
+        );
+      });
+      return;
+    }
+
     if (prevProps.playlistType !== playlistType) {
       this.setState(
         {
           playlists: playlists.map((pl) => pl.playlist),
           sortBy: initialSort,
           view: initialView,
+          activeSearchQuery: "",
+          searchTerm: "",
         },
         () => {
           this.setSortOption(initialSort);
@@ -126,7 +153,7 @@ export default class UserPlaylists extends React.Component<
       );
       return;
     }
-    if (prevProps.playlists !== playlists) {
+    if (prevProps.playlists !== playlists && !activeSearchQuery) {
       this.setState(
         {
           playlists: playlists.map((pl) => pl.playlist),
@@ -270,14 +297,28 @@ export default class UserPlaylists extends React.Component<
     });
   };
 
+  isSearchActive = () =>
+    this.state.activeSearchQuery.length >= MIN_SEARCH_LENGTH;
+
   // Reset to full playlist list when search is cleared or too short
   resetSearchResults = () => {
-    const { playlists, initialSort, pageCount } = this.props;
+    const {
+      playlists,
+      initialSort,
+      pageCount,
+      resetToPageOne,
+      page,
+    } = this.props;
     const { sortBy } = this.state;
+
+    if (page !== 1) {
+      resetToPageOne();
+    }
 
     this.setState(
       {
         playlists: playlists.map((pl) => pl.playlist),
+        activeSearchQuery: "",
         isSearching: false,
         searchPageCount: pageCount,
       },
@@ -288,27 +329,33 @@ export default class UserPlaylists extends React.Component<
     );
   };
 
-  performPlaylistSearch = async (query: string) => {
+  performPlaylistSearch = async (query: string, page: number) => {
     const { APIService } = this.context;
     const { user, initialSort } = this.props;
     const { sortBy } = this.state;
 
-    const result = await APIService.searchPlaylistsForUser(query, user.name);
+    this.setState({ isSearching: true });
+    const offset = (page - 1) * PLAYLISTS_PAGE_SIZE;
+    const result = await APIService.searchPlaylistsForUser(
+      query,
+      user.name,
+      PLAYLISTS_PAGE_SIZE,
+      offset
+    );
 
     const playlistsFromApi = result.playlists ?? [];
     const playlists = playlistsFromApi.map((pl: any) => pl.playlist);
 
     const total = result.playlist_count ?? playlists.length;
-    const pageCount = Math.max(1, Math.ceil(total / PLAYLISTS_PAGE_SIZE));
+    const searchPageCount = Math.max(1, Math.ceil(total / PLAYLISTS_PAGE_SIZE));
 
     this.setState(
       {
         playlists,
-        searchPageCount: pageCount,
+        searchPageCount,
         isSearching: false,
       },
       () => {
-        // Use the current sort if it exists otherwise use default
         const activeSort = sortBy || initialSort;
         this.setSortOption(activeSort);
       }
@@ -321,6 +368,7 @@ export default class UserPlaylists extends React.Component<
     e.preventDefault();
 
     const { searchTerm } = this.state;
+    const { page, resetToPageOne } = this.props;
     const query = searchTerm.trim();
 
     if (!query || query.length < MIN_SEARCH_LENGTH) {
@@ -328,18 +376,38 @@ export default class UserPlaylists extends React.Component<
       return;
     }
 
-    this.setState({ isSearching: true });
+    this.setState({ activeSearchQuery: query, isSearching: true });
 
+    const shouldResetPagination = page !== 1;
     try {
-      await this.performPlaylistSearch(query);
+      if (shouldResetPagination) {
+        resetToPageOne();
+        return;
+      }
+      await this.performPlaylistSearch(query, 1);
     } catch (error) {
-      this.setState({ isSearching: false });
+      this.setState({ isSearching: false, activeSearchQuery: "" });
       toast.error(
         <ToastMsg
           title="Search failed"
           message="Unable to search playlists. Please try again."
         />
       );
+    }
+  };
+
+  handleSearchClickNext = () => {
+    const { page, handleClickNext } = this.props;
+    const { searchPageCount } = this.state;
+    if (page < searchPageCount) {
+      handleClickNext();
+    }
+  };
+
+  handleSearchClickPrevious = () => {
+    const { page, handleClickPrevious } = this.props;
+    if (page > 1) {
+      handleClickPrevious();
     }
   };
 
@@ -362,6 +430,8 @@ export default class UserPlaylists extends React.Component<
       searchPageCount,
     } = this.state;
     const { currentUser } = this.context;
+    const isSearchActive = this.isSearchActive();
+    const activePageCount = isSearchActive ? searchPageCount : pageCount;
 
     return (
       <div role="main" id="playlists-page">
@@ -576,9 +646,15 @@ export default class UserPlaylists extends React.Component<
           onPlaylistDeleted={this.onPlaylistDeleted}
           view={view}
           page={page}
-          handleClickPrevious={handleClickPrevious}
-          handleClickNext={handleClickNext}
-          pageCount={pageCount}
+          handleClickPrevious={
+            isSearchActive
+              ? this.handleSearchClickPrevious
+              : handleClickPrevious
+          }
+          handleClickNext={
+            isSearchActive ? this.handleSearchClickNext : handleClickNext
+          }
+          pageCount={activePageCount}
         >
           {this.isCurrentUserPage() && [
             <Card
@@ -626,8 +702,14 @@ export function UserPlaylistsWrapper() {
   const handleClickNext = () => {
     setSearchParams({
       ...searchParamsObj,
-      page: Math.min(currPageNo + 1, data.pageCount).toString(),
+      page: (currPageNo + 1).toString(),
     });
+  };
+
+  const resetToPageOne = () => {
+    if (currPageNo !== 1) {
+      setSearchParams({ ...searchParamsObj, page: "1" });
+    }
   };
 
   const playlistType =
@@ -658,6 +740,7 @@ export function UserPlaylistsWrapper() {
       playlistType={playlistType}
       handleClickPrevious={handleClickPrevious}
       handleClickNext={handleClickNext}
+      resetToPageOne={resetToPageOne}
       handleSetPlaylistType={handleSetPlaylistType}
       initialView={persistentView}
       setPersistentView={setPersistentView}

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -51,13 +51,10 @@ export type UserPlaylistsState = {
   sortBy: SortOption;
   view: PlaylistView;
   searchTerm: string;
-  activeSearchQuery: string;
-  searchPage: number;
-  isSearching: boolean;
-  searchPageCount: number;
 };
 
-enum SortOption {
+export enum SortOption {
+  RELEVANCE = "relevance",
   DATE_CREATED = "dateCreated",
   DATE_UPDATED = "dateUpdated",
   TITLE = "title",
@@ -65,20 +62,42 @@ enum SortOption {
   RANDOM = "random",
 }
 
+type BrowseSortOption =
+  | SortOption.DATE_CREATED
+  | SortOption.DATE_UPDATED
+  | SortOption.TITLE
+  | SortOption.CREATOR;
+
+type PlaylistSortCriterion = (playlist: JSPFPlaylist) => string | number;
+type PlaylistSortOrder = "asc" | "desc";
+
+function isBrowseSortOption(option: SortOption): option is BrowseSortOption {
+  return (
+    option === SortOption.DATE_CREATED ||
+    option === SortOption.DATE_UPDATED ||
+    option === SortOption.TITLE ||
+    option === SortOption.CREATOR
+  );
+}
+
 type UserPlaylistsLoaderData = UserPlaylistsProps;
 
 type UserPlaylistsClassProps = UserPlaylistsProps & {
   page: number;
   playlistType: PlaylistType;
+  searchQuery: string;
+  urlSort: SortOption;
   handleClickPrevious: () => void;
   handleClickNext: () => void;
-  resetToPageOne: () => void;
   handleSetPlaylistType: (newType: PlaylistType) => void;
+  onSearchSubmit: (query: string) => void;
+  onSortChangeDuringSearch: (sort: SortOption) => void;
   initialView: PlaylistView;
   setPersistentView: (view: PlaylistView) => void;
   initialSort: SortOption;
   setPersistentSort: (sort: SortOption) => void;
 };
+
 const playlistViewAtom = atomWithStorage<PlaylistView>(
   "lb_playlists_overview_view",
   PlaylistView.GRID
@@ -91,16 +110,7 @@ const playlistTypeAtom = atomWithStorage<string>(
   "lb_playlists_overview_type",
   ""
 );
-const MIN_SEARCH_LENGTH = 3;
-const PLAYLISTS_PAGE_SIZE = 25;
-
-const getSearchTypeForPlaylistTab = (
-  playlistType: PlaylistType
-): "owned" | "collaborative" => {
-  return playlistType === PlaylistType.collaborations
-    ? "collaborative"
-    : "owned";
-};
+export const MIN_SEARCH_LENGTH = 3;
 
 export default class UserPlaylists extends React.Component<
   UserPlaylistsClassProps,
@@ -111,22 +121,26 @@ export default class UserPlaylists extends React.Component<
 
   constructor(props: UserPlaylistsClassProps) {
     super(props);
-    const { playlists, pageCount, initialView, initialSort } = props;
+    const { playlists, initialView, initialSort, searchQuery, urlSort } = props;
+    const isSearchActive = searchQuery.length >= MIN_SEARCH_LENGTH;
     this.state = {
       playlists: playlists?.map((pl) => pl.playlist) ?? [],
-      sortBy: initialSort,
+      sortBy: isSearchActive ? urlSort : initialSort,
       view: initialView,
-      searchTerm: "",
-      activeSearchQuery: "",
-      searchPage: 1,
-      isSearching: false,
-      searchPageCount: pageCount,
+      searchTerm: searchQuery,
     };
   }
 
   componentDidUpdate(prevProps: Readonly<UserPlaylistsClassProps>): void {
-    const { playlists, initialView, initialSort, playlistType } = this.props;
-    const { sortBy, activeSearchQuery } = this.state;
+    const {
+      playlists,
+      initialView,
+      initialSort,
+      playlistType,
+      searchQuery,
+      urlSort,
+    } = this.props;
+    const { sortBy } = this.state;
 
     if (prevProps.playlistType !== playlistType) {
       this.setState(
@@ -134,35 +148,57 @@ export default class UserPlaylists extends React.Component<
           playlists: playlists.map((pl) => pl.playlist),
           sortBy: initialSort,
           view: initialView,
-          activeSearchQuery: "",
           searchTerm: "",
-          searchPage: 1,
         },
         () => {
-          this.setSortOption(initialSort);
+          this.applyBrowseSort(initialSort);
         }
       );
       return;
     }
-    if (prevProps.playlists !== playlists && !activeSearchQuery) {
+
+    if (prevProps.searchQuery !== searchQuery) {
+      const isSearchActive = this.isSearchActive();
       this.setState(
         {
-          playlists: playlists.map((pl) => pl.playlist),
+          searchTerm: searchQuery,
+          sortBy: isSearchActive ? urlSort : initialSort,
         },
         () => {
-          this.setSortOption(sortBy || initialSort);
+          if (!isSearchActive) {
+            this.applyBrowseSort(initialSort);
+          }
         }
       );
     }
+
+    if (prevProps.urlSort !== urlSort && this.isSearchActive()) {
+      this.setState({ sortBy: urlSort });
+    }
+
+    if (prevProps.playlists !== playlists) {
+      this.setState({ playlists: playlists.map((pl) => pl.playlist) }, () => {
+        if (!this.isSearchActive()) {
+          this.applyBrowseSort(sortBy || initialSort);
+        }
+      });
+    }
+
     if (prevProps.initialView !== initialView) {
       this.setState({ view: initialView });
     }
-    if (prevProps.initialSort !== initialSort) {
+
+    if (prevProps.initialSort !== initialSort && !this.isSearchActive()) {
       this.setState({ sortBy: initialSort }, () => {
-        this.setSortOption(initialSort);
+        this.applyBrowseSort(initialSort);
       });
     }
   }
+
+  isSearchActive = () => {
+    const { searchQuery } = this.props;
+    return searchQuery.length >= MIN_SEARCH_LENGTH;
+  };
 
   alertNotAuthorized = () => {
     toast.error(
@@ -191,7 +227,6 @@ export default class UserPlaylists extends React.Component<
   };
 
   onPlaylistEdited = async (playlist: JSPFPlaylist): Promise<void> => {
-    // Once API call succeeds, update playlist in state
     const { playlists } = this.state;
     const playlistsCopy = [...playlists];
     const playlistIndex = playlistsCopy.findIndex(
@@ -234,7 +269,7 @@ export default class UserPlaylists extends React.Component<
     return currentUser?.name === user.name;
   };
 
-  setSortOption = (option: SortOption) => {
+  applyBrowseSort = (option: SortOption) => {
     const { playlists } = this.state;
     const { setPersistentSort } = this.props;
     setPersistentSort(option);
@@ -246,33 +281,40 @@ export default class UserPlaylists extends React.Component<
       return;
     }
 
-    const sortPlaylists = (criteria: any, orders: any) =>
-      orderBy([...playlists], criteria, orders);
+    if (option === SortOption.RELEVANCE) {
+      return;
+    }
 
-    const criterias = {
-      [SortOption.DATE_CREATED]: (pl: JSPFPlaylist) =>
-        new Date(pl.date).getTime(),
-      [SortOption.TITLE]: (pl: JSPFPlaylist) => pl.title.toLowerCase(),
-      [SortOption.CREATOR]: (pl: JSPFPlaylist) => pl.creator.toLowerCase(),
-      [SortOption.DATE_UPDATED]: (pl: JSPFPlaylist) =>
+    if (!isBrowseSortOption(option)) {
+      return;
+    }
+
+    const sortPlaylists = (
+      criteria: PlaylistSortCriterion[],
+      sortOrders: PlaylistSortOrder[]
+    ): JSPFPlaylist[] => orderBy([...playlists], criteria, sortOrders);
+
+    const criterias: Record<BrowseSortOption, PlaylistSortCriterion> = {
+      [SortOption.DATE_CREATED]: (pl) => new Date(pl.date).getTime(),
+      [SortOption.TITLE]: (pl) => pl.title.toLowerCase(),
+      [SortOption.CREATOR]: (pl) => pl.creator.toLowerCase(),
+      [SortOption.DATE_UPDATED]: (pl) =>
         getPlaylistExtension(pl)?.last_modified_at || pl.date,
     };
 
-    const orders = {
-      [SortOption.DATE_CREATED]: ["desc"],
-      [SortOption.TITLE]: ["asc"],
-      [SortOption.CREATOR]: ["asc"],
-      [SortOption.DATE_UPDATED]: ["desc"],
+    const orders: Record<BrowseSortOption, PlaylistSortOrder> = {
+      [SortOption.DATE_CREATED]: "desc",
+      [SortOption.TITLE]: "asc",
+      [SortOption.CREATOR]: "asc",
+      [SortOption.DATE_UPDATED]: "desc",
     };
 
-    const sortingCriteriaBasedOnOption = [
-      criterias[option as keyof typeof criterias],
-      ...Object.values(criterias).filter(
-        (c) => c !== criterias[option as keyof typeof criterias]
-      ),
+    const sortingCriteriaBasedOnOption: PlaylistSortCriterion[] = [
+      criterias[option],
+      ...Object.values(criterias).filter((c) => c !== criterias[option]),
     ];
 
-    const sortingOrdersBasedOnOption = [
+    const sortingOrdersBasedOnOption: PlaylistSortOrder[] = [
       orders[option],
       ...Object.values(orders).filter((o) => o !== orders[option]),
     ];
@@ -288,117 +330,43 @@ export default class UserPlaylists extends React.Component<
     });
   };
 
-  fetchSearchResultsForPage = (query: string, page: number) => {
-    this.performPlaylistSearch(query, page).catch(() => {
-      this.setState({ isSearching: false, activeSearchQuery: "" });
-      toast.error(
-        <ToastMsg
-          title="Search failed"
-          message="Unable to search playlists. Please try again."
-        />
-      );
-    });
-  };
-
-  // Reset to full playlist list when search is cleared or too short
-  resetSearchResults = () => {
-    const {
-      playlists,
-      initialSort,
-      pageCount,
-      resetToPageOne,
-      page,
-    } = this.props;
-    const { sortBy } = this.state;
-
-    if (page !== 1) {
-      resetToPageOne();
+  setSortOption = (option: SortOption) => {
+    const { onSortChangeDuringSearch } = this.props;
+    if (this.isSearchActive()) {
+      onSortChangeDuringSearch(option);
+      this.setState({ sortBy: option });
+      return;
     }
-
-    this.setState(
-      {
-        playlists: playlists.map((pl) => pl.playlist),
-        activeSearchQuery: "",
-        searchPage: 1,
-        isSearching: false,
-        searchPageCount: pageCount,
-      },
-      () => {
-        const activeSort = sortBy || initialSort;
-        this.setSortOption(activeSort);
-      }
-    );
-  };
-
-  performPlaylistSearch = async (query: string, page: number) => {
-    const { APIService } = this.context;
-    const { user, initialSort, playlistType } = this.props;
-    const { sortBy } = this.state;
-
-    this.setState({ isSearching: true });
-    const offset = (page - 1) * PLAYLISTS_PAGE_SIZE;
-    const result = await APIService.searchPlaylistsForUser(
-      query,
-      user.name,
-      PLAYLISTS_PAGE_SIZE,
-      offset,
-      getSearchTypeForPlaylistTab(playlistType)
-    );
-
-    const playlists = (result.playlists ?? []).map(
-      (playlistObject) => playlistObject.playlist
-    );
-
-    const total = result.playlist_count ?? playlists.length;
-    const searchPageCount = Math.max(1, Math.ceil(total / PLAYLISTS_PAGE_SIZE));
-
-    this.setState(
-      {
-        playlists,
-        searchPageCount,
-        isSearching: false,
-      },
-      () => {
-        const activeSort = sortBy || initialSort;
-        this.setSortOption(activeSort);
-      }
-    );
+    this.applyBrowseSort(option);
   };
 
   handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
-
+    const { onSearchSubmit } = this.props;
     const { searchTerm } = this.state;
-    const query = searchTerm.trim();
-
-    if (!query || query.length < MIN_SEARCH_LENGTH) {
-      this.resetSearchResults();
-      return;
-    }
-
-    this.setState({ activeSearchQuery: query, searchPage: 1 }, () => {
-      this.fetchSearchResultsForPage(query, 1);
-    });
+    onSearchSubmit(searchTerm.trim());
   };
 
-  handleSearchClickNext = () => {
-    const { searchPage, searchPageCount, activeSearchQuery } = this.state;
-    if (searchPage < searchPageCount) {
-      const nextPage = searchPage + 1;
-      this.setState({ searchPage: nextPage }, () => {
-        this.fetchSearchResultsForPage(activeSearchQuery, nextPage);
-      });
-    }
-  };
+  renderSortOptions = () => {
+    const isSearchActive = this.isSearchActive();
+    const options = [
+      ...(isSearchActive
+        ? [{ value: SortOption.RELEVANCE, label: "Best match" }]
+        : []),
+      { value: SortOption.DATE_CREATED, label: "Date Created" },
+      { value: SortOption.DATE_UPDATED, label: "Date Updated" },
+      { value: SortOption.TITLE, label: "Title" },
+      { value: SortOption.CREATOR, label: "Creator" },
+      ...(!isSearchActive
+        ? [{ value: SortOption.RANDOM, label: "Random" }]
+        : []),
+    ];
 
-  handleSearchClickPrevious = () => {
-    const { searchPage, activeSearchQuery } = this.state;
-    if (searchPage > 1) {
-      const previousPage = searchPage - 1;
-      this.setState({ searchPage: previousPage }, () => {
-        this.fetchSearchResultsForPage(activeSearchQuery, previousPage);
-      });
-    }
+    return options.map((option) => (
+      <option key={option.value} value={option.value}>
+        {option.label}
+      </option>
+    ));
   };
 
   render() {
@@ -411,20 +379,8 @@ export default class UserPlaylists extends React.Component<
       handleClickNext,
       setPersistentView,
     } = this.props;
-    const {
-      playlists,
-      sortBy,
-      view,
-      searchTerm,
-      isSearching,
-      searchPage,
-      searchPageCount,
-      activeSearchQuery,
-    } = this.state;
+    const { playlists, sortBy, view, searchTerm } = this.state;
     const { currentUser } = this.context;
-    const isSearchActive = activeSearchQuery.length >= MIN_SEARCH_LENGTH;
-    const activePage = isSearchActive ? searchPage : page;
-    const activePageCount = isSearchActive ? searchPageCount : pageCount;
 
     return (
       <div role="main" id="playlists-page">
@@ -459,7 +415,7 @@ export default class UserPlaylists extends React.Component<
                 type="secondary"
                 onClick={() => {
                   this.setState({ view: PlaylistView.GRID });
-                  setPersistentView(PlaylistView.GRID); // Atom/Storage..
+                  setPersistentView(PlaylistView.GRID);
                 }}
                 title="Grid view"
               >
@@ -490,11 +446,7 @@ export default class UserPlaylists extends React.Component<
                 className="form-select"
                 style={{ width: "200px" }}
               >
-                <option value={SortOption.DATE_CREATED}>Date Created</option>
-                <option value={SortOption.DATE_UPDATED}>Date Updated</option>
-                <option value={SortOption.TITLE}>Title</option>
-                <option value={SortOption.CREATOR}>Creator</option>
-                <option value={SortOption.RANDOM}>Random</option>
+                {this.renderSortOptions()}
               </select>
             </div>
 
@@ -509,7 +461,7 @@ export default class UserPlaylists extends React.Component<
                     this.setState({ searchTerm: e.target.value })
                   }
                 />
-                <button type="submit" disabled={isSearching}>
+                <button type="submit">
                   <FontAwesomeIcon icon={faMagnifyingGlass as IconProp} />
                 </button>
               </form>
@@ -638,16 +590,10 @@ export default class UserPlaylists extends React.Component<
           onPlaylistEdited={this.onPlaylistEdited}
           onPlaylistDeleted={this.onPlaylistDeleted}
           view={view}
-          page={activePage}
-          handleClickPrevious={
-            isSearchActive
-              ? this.handleSearchClickPrevious
-              : handleClickPrevious
-          }
-          handleClickNext={
-            isSearchActive ? this.handleSearchClickNext : handleClickNext
-          }
-          pageCount={activePageCount}
+          page={page}
+          handleClickPrevious={handleClickPrevious}
+          handleClickNext={handleClickNext}
+          pageCount={pageCount}
         >
           {this.isCurrentUserPage() && [
             <Card
@@ -674,16 +620,28 @@ export default class UserPlaylists extends React.Component<
     );
   }
 }
+
+const parseUrlSort = (sortParam: string | null): SortOption => {
+  const validSorts = Object.values(SortOption);
+  if (sortParam && validSorts.includes(sortParam as SortOption)) {
+    return sortParam as SortOption;
+  }
+  return SortOption.RELEVANCE;
+};
+
 export function UserPlaylistsWrapper() {
   const data = useLoaderData() as UserPlaylistsLoaderData;
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParamsObj = getObjectForURLSearchParams(searchParams);
+  const skipTypeRestoreRef = React.useRef(false);
   const [persistentView, setPersistentView] = useAtom(playlistViewAtom);
   const [persistentSort, setPersistentSort] = useAtom(playlistSortAtom);
   const [persistentType, setPersistentType] = useAtom(playlistTypeAtom);
   const currPageNoStr = searchParams.get("page") || "1";
   const currPageNo = parseInt(currPageNoStr, 10);
   const type = searchParams.get("type") || persistentType;
+  const searchQuery = searchParams.get("search") || "";
+  const urlSort = parseUrlSort(searchParams.get("sort"));
 
   const handleClickPrevious = () => {
     setSearchParams({
@@ -699,42 +657,73 @@ export function UserPlaylistsWrapper() {
     });
   };
 
-  const resetToPageOne = () => {
-    if (currPageNo !== 1) {
-      setSearchParams({ ...searchParamsObj, page: "1" });
-    }
-  };
-
   const playlistType =
     type === "collaborative"
       ? PlaylistType.collaborations
       : PlaylistType.playlists;
 
   const handleSetPlaylistType = (newType: PlaylistType) => {
-    const newParams = { ...searchParamsObj };
+    skipTypeRestoreRef.current = true;
+    const newParams: Record<string, string> = { page: "1" };
     if (newType === PlaylistType.collaborations) {
       newParams.type = "collaborative";
       setPersistentType("collaborative");
     } else {
-      delete newParams?.type;
       setPersistentType("");
     }
     setSearchParams(newParams);
   };
+
+  const onSearchSubmit = (query: string) => {
+    const newParams: Record<string, string> = {
+      ...searchParamsObj,
+      page: "1",
+    };
+    if (!query || query.length < MIN_SEARCH_LENGTH) {
+      delete newParams.search;
+      delete newParams.sort;
+    } else {
+      newParams.search = query;
+      newParams.sort = SortOption.RELEVANCE;
+    }
+    setSearchParams(newParams);
+  };
+
+  const onSortChangeDuringSearch = (sort: SortOption) => {
+    const newParams: Record<string, string> = {
+      ...searchParamsObj,
+      sort,
+      page: "1",
+    };
+    setSearchParams(newParams);
+  };
+
   React.useEffect(() => {
+    if (skipTypeRestoreRef.current) {
+      skipTypeRestoreRef.current = false;
+      return;
+    }
     if (!searchParams.get("type") && persistentType === "collaborative") {
-      setSearchParams({ ...searchParamsObj, type: "collaborative" });
+      const newParams: Record<string, string> = {
+        page: searchParams.get("page") || "1",
+        type: "collaborative",
+      };
+      setSearchParams(newParams);
     }
   }, [searchParams, persistentType]);
+
   return (
     <UserPlaylists
       {...data}
       page={currPageNo}
       playlistType={playlistType}
+      searchQuery={searchQuery}
+      urlSort={urlSort}
       handleClickPrevious={handleClickPrevious}
       handleClickNext={handleClickNext}
-      resetToPageOne={resetToPageOne}
       handleSetPlaylistType={handleSetPlaylistType}
+      onSearchSubmit={onSearchSubmit}
+      onSortChangeDuringSearch={onSortChangeDuringSearch}
       initialView={persistentView}
       setPersistentView={setPersistentView}
       initialSort={persistentSort}

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -3,6 +3,7 @@ import {
   faPlusCircle,
   faUsers,
   faFileImport,
+  faMagnifyingGlass,
 } from "@fortawesome/free-solid-svg-icons";
 import {
   faSpotify,
@@ -49,6 +50,9 @@ export type UserPlaylistsState = {
   playlists: JSPFPlaylist[];
   sortBy: SortOption;
   view: PlaylistView;
+  searchTerm: string;
+  isSearching: boolean;
+  searchPageCount: number;
 };
 
 enum SortOption {
@@ -84,6 +88,8 @@ const playlistTypeAtom = atomWithStorage<string>(
   "lb_playlists_overview_type",
   ""
 );
+const MIN_SEARCH_LENGTH = 3;
+const PLAYLISTS_PAGE_SIZE = 25;
 export default class UserPlaylists extends React.Component<
   UserPlaylistsClassProps,
   UserPlaylistsState
@@ -98,6 +104,9 @@ export default class UserPlaylists extends React.Component<
       playlists: playlists?.map((pl) => pl.playlist) ?? [],
       sortBy: initialSort,
       view: initialView,
+      searchTerm: "",
+      isSearching: false,
+      searchPageCount: playlistCount,
     };
   }
 
@@ -261,6 +270,77 @@ export default class UserPlaylists extends React.Component<
     });
   };
 
+  // Reset to full playlist list when search is cleared or too short
+  resetSearchResults = () => {
+    const { playlists, initialSort, pageCount } = this.props;
+    const { sortBy } = this.state;
+
+    this.setState(
+      {
+        playlists: playlists.map((pl) => pl.playlist),
+        isSearching: false,
+        searchPageCount: pageCount,
+      },
+      () => {
+        this.setSortOption(sortBy || initialSort);
+      }
+    );
+  };
+
+  performPlaylistSearch = async (query: string) => {
+    const { APIService } = this.context;
+    const { user, initialSort } = this.props;
+    const { sortBy } = this.state;
+
+    const result = await APIService.searchPlaylistsForUser(query, user.name);
+
+    const playlistsFromApi = result.playlists ?? [];
+    const playlists = playlistsFromApi.map((pl: any) => pl.playlist);
+
+    const total = result.playlist_count ?? playlists.length;
+    const pageCount = Math.max(1, Math.ceil(total / PLAYLISTS_PAGE_SIZE));
+
+    this.setState(
+      {
+        playlists,
+        searchPageCount: pageCount,
+        isSearching: false,
+      },
+      () => {
+        // Use the current sort if it exists otherwise use default
+        this.setSortOption(sortBy || initialSort);
+      }
+    );
+  };
+
+  handleSearchSubmit = async (
+    e: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
+    e.preventDefault();
+
+    const { searchTerm } = this.state;
+    const query = searchTerm.trim();
+
+    if (!query || query.length < MIN_SEARCH_LENGTH) {
+      this.resetSearchResults();
+      return;
+    }
+
+    this.setState({ isSearching: true });
+
+    try {
+      await this.performPlaylistSearch(query);
+    } catch (error) {
+      this.setState({ isSearching: false });
+      toast.error(
+        <ToastMsg
+          title="Search failed"
+          message="Unable to search playlists. Please try again."
+        />
+      );
+    }
+  };
+
   render() {
     const {
       user,
@@ -271,7 +351,14 @@ export default class UserPlaylists extends React.Component<
       handleClickNext,
       setPersistentView,
     } = this.props;
-    const { playlists, sortBy, view } = this.state;
+    const {
+      playlists,
+      sortBy,
+      view,
+      searchTerm,
+      isSearching,
+      searchPageCount,
+    } = this.state;
     const { currentUser } = this.context;
 
     return (
@@ -344,6 +431,23 @@ export default class UserPlaylists extends React.Component<
                 <option value={SortOption.CREATOR}>Creator</option>
                 <option value={SortOption.RANDOM}>Random</option>
               </select>
+            </div>
+
+            <div className="playlist-search-controls">
+              <form className="search-bar" onSubmit={this.handleSearchSubmit}>
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Search playlists"
+                  value={searchTerm}
+                  onChange={(e) =>
+                    this.setState({ searchTerm: e.target.value })
+                  }
+                />
+                <button type="submit" disabled={isSearching}>
+                  <FontAwesomeIcon icon={faMagnifyingGlass as IconProp} />
+                </button>
+              </form>
             </div>
 
             {this.isCurrentUserPage() && (

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -126,15 +126,7 @@ export default class UserPlaylists extends React.Component<
     const isSearchActive = activeSearchQuery.length >= MIN_SEARCH_LENGTH;
 
     if (pageChanged && isSearchActive) {
-      void this.performPlaylistSearch(activeSearchQuery, page).catch(() => {
-        this.setState({ isSearching: false, activeSearchQuery: "" });
-        toast.error(
-          <ToastMsg
-            title="Search failed"
-            message="Unable to search playlists. Please try again."
-          />
-        );
-      });
+      this.fetchSearchResultsForPage(activeSearchQuery, page);
       return;
     }
 
@@ -297,8 +289,17 @@ export default class UserPlaylists extends React.Component<
     });
   };
 
-  isSearchActive = () =>
-    this.state.activeSearchQuery.length >= MIN_SEARCH_LENGTH;
+  fetchSearchResultsForPage = (query: string, page: number) => {
+    this.performPlaylistSearch(query, page).catch(() => {
+      this.setState({ isSearching: false, activeSearchQuery: "" });
+      toast.error(
+        <ToastMsg
+          title="Search failed"
+          message="Unable to search playlists. Please try again."
+        />
+      );
+    });
+  };
 
   // Reset to full playlist list when search is cleared or too short
   resetSearchResults = () => {
@@ -428,9 +429,10 @@ export default class UserPlaylists extends React.Component<
       searchTerm,
       isSearching,
       searchPageCount,
+      activeSearchQuery,
     } = this.state;
     const { currentUser } = this.context;
-    const isSearchActive = this.isSearchActive();
+    const isSearchActive = activeSearchQuery.length >= MIN_SEARCH_LENGTH;
     const activePageCount = isSearchActive ? searchPageCount : pageCount;
 
     return (

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -52,6 +52,7 @@ export type UserPlaylistsState = {
   view: PlaylistView;
   searchTerm: string;
   activeSearchQuery: string;
+  searchPage: number;
   isSearching: boolean;
   searchPageCount: number;
 };
@@ -92,6 +93,15 @@ const playlistTypeAtom = atomWithStorage<string>(
 );
 const MIN_SEARCH_LENGTH = 3;
 const PLAYLISTS_PAGE_SIZE = 25;
+
+const getSearchTypeForPlaylistTab = (
+  playlistType: PlaylistType
+): "owned" | "collaborative" => {
+  return playlistType === PlaylistType.collaborations
+    ? "collaborative"
+    : "owned";
+};
+
 export default class UserPlaylists extends React.Component<
   UserPlaylistsClassProps,
   UserPlaylistsState
@@ -108,27 +118,15 @@ export default class UserPlaylists extends React.Component<
       view: initialView,
       searchTerm: "",
       activeSearchQuery: "",
+      searchPage: 1,
       isSearching: false,
       searchPageCount: pageCount,
     };
   }
 
   componentDidUpdate(prevProps: Readonly<UserPlaylistsClassProps>): void {
-    const {
-      playlists,
-      initialView,
-      initialSort,
-      playlistType,
-      page,
-    } = this.props;
+    const { playlists, initialView, initialSort, playlistType } = this.props;
     const { sortBy, activeSearchQuery } = this.state;
-    const pageChanged = prevProps.page !== page;
-    const isSearchActive = activeSearchQuery.length >= MIN_SEARCH_LENGTH;
-
-    if (pageChanged && isSearchActive) {
-      this.fetchSearchResultsForPage(activeSearchQuery, page);
-      return;
-    }
 
     if (prevProps.playlistType !== playlistType) {
       this.setState(
@@ -138,6 +136,7 @@ export default class UserPlaylists extends React.Component<
           view: initialView,
           activeSearchQuery: "",
           searchTerm: "",
+          searchPage: 1,
         },
         () => {
           this.setSortOption(initialSort);
@@ -320,6 +319,7 @@ export default class UserPlaylists extends React.Component<
       {
         playlists: playlists.map((pl) => pl.playlist),
         activeSearchQuery: "",
+        searchPage: 1,
         isSearching: false,
         searchPageCount: pageCount,
       },
@@ -332,7 +332,7 @@ export default class UserPlaylists extends React.Component<
 
   performPlaylistSearch = async (query: string, page: number) => {
     const { APIService } = this.context;
-    const { user, initialSort } = this.props;
+    const { user, initialSort, playlistType } = this.props;
     const { sortBy } = this.state;
 
     this.setState({ isSearching: true });
@@ -341,7 +341,8 @@ export default class UserPlaylists extends React.Component<
       query,
       user.name,
       PLAYLISTS_PAGE_SIZE,
-      offset
+      offset,
+      getSearchTypeForPlaylistTab(playlistType)
     );
 
     const playlistsFromApi = result.playlists ?? [];
@@ -363,13 +364,10 @@ export default class UserPlaylists extends React.Component<
     );
   };
 
-  handleSearchSubmit = async (
-    e: React.FormEvent<HTMLFormElement>
-  ): Promise<void> => {
+  handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
 
     const { searchTerm } = this.state;
-    const { page, resetToPageOne } = this.props;
     const query = searchTerm.trim();
 
     if (!query || query.length < MIN_SEARCH_LENGTH) {
@@ -377,38 +375,28 @@ export default class UserPlaylists extends React.Component<
       return;
     }
 
-    this.setState({ activeSearchQuery: query, isSearching: true });
-
-    const shouldResetPagination = page !== 1;
-    try {
-      if (shouldResetPagination) {
-        resetToPageOne();
-        return;
-      }
-      await this.performPlaylistSearch(query, 1);
-    } catch (error) {
-      this.setState({ isSearching: false, activeSearchQuery: "" });
-      toast.error(
-        <ToastMsg
-          title="Search failed"
-          message="Unable to search playlists. Please try again."
-        />
-      );
-    }
+    this.setState({ activeSearchQuery: query, searchPage: 1 }, () => {
+      this.fetchSearchResultsForPage(query, 1);
+    });
   };
 
   handleSearchClickNext = () => {
-    const { page, handleClickNext } = this.props;
-    const { searchPageCount } = this.state;
-    if (page < searchPageCount) {
-      handleClickNext();
+    const { searchPage, searchPageCount, activeSearchQuery } = this.state;
+    if (searchPage < searchPageCount) {
+      const nextPage = searchPage + 1;
+      this.setState({ searchPage: nextPage }, () => {
+        this.fetchSearchResultsForPage(activeSearchQuery, nextPage);
+      });
     }
   };
 
   handleSearchClickPrevious = () => {
-    const { page, handleClickPrevious } = this.props;
-    if (page > 1) {
-      handleClickPrevious();
+    const { searchPage, activeSearchQuery } = this.state;
+    if (searchPage > 1) {
+      const previousPage = searchPage - 1;
+      this.setState({ searchPage: previousPage }, () => {
+        this.fetchSearchResultsForPage(activeSearchQuery, previousPage);
+      });
     }
   };
 
@@ -428,11 +416,13 @@ export default class UserPlaylists extends React.Component<
       view,
       searchTerm,
       isSearching,
+      searchPage,
       searchPageCount,
       activeSearchQuery,
     } = this.state;
     const { currentUser } = this.context;
     const isSearchActive = activeSearchQuery.length >= MIN_SEARCH_LENGTH;
+    const activePage = isSearchActive ? searchPage : page;
     const activePageCount = isSearchActive ? searchPageCount : pageCount;
 
     return (
@@ -647,7 +637,7 @@ export default class UserPlaylists extends React.Component<
           onPlaylistEdited={this.onPlaylistEdited}
           onPlaylistDeleted={this.onPlaylistDeleted}
           view={view}
-          page={page}
+          page={activePage}
           handleClickPrevious={
             isSearchActive
               ? this.handleSearchClickPrevious

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -345,8 +345,9 @@ export default class UserPlaylists extends React.Component<
       getSearchTypeForPlaylistTab(playlistType)
     );
 
-    const playlistsFromApi = result.playlists ?? [];
-    const playlists = playlistsFromApi.map((pl: any) => pl.playlist);
+    const playlists = (result.playlists ?? []).map(
+      (playlistObject) => playlistObject.playlist
+    );
 
     const total = result.playlist_count ?? playlists.length;
     const searchPageCount = Math.max(1, Math.ceil(total / PLAYLISTS_PAGE_SIZE));

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -2293,14 +2293,21 @@ export default class APIService {
     searchQuery: string,
     musicbrainzID: string,
     count: number = 25,
-    offset: number = 0
+    offset: number = 0,
+    type?: "owned" | "collaborative"
   ): Promise<PlaylistTypeSearchResult> => {
-    const url = `${this.APIBaseURI}/user/${encodeURIComponent(
-      musicbrainzID
-    )}/playlists/search?query=${encodeURIComponent(
-      searchQuery
-    )}&count=${count}&offset=${offset}`;
-    const response = await fetch(url);
+    const url = new URL(
+      `${this.APIBaseURI}/user/${encodeURIComponent(
+        musicbrainzID
+      )}/playlists/search`
+    );
+    url.searchParams.set("query", searchQuery);
+    url.searchParams.set("count", count.toString());
+    url.searchParams.set("offset", offset.toString());
+    if (type) {
+      url.searchParams.set("type", type);
+    }
+    const response = await fetch(url.toString());
     await this.checkStatus(response);
     return response.json();
   };

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -387,6 +387,7 @@ def search_playlists_for_user(
     offset: int = 0,
     viewer_id: Optional[int] = None,
     include_global: bool = False,
+    playlist_type: Optional[str] = None,
 ):
     """
     Search for playlists associated with a user by name or description.
@@ -404,6 +405,10 @@ def search_playlists_for_user(
             - If set to the same as ``user_id``, all associated playlists are visible.
         include_global: If True, also include all public playlists globally in addition to
             the user's associated playlists. Default: False.
+        playlist_type: Restrict which playlists are searched.
+            - ``None``: search playlists the user created, or collaborates on.
+            - ``"owned"``: search only playlists created by the user.
+            - ``"collaborative"``: search only playlists the user collaborates on.
 
     Returns:
         a tuple (playlists, total_playlists)
@@ -443,20 +448,32 @@ def search_playlists_for_user(
             )
         """
 
-    # Build the association condition: user's playlists OR (if include_global) all public playlists
-    global_condition = "OR pl.public = true" if include_global else ""
-    association_condition = f"""\
-        (
-            pl.creator_id = :user_id
-         OR pl.created_for_id = :user_id
-         OR EXISTS (
+    # Build the association condition based on the requested playlist type.
+    if playlist_type == "collaborative":
+        association_condition = """\
+            EXISTS (
                 SELECT 1
                   FROM playlist.playlist_collaborator pc_target
                  WHERE pc_target.playlist_id = pl.id
                    AND pc_target.collaborator_id = :user_id
-            ) {global_condition}
-        )
-    """
+            )
+        """
+    elif playlist_type == "owned":
+        association_condition = "pl.creator_id = :user_id"
+    else:
+        global_condition = "OR pl.public = true" if include_global else ""
+        association_condition = f"""\
+            (
+                pl.creator_id = :user_id
+             OR pl.created_for_id = :user_id
+             OR EXISTS (
+                    SELECT 1
+                      FROM playlist.playlist_collaborator pc_target
+                     WHERE pc_target.playlist_id = pl.id
+                       AND pc_target.collaborator_id = :user_id
+                ) {global_condition}
+            )
+        """
 
     query = text(f"""
     WITH candidate_playlists AS (

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -19,6 +19,14 @@ LISTENBRAINZ_USER_ID = 23944
 DELETED_USER_ID = 2615344
 DELETED_USER_NAME = "deleted_lb_user"
 
+SEARCH_PLAYLIST_SORTS = {
+    "relevance": "mp.name_similarity DESC, mp.description_similarity DESC",
+    "dateCreated": "pl.created DESC",
+    "dateUpdated": "pl.last_updated DESC NULLS LAST, pl.created DESC",
+    "title": "pl.name ASC",
+    "creator": "pl.creator_id ASC",
+}
+
 # These are the recommendation troi patches that we showcase on the recommendations page for each user
 RECOMMENDATION_PATCHES = (
     'daily-jams',
@@ -388,6 +396,7 @@ def search_playlists_for_user(
     viewer_id: Optional[int] = None,
     include_global: bool = False,
     playlist_type: Optional[str] = None,
+    sort: str = "relevance",
 ):
     """
     Search for playlists associated with a user by name or description.
@@ -409,12 +418,16 @@ def search_playlists_for_user(
             - ``None``: search playlists the user created, or collaborates on.
             - ``"owned"``: search only playlists created by the user.
             - ``"collaborative"``: search only playlists the user collaborates on.
+        sort: How to order search results. One of ``relevance``, ``dateCreated``,
+            ``dateUpdated``, ``title``, or ``creator``. Default: ``relevance``.
 
     Returns:
         a tuple (playlists, total_playlists)
     """
     if count == 0:
         count = None
+
+    order_clause = SEARCH_PLAYLIST_SORTS.get(sort, SEARCH_PLAYLIST_SORTS["relevance"])
 
     params = {
         "query": query,
@@ -489,9 +502,6 @@ def search_playlists_for_user(
           FROM candidate_playlists
          WHERE name_similarity > 0.1
             OR description_similarity > 0.1
-         ORDER BY name_similarity DESC, description_similarity DESC
-         LIMIT :count
-        OFFSET :offset
     )
     SELECT pl.id
          , pl.mbid
@@ -512,7 +522,9 @@ def search_playlists_for_user(
         ON pl.id = mp.id
  LEFT JOIN playlist.playlist AS copy
         ON pl.copied_from_id = copy.id
-  ORDER BY mp.name_similarity DESC, mp.description_similarity DESC
+  ORDER BY {order_clause}
+     LIMIT :count
+    OFFSET :offset
     """)
 
     result = ts_conn.execute(query, params)

--- a/listenbrainz/db/tests/test_playlist.py
+++ b/listenbrainz/db/tests/test_playlist.py
@@ -194,6 +194,35 @@ class PlaylistTestCase(IntegrationTestCase):
         self.assertEqual(count, 1)
         self.assertEqual(playlists[0].name, playlist_1.name)
 
+        playlist_a = WritablePlaylist(
+            name="alpha_search_playlist",
+            creator_id=self.user_1['id'],
+            description="search sort test",
+            collaborator_ids=[],
+            collaborators=[],
+            public=True,
+            additional_metadata={}
+        )
+        playlist_z = WritablePlaylist(
+            name="zulu_search_playlist",
+            creator_id=self.user_1['id'],
+            description="search sort test",
+            collaborator_ids=[],
+            collaborators=[],
+            public=True,
+            additional_metadata={}
+        )
+        db_playlist.create(self.db_conn, self.ts_conn, playlist_a)
+        db_playlist.create(self.db_conn, self.ts_conn, playlist_z)
+
+        playlists, count = db_playlist.search_playlists_for_user(
+            self.db_conn, self.ts_conn, self.user_1['id'], "search sort",
+            viewer_id=self.user_1['id'], playlist_type="owned", sort="title"
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(playlists[0].name, playlist_a.name)
+        self.assertEqual(playlists[1].name, playlist_z.name)
+
     def test_delete_deletes_user_playlists(self):
         """Tests that deleting a user also deletes their playlists"""
         query = text('INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token) VALUES (:user_id, :mb_id, :mb_row_id, :token)')

--- a/listenbrainz/db/tests/test_playlist.py
+++ b/listenbrainz/db/tests/test_playlist.py
@@ -165,6 +165,35 @@ class PlaylistTestCase(IntegrationTestCase):
         self.assertEqual(count, 3)
         self.assertEqual({p.name for p in playlists}, {playlist_1.name, playlist_2.name, playlist_3.name})
 
+        playlists, count = db_playlist.search_playlists_for_user(
+            self.db_conn, self.ts_conn, self.user_1['id'], "test", viewer_id=self.user_1['id'],
+            playlist_type="owned"
+        )
+
+        # Owned search should only include playlists created by user_1.
+        self.assertEqual(len(playlists), 2)
+        self.assertEqual(count, 2)
+        self.assertEqual({p.name for p in playlists}, {playlist_1.name, playlist_3.name})
+
+        playlists, count = db_playlist.search_playlists_for_user(
+            self.db_conn, self.ts_conn, self.user_1['id'], "test", viewer_id=self.user_1['id'],
+            playlist_type="collaborative"
+        )
+
+        # user_1 is not a collaborator on any playlist in this test data.
+        self.assertEqual(len(playlists), 0)
+        self.assertEqual(count, 0)
+
+        playlists, count = db_playlist.search_playlists_for_user(
+            self.db_conn, self.ts_conn, self.user_2['id'], "test", viewer_id=self.user_2['id'],
+            playlist_type="collaborative"
+        )
+
+        # Collaborative search for user_2 should only include playlist_1.
+        self.assertEqual(len(playlists), 1)
+        self.assertEqual(count, 1)
+        self.assertEqual(playlists[0].name, playlist_1.name)
+
     def test_delete_deletes_user_playlists(self):
         """Tests that deleting a user also deletes their playlists"""
         query = text('INSERT INTO "user" (id, musicbrainz_id, musicbrainz_row_id, auth_token) VALUES (:user_id, :mb_id, :mb_row_id, :token)')

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -762,8 +762,12 @@ def search_user_playlist(playlist_user_name):
     :queryparam offset: the offset of the playlists to return. Default: 0.
     :queryparam include_global: if true, also include all public playlists globally in addition to
         the user's associated playlists. Default: false.
+    :queryparam type: restrict which playlists are searched. If ``collaborative``, search only
+        playlists the user collaborates on. If ``owned``, search only playlists created by the user.
+        If omitted, search all playlists associated with the user.
 
     :statuscode 200: success
+    :statuscode 400: invalid query string or type, see error message for details.
     :statuscode 404: user not found
     :resheader Content-Type: *application/json*
     """
@@ -777,14 +781,17 @@ def search_user_playlist(playlist_user_name):
     count = get_non_negative_param("count", DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL)
     offset = get_non_negative_param("offset", 0)
     include_global = parse_boolean_arg("include_global", False)
+    playlist_type = request.args.get("type")
+    if playlist_type and playlist_type not in ("collaborative", "owned"):
+        log_raise_400("type must be either 'collaborative' or 'owned'.")
 
     if not query or len(query) < 3:
         log_raise_400("Query string must be at least 3 characters long.")
 
     viewer_id = user["id"] if user else None
     playlists, playlist_count = db_playlist.search_playlists_for_user(
-        db_conn, ts_conn, playlist_user["id"], query, count, offset, 
-        viewer_id=viewer_id, include_global=include_global
+        db_conn, ts_conn, playlist_user["id"], query, count, offset,
+        viewer_id=viewer_id, include_global=include_global, playlist_type=playlist_type
     )
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -13,7 +13,13 @@ from psycopg2.extras import DictCursor
 
 from listenbrainz import webserver
 from listenbrainz.db.msid_mbid_mapping import fetch_track_metadata_for_items
-from listenbrainz.db.playlist import get_playlists_for_user, get_recommendation_playlists_for_user, get_playlists_collaborated_on
+from listenbrainz.db.playlist import (
+    get_playlists_for_user,
+    get_recommendation_playlists_for_user,
+    get_playlists_collaborated_on,
+    search_playlists_for_user,
+    SEARCH_PLAYLIST_SORTS,
+)
 from listenbrainz.db.pinned_recording import get_current_pin_for_user, get_pin_count_for_user, get_pin_history_for_user
 from listenbrainz.db.feedback import get_feedback_count_for_user, get_feedback_for_user
 from listenbrainz.db import year_in_music as db_year_in_music
@@ -147,6 +153,8 @@ def playlists(user_name: str):
 
     page = get_non_negative_param("page", default=1)
     type = request.args.get("type", "")
+    search_query = (request.args.get("search") or "").strip()
+    sort = request.args.get("sort", "relevance")
 
     user = _get_user(user_name)
     if not user:
@@ -158,11 +166,32 @@ def playlists(user_name: str):
     }
 
     include_private = current_user.is_authenticated and current_user.id == user.id
-
-    playlists = []
     offset = (page - 1) * DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL
 
-    if type == "collaborative":
+    if search_query and len(search_query) >= 3:
+        if sort not in SEARCH_PLAYLIST_SORTS:
+            sort = "relevance"
+
+        if include_private:
+            viewer_id = user.id
+        elif current_user.is_authenticated:
+            viewer_id = current_user.id
+        else:
+            viewer_id = None
+
+        playlist_type = "collaborative" if type == "collaborative" else "owned"
+        user_playlists, playlist_count = search_playlists_for_user(
+            db_conn,
+            ts_conn,
+            user.id,
+            search_query,
+            DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL,
+            offset,
+            viewer_id=viewer_id,
+            playlist_type=playlist_type,
+            sort=sort,
+        )
+    elif type == "collaborative":
         user_playlists, playlist_count = get_playlists_collaborated_on(
             db_conn, ts_conn, user.id, include_private=include_private,
             load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset
@@ -172,6 +201,8 @@ def playlists(user_name: str):
             db_conn, ts_conn, user.id, include_private=include_private,
             load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset
         )
+
+    playlists = []
     for playlist in user_playlists:
         playlists.append(playlist.serialize_jspf())
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# PR Description

This is the first PR for the Feature 1 ( Add search functionality on playlists ) . I had first implemented 
the basic search with a valid input query of greater than or equal to 3 chars with the help of existing user playlist 
search API `( /1/user/<username>/playlists/search API via APIService.searchPlaylistsForUser)`
This makes searching playlists easy, without relying on the global search.Existing sorting options are preserved when search results are loaded.
Then I properly implemented the pagination for the searched playlists shown on the screen .

Currently the scope of this pr is basic search with proper pagination.


# Testing 

For this PR I tested manually by creating playlists with different names/descriptions , directly from the frontend screen.
And the results are as expected.

## Testing Plan : 

-  Open your own playlists page and confirm the search bar appears next to Sort by .

-  Submit a query with fewer than 3 characters — original playlist list should remain unchanged

-  Search with a valid term (3+ chars) — only matching playlists should appear

-  If results exceed 25, verify pagination works (next/previous) and page count is correct

-  Start a new search while on page 2+ — URL should reset to page 1 and show results for the new query



# Upcoming Features

 In upcoming PR's for this feature . I will be implementing : 
- Spinner loader 
- Showing proper EmptyMessage for no search match or invalid query . 
- When user clear input after search  then restores original playlists automatically without hitting ENTER


### Frontend tests will be added once all sub-features are implemented .

