### PR TITLE
Support RabbitMQ service cluster config

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -161,16 +161,15 @@ REDIS_NAMESPACE = "SERVICEDOESNOTEXIST_listenbrainz-redis"
 {{end}}
 
 {{ $rabbitmq_key := (printf "docker-server-configs/LB/config.%s.json/rabbitmq_service" (env "DEPLOY_ENV")) }}
-{{- with $rabbitmq_service_name := keyOrDefault $rabbitmq_key "rabbitmq"}}
-{{- if service $rabbitmq_service_name}}
-{{- with index (service $rabbitmq_service_name) 0}}
-RABBITMQ_HOST = "{{.Address}}"
-RABBITMQ_PORT = {{.Port}}
-{{end}}
+{{- $rabbitmq_services := service "rabbitmq-listenbrainz"}}
+{{- if $rabbitmq_services}}
+RABBITMQ_HOSTS = [
+{{- range $rabbitmq_services}}
+    ("{{.Address}}", {{.Port}}),
+{{- end}}
+]
 {{else}}
-RABBITMQ_HOST = "SERVICEDOESNOTEXIST_rabbitmq"
-RABBITMQ_PORT = "SERVICEDOESNOTEXIST_rabbitmq"
-{{end}}
+RABBITMQ_HOSTS = [("SERVICEDOESNOTEXIST_rabbitmq-listenbrainz", "SERVICEDOESNOTEXIST_rabbitmq-listenbrainz")]
 {{end}}
 RABBITMQ_USERNAME = '''{{template "KEY" "rabbitmq_user"}}'''
 RABBITMQ_PASSWORD = '''{{template "KEY" "rabbitmq_pass"}}'''

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -56,8 +56,7 @@ REDIS_PORT = 6379
 REDIS_NAMESPACE = "listenbrainz"
 
 # RabbitMQ
-RABBITMQ_HOST = "rabbitmq"
-RABBITMQ_PORT = 5672
+RABBITMQ_HOSTS = [("rabbitmq", 5672)]
 RABBITMQ_USERNAME = "guest"
 RABBITMQ_PASSWORD = "guest"
 RABBITMQ_VHOST = "/"

--- a/listenbrainz/mbid_mapping_writer/mbid_mapping_writer.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapping_writer.py
@@ -1,10 +1,10 @@
 import json
 import time
 
-from kombu import Exchange, Queue, Connection, Consumer, Message
+from kombu import Exchange, Queue, Consumer, Message
 from kombu.mixins import ConsumerMixin
 
-from listenbrainz.utils import get_fallback_connection_name
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.webserver import create_app
 from listenbrainz.mbid_mapping_writer.job_queue import MappingJobQueue
 
@@ -30,14 +30,7 @@ class MBIDMappingWriter(ConsumerMixin):
         message.ack()
 
     def init_rabbitmq_connection(self):
-        self.connection = Connection(
-            hostname=self.app.config["RABBITMQ_HOST"],
-            userid=self.app.config["RABBITMQ_USERNAME"],
-            port=self.app.config["RABBITMQ_PORT"],
-            password=self.app.config["RABBITMQ_PASSWORD"],
-            virtual_host=self.app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        self.connection = create_rabbitmq_connection(self.app.config)
 
     def start(self):
         while True:

--- a/listenbrainz/metadata_cache/consumer.py
+++ b/listenbrainz/metadata_cache/consumer.py
@@ -1,12 +1,12 @@
 import json
 import time
 
-from kombu import Exchange, Queue, Connection, Consumer, Message
+from kombu import Exchange, Queue, Consumer, Message
 from kombu.mixins import ConsumerMixin
 
 from listenbrainz.metadata_cache.crawler import Crawler
 from listenbrainz.metadata_cache.handler import BaseHandler
-from listenbrainz.utils import get_fallback_connection_name
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 
 
 class ServiceMetadataCache(ConsumerMixin):
@@ -65,14 +65,7 @@ class ServiceMetadataCache(ConsumerMixin):
         message.ack()
 
     def init_rabbitmq_connection(self):
-        self.connection = Connection(
-            hostname=self.app.config["RABBITMQ_HOST"],
-            userid=self.app.config["RABBITMQ_USERNAME"],
-            port=self.app.config["RABBITMQ_PORT"],
-            password=self.app.config["RABBITMQ_PASSWORD"],
-            virtual_host=self.app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        self.connection = create_rabbitmq_connection(self.app.config)
 
     def start(self):
         while True:

--- a/listenbrainz/metadata_cache/seeder.py
+++ b/listenbrainz/metadata_cache/seeder.py
@@ -1,12 +1,12 @@
 from flask import current_app
-from kombu import Connection, Exchange
+from kombu import Exchange
 from kombu.entity import PERSISTENT_DELIVERY_MODE
 
 from listenbrainz.metadata_cache.apple.handler import AppleCrawlerHandler
 from listenbrainz.metadata_cache.soundcloud.handler import SoundcloudCrawlerHandler
 from listenbrainz.metadata_cache.spotify.handler import SpotifyCrawlerHandler
 from listenbrainz.metadata_cache.internetarchive.handler import InternetArchiveHandler
-from listenbrainz.utils import get_fallback_connection_name
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.webserver import create_app
 
 
@@ -27,14 +27,7 @@ def submit_new_releases_to_cache():
     """ Query spotify new releases for album ids and submit those to spotify metadata cache """
     app = create_app()
     with app.app_context():
-        connection = Connection(
-            hostname=current_app.config["RABBITMQ_HOST"],
-            userid=current_app.config["RABBITMQ_USERNAME"],
-            port=current_app.config["RABBITMQ_PORT"],
-            password=current_app.config["RABBITMQ_PASSWORD"],
-            virtual_host=current_app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        connection = create_rabbitmq_connection(current_app.config)
 
         try:
             current_app.logger.info("Searching new album ids to seed spotify metadata cache")

--- a/listenbrainz/rabbitmq.py
+++ b/listenbrainz/rabbitmq.py
@@ -1,0 +1,37 @@
+from urllib.parse import quote
+
+from kombu import Connection
+
+from listenbrainz.utils import get_fallback_connection_name
+
+
+def _get_config_value(config, key, default=None):
+    return config.get(key, default)
+
+
+def _rabbitmq_url(host, port, config):
+    username = quote(str(_get_config_value(config, "RABBITMQ_USERNAME", "")), safe="")
+    password = quote(str(_get_config_value(config, "RABBITMQ_PASSWORD", "")), safe="")
+    vhost = quote(str(_get_config_value(config, "RABBITMQ_VHOST", "/")), safe="")
+    return f"amqp://{username}:{password}@{host}:{port}/{vhost}"
+
+
+def get_rabbitmq_urls(config):
+    """Return one or more RabbitMQ broker URLs from RABBITMQ_HOSTS."""
+    hosts = _get_config_value(config, "RABBITMQ_HOSTS")
+    if not hosts:
+        raise ConnectionError("RabbitMQ hosts not defined, cannot create RabbitMQ connection...")
+
+    return [_rabbitmq_url(host, port, config) for host, port in hosts]
+
+
+def create_rabbitmq_connection(config, connection_name=None, **kwargs):
+    transport_options = kwargs.pop("transport_options", {})
+    client_properties = transport_options.setdefault("client_properties", {})
+    client_properties.setdefault("connection_name", connection_name or get_fallback_connection_name())
+
+    return Connection(
+        hostname=get_rabbitmq_urls(config),
+        transport_options=transport_options,
+        **kwargs,
+    )

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -21,8 +21,7 @@ REDIS_PORT = 6379
 REDIS_NAMESPACE = "listenbrainz"
 
 # RabbitMQ
-RABBITMQ_HOST = "rabbitmq"
-RABBITMQ_PORT = 5672
+RABBITMQ_HOSTS = [("rabbitmq", 5672)]
 RABBITMQ_USERNAME = "guest"
 RABBITMQ_PASSWORD = "guest"
 RABBITMQ_VHOST = "/"

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -6,11 +6,10 @@ import click
 import orjson
 from click import UsageError
 from dateutil.relativedelta import relativedelta, MO
-from kombu import Connection
 from kombu.entity import PERSISTENT_DELIVERY_MODE, Exchange
 
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.troi.weekly_playlists import get_users_for_weekly_playlists
-from listenbrainz.utils import get_fallback_connection_name
 from data.model.common_stat import ALLOWED_STATISTICS_RANGE
 from listenbrainz.webserver import create_app
 
@@ -69,14 +68,7 @@ def send_request_to_spark_cluster(query, **params):
     app = create_app()
     with app.app_context():
         message = _prepare_query_message(query, **params)
-        connection = Connection(
-            hostname=app.config["RABBITMQ_HOST"],
-            userid=app.config["RABBITMQ_USERNAME"],
-            port=app.config["RABBITMQ_PORT"],
-            password=app.config["RABBITMQ_PASSWORD"],
-            virtual_host=app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        connection = create_rabbitmq_connection(app.config)
         producer = connection.Producer()
         spark_request_exchange = Exchange(app.config["SPARK_REQUEST_EXCHANGE"], "fanout", durable=False)
         producer.publish(

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -4,8 +4,8 @@ import time
 from kombu import Connection, Message, Consumer, Exchange, Queue
 from kombu.mixins import ConsumerMixin
 
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.spark.background import BackgroundJobProcessor
-from listenbrainz.utils import get_fallback_connection_name
 from listenbrainz.webserver import create_app
 
 PREFETCH_COUNT = 1000
@@ -42,14 +42,7 @@ class SparkReader(ConsumerMixin):
         )]
 
     def init_rabbitmq_connection(self):
-        self.connection = Connection(
-            hostname=self.app.config["RABBITMQ_HOST"],
-            userid=self.app.config["RABBITMQ_USERNAME"],
-            port=self.app.config["RABBITMQ_PORT"],
-            password=self.app.config["RABBITMQ_PASSWORD"],
-            virtual_host=self.app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        self.connection = create_rabbitmq_connection(self.app.config)
 
     def start(self):
         """ initiates RabbitMQ connection and starts consuming from the queue """

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -6,12 +6,13 @@ from random import randint
 import amqp
 import orjson
 from flask import current_app
-from kombu import Connection, Queue, Exchange
+from kombu import Queue, Exchange
 from kombu.entity import PERSISTENT_DELIVERY_MODE
 
 import listenbrainz.db.user as db_user
 from listenbrainz.listen import Listen
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 from listenbrainz.webserver import redis_connection, timescale_connection
 
@@ -141,13 +142,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         """ Test that listens are published to rejection queue when processing fails """
         user = db_user.get_or_create(self.db_conn, 1, 'difftracksametsuser')
 
-        connection = Connection(
-            hostname=current_app.config["RABBITMQ_HOST"],
-            userid=current_app.config["RABBITMQ_USERNAME"],
-            port=current_app.config["RABBITMQ_PORT"],
-            password=current_app.config["RABBITMQ_PASSWORD"],
-            virtual_host=current_app.config["RABBITMQ_VHOST"],
-        )
+        connection = create_rabbitmq_connection(current_app.config)
 
         with connection:
             ts = int(time.time())

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -7,14 +7,14 @@ import psycopg2
 import orjson
 from brainzutils import metrics
 from flask import current_app
-from kombu import Exchange, Queue, Consumer, Message, Connection
+from kombu import Exchange, Queue, Consumer, Message
 from kombu.entity import PERSISTENT_DELIVERY_MODE
 from kombu.mixins import ConsumerProducerMixin
 from more_itertools import chunked
 
 from listenbrainz import messybrainz
 from listenbrainz.listen import Listen
-from listenbrainz.utils import get_fallback_connection_name
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.webserver import create_app, redis_connection, timescale_connection
 from listenbrainz.webserver.listens_cache import invalidate_user_listen_caches
 from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP
@@ -193,14 +193,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
         return len(data)
 
     def init_rabbitmq_connection(self):
-        self.connection = Connection(
-            hostname=current_app.config["RABBITMQ_HOST"],
-            userid=current_app.config["RABBITMQ_USERNAME"],
-            port=current_app.config["RABBITMQ_PORT"],
-            password=current_app.config["RABBITMQ_PASSWORD"],
-            virtual_host=current_app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        self.connection = create_rabbitmq_connection(current_app.config)
 
     def start(self):
         while True:

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
-from kombu import Connection, pools, producers, Exchange
+from kombu import pools, producers, Exchange
 from kombu.pools import ProducerPool
 
-from listenbrainz.utils import get_fallback_connection_name
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 
 rabbitmq: Optional[ProducerPool] = None
 INCOMING_EXCHANGE: Optional[Exchange] = None
@@ -27,18 +27,11 @@ def init_rabbitmq_connection(app):
     # if RabbitMQ config values are not in the config file
     # raise an error. This is caught in create_app, so the app will continue running.
     # Consul will bring the values back into config once the RabbitMQ service comes up.
-    if "RABBITMQ_HOST" not in app.config:
-        app.logger.critical("RabbitMQ host:port not defined, cannot create RabbitMQ connection...")
+    if not app.config.get("RABBITMQ_HOSTS"):
+        app.logger.critical("RabbitMQ hosts not defined, cannot create RabbitMQ connection...")
         raise ConnectionError("RabbitMQ service is not up!")
 
-    connection = Connection(
-        hostname=app.config["RABBITMQ_HOST"],
-        userid=app.config["RABBITMQ_USERNAME"],
-        port=app.config["RABBITMQ_PORT"],
-        password=app.config["RABBITMQ_PASSWORD"],
-        virtual_host=app.config["RABBITMQ_VHOST"],
-        transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}},
-    ).ensure_connection(max_retries=CONNECTION_RETRIES)
+    connection = create_rabbitmq_connection(app.config).ensure_connection(max_retries=CONNECTION_RETRIES)
     pools.set_limit(CONNECTION_LIMIT)
 
     INCOMING_EXCHANGE = Exchange(app.config["INCOMING_EXCHANGE"], "fanout", durable=False)

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -4,10 +4,11 @@ from time import time
 from brainzutils import cache
 from brainzutils.ratelimit import ratelimit
 from flask import Blueprint, request, jsonify, current_app
-from kombu import Connection, Queue, Exchange
+from kombu import Queue, Exchange
 from kombu.exceptions import KombuError
 
 import listenbrainz.db.stats as db_stats
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 from listenbrainz.db.dump_entry import get_dump_entries, get_dump_entry
 from listenbrainz.db.playlist import get_recommendation_playlists_for_user
 from listenbrainz.webserver import db_conn, ts_conn
@@ -166,12 +167,7 @@ def get_incoming_listens_count():
             incoming_exchange = Exchange(current_app.config["INCOMING_EXCHANGE"], "fanout", durable=False)
             incoming_queue = Queue(current_app.config["INCOMING_QUEUE"], exchange=incoming_exchange, durable=True)
 
-            with Connection(hostname=current_app.config["RABBITMQ_HOST"],
-                            userid=current_app.config["RABBITMQ_USERNAME"],
-                            port=current_app.config["RABBITMQ_PORT"],
-                            password=current_app.config["RABBITMQ_PASSWORD"],
-                            virtual_host=current_app.config["RABBITMQ_VHOST"]) as conn:
-
+            with create_rabbitmq_connection(current_app.config) as conn:
                 _, listen_count, _ = incoming_queue.queue_declare(channel=conn.channel(), passive=True)
         except KombuError as err:
             current_app.logger.error("RabbitMQ is currently not available. Error: %s" % (str(err)))

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -4,9 +4,9 @@ import time
 from kombu.mixins import ConsumerMixin
 
 from listenbrainz.listen import Listen, NowPlayingListen
-from listenbrainz.utils import get_fallback_connection_name
+from listenbrainz.rabbitmq import create_rabbitmq_connection
 
-from kombu import Connection, Exchange, Queue, Consumer
+from kombu import Exchange, Queue, Consumer
 
 
 class ListensDispatcher(ConsumerMixin):
@@ -50,14 +50,7 @@ class ListensDispatcher(ConsumerMixin):
             self.playing_now_channel.close()
 
     def init_rabbitmq_connection(self):
-        self.connection = Connection(
-            hostname=self.app.config["RABBITMQ_HOST"],
-            userid=self.app.config["RABBITMQ_USERNAME"],
-            port=self.app.config["RABBITMQ_PORT"],
-            password=self.app.config["RABBITMQ_PASSWORD"],
-            virtual_host=self.app.config["RABBITMQ_VHOST"],
-            transport_options={"client_properties": {"connection_name": get_fallback_connection_name()}}
-        )
+        self.connection = create_rabbitmq_connection(self.app.config)
 
     def start(self):
         while True:

--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -3,8 +3,7 @@ HDFS_HTTP_URI = 'http://namenode:9870' # the URI of the http webclient for HDFS
 HDFS_CLUSTER_URI = 'hdfs://namenode:9000' # the URI to be used with Spark
 
 # rabbitmq
-RABBITMQ_HOST = "rabbitmq"
-RABBITMQ_PORT = 5672
+RABBITMQ_HOSTS = [("rabbitmq", 5672)]
 RABBITMQ_USERNAME = "guest"
 RABBITMQ_PASSWORD = "guest"
 RABBITMQ_VHOST = "/"

--- a/listenbrainz_spark/rabbitmq.py
+++ b/listenbrainz_spark/rabbitmq.py
@@ -1,0 +1,30 @@
+from urllib.parse import quote
+
+from kombu import Connection
+
+
+def _rabbitmq_url(host, port, config):
+    username = quote(str(config.RABBITMQ_USERNAME), safe="")
+    password = quote(str(config.RABBITMQ_PASSWORD), safe="")
+    vhost = quote(str(config.RABBITMQ_VHOST), safe="")
+    return f"amqp://{username}:{password}@{host}:{port}/{vhost}"
+
+
+def get_rabbitmq_urls(config):
+    hosts = getattr(config, "RABBITMQ_HOSTS", None)
+    if not hosts:
+        raise ConnectionError("RabbitMQ hosts not defined, cannot create RabbitMQ connection...")
+
+    return [_rabbitmq_url(host, port, config) for host, port in hosts]
+
+
+def create_rabbitmq_connection(config, connection_name, **kwargs):
+    transport_options = kwargs.pop("transport_options", {})
+    client_properties = transport_options.setdefault("client_properties", {})
+    client_properties.setdefault("connection_name", connection_name)
+
+    return Connection(
+        hostname=get_rabbitmq_urls(config),
+        transport_options=transport_options,
+        **kwargs,
+    )

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -21,13 +21,14 @@ import socket
 import time
 import logging
 
-from kombu import Exchange, Queue, Message, Connection, Consumer
+from kombu import Exchange, Queue, Message, Consumer
 from kombu.entity import PERSISTENT_DELIVERY_MODE
 from kombu.mixins import ConsumerProducerMixin
 
 import listenbrainz_spark
 import listenbrainz_spark.query_map
 from listenbrainz_spark import config, hdfs_connection
+from listenbrainz_spark.rabbitmq import create_rabbitmq_connection
 
 
 RABBITMQ_HEARTBEAT_TIME = 2 * 60 * 60  # 2 hours -- a full dump import takes 40 minutes right now
@@ -119,14 +120,7 @@ class RequestConsumer(ConsumerProducerMixin):
 
     def init_rabbitmq_connection(self):
         connection_name = "spark-request-consumer-" + socket.gethostname()
-        self.connection = Connection(
-            hostname=config.RABBITMQ_HOST,
-            userid=config.RABBITMQ_USERNAME,
-            port=config.RABBITMQ_PORT,
-            password=config.RABBITMQ_PASSWORD,
-            virtual_host=config.RABBITMQ_VHOST,
-            transport_options={"client_properties": {"connection_name": connection_name}}
-        )
+        self.connection = create_rabbitmq_connection(config, connection_name)
 
     def start(self, app_name):
         while True:


### PR DESCRIPTION
Use a rabbitmq cluster for listenbrainz that is separate from MusicBrainz to avoid overloading it and also to avoid single point of failures.