### PR TITLE
Separate full dumps into separate container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -216,9 +216,11 @@ RUN touch /etc/service/uwsgi/down
 
 COPY ./docker/rc.local /etc/rc.local
 
-# crontab
-COPY ./docker/services/cron/crontab /etc/cron.d/crontab
-RUN chmod 0644 /etc/cron.d/crontab
+# crontabs
+RUN mkdir -p /etc/listenbrainz-crontabs
+COPY ./docker/services/cron/crontab /etc/listenbrainz-crontabs/crontab
+COPY ./docker/services/cron/full-dumps-crontab /etc/listenbrainz-crontabs/full-dumps-crontab
+RUN chmod 0644 /etc/listenbrainz-crontabs/*
 
 # copy the compiled js files and statis assets from image to prod
 COPY --from=listenbrainz-frontend-prod /code/frontend/robots.txt /static/

--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -42,5 +42,5 @@ RSYNC_SAMPLE_KEY='{{template "KEY" "user_home"}}/.ssh/rsync-listenbrainz-dumps-s
 
 # Check to make sure that this container is the prod cron container, otherwise never rsync anything!
 # these variables may also be read by the dump command in python so export to ensure availability
-export PROD="{{ (env "DEPLOY_ENV") }}"
+export DEPLOY_ENV="{{ (env "DEPLOY_ENV") }}"
 export CONTAINER_NAME="{{ (env "CONTAINER_NAME") }}"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -36,9 +36,10 @@ source "admin/functions.sh"
 # exits, so we sanitise it here in case it was included in the environment.
 DUMP_INTERMEDIATE_DIR=""
 
-if [ "$CONTAINER_NAME" == "listenbrainz-cron-prod" ] && [ "$PROD" == "prod" ]
+if [ "$DEPLOY_ENV" == "prod" ] && \
+   { [ "$CONTAINER_NAME" == "listenbrainz-cron-prod" ] || [ "$CONTAINER_NAME" == "listenbrainz-full-dumps-cron-prod" ]; }
 then
-    echo "Running in listenbrainz-cron-prod container, good!"
+    echo "Running in $CONTAINER_NAME container, good!"
 else
     echo "This container is not the production cron container, exiting..."
     exit

--- a/admin/cron_lock.py
+++ b/admin/cron_lock.py
@@ -7,6 +7,10 @@ import click
 
 
 CRON_LOGS_DIR = "/logs"
+CRON_CONTAINER_NAMES = {
+    "listenbrainz-cron-prod",
+    "listenbrainz-full-dumps-cron-prod",
+}
 
 
 def sanity_check():
@@ -22,7 +26,7 @@ def sanity_check():
         print("cron logs dir does not exist. Is this code running in the container?")
         sys.exit(-1)
 
-    if "CONTAINER_NAME" not in os.environ or os.environ["CONTAINER_NAME"] != "listenbrainz-cron-prod":
+    if os.environ.get("CONTAINER_NAME") not in CRON_CONTAINER_NAMES:
         print("we do not seem to be running inside the cron prod container.")
         sys.exit(-1)
 

--- a/docker/rc.local
+++ b/docker/rc.local
@@ -5,6 +5,15 @@ function log() {
    echo $@
 }
 
+function enable_cron() {
+    local crontab=$1
+
+    cp "$crontab" /etc/cron.d/crontab
+    chmod 0644 /etc/cron.d/crontab
+    rm -f /etc/service/cron/down
+    rm -f /etc/service/cron-config/down
+}
+
 log "Hello, this is rc.local. CONTAINER_NAME is $CONTAINER_NAME, and DEPLOY_ENV is $DEPLOY_ENV"
 
 if [ "${CONTAINER_NAME}" = "listenbrainz-web-${DEPLOY_ENV}" ]
@@ -70,8 +79,13 @@ fi
 if [ "${CONTAINER_NAME}" = "listenbrainz-cron-prod" ]
 then
     log Enabling cron
-    rm -f /etc/service/cron/down
-    rm -f /etc/service/cron-config/down
+    enable_cron /etc/listenbrainz-crontabs/crontab
+fi
+
+if [ "${CONTAINER_NAME}" = "listenbrainz-full-dumps-cron-prod" ]
+then
+    log Enabling full dumps cron
+    enable_cron /etc/listenbrainz-crontabs/full-dumps-crontab
 fi
 
 if [ "${CONTAINER_NAME}" = "listenbrainz-mbid-mapping-writer-${DEPLOY_ENV}" ]
@@ -99,4 +113,3 @@ if [ "${CONTAINER_NAME}" = "listenbrainz-soundcloud-metadata-cache-${DEPLOY_ENV}
 then
     rm -f /etc/service/soundcloud_metadata_cache/down
 fi
-

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -39,8 +39,7 @@ MAILTO=""
 # Request user fresh releases daily
 0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --threshold 10 >> /logs/fresh_releases.log 2>&1
 
-## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
-0 4 1,15 * * root flock -x -n /var/lock/lb-full-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/full_dumps.log 2>&1
+# Full dumps run in a separate cron container using full-dumps-crontab.
 
 # run job to update msids with mapped mbids daily
 0 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py update-msid-tables >> /logs/msid-updater.log 2>&1

--- a/docker/services/cron/full-dumps-crontab
+++ b/docker/services/cron/full-dumps-crontab
@@ -1,0 +1,4 @@
+MAILTO=""
+
+## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
+0 4 1,15 * * root flock -x -n /var/lock/lb-full-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/full_dumps.log 2>&1

--- a/docs/developers/architecture.rst
+++ b/docs/developers/architecture.rst
@@ -91,8 +91,11 @@ In production, webservers run uwsgi server to serve the flask application. In de
      - runs a nginx container for the compat API that exposes this service on a local IP, not through gateways.
 
    * - listenbrainz-cron-prod
-     - runs cron jobs used to execute periodic tasks like creating dumps, invoking spark jobs to import dump, requesting
-       statistics and so on.
+     - runs cron jobs used to execute periodic tasks like creating non-full dumps, invoking spark jobs to import dumps,
+       requesting statistics and so on.
+
+   * - listenbrainz-full-dumps-cron-prod
+     - runs the twice-monthly full dump cron job.
 
    * - exim-relay-listenbrainz.org
      - smtp relay used by LB to send emails.

--- a/docs/maintainers/dumps.rst
+++ b/docs/maintainers/dumps.rst
@@ -11,12 +11,17 @@ received by the maintainers, it is possible that the cron jobs are not setup pro
 
 Logs
 ^^^^
-Looking at the logs is a good starting point to debug dump failures, the log file is located at :file:`/logs/dumps.log`
-inside the listenbrainz-cron-prod container. The output of dump-related jobs is `redirected in the crontab <https://github.com/metabrainz/listenbrainz-server/blob/1f2e2634126a32a75bdb717b741d55099f4dd411/docker/services/cron/crontab#L8-L19>`_
-. Open a bash shell in the cron container by running :code:`docker exec -it listenbrainz-cron-prod bash`.
+Looking at the logs is a good starting point to debug dump failures. Incremental, feedback, and canonical dump jobs
+run in the :code:`listenbrainz-cron-prod` container. Full dump jobs run in the
+:code:`listenbrainz-full-dumps-cron-prod` container. The output of dump-related jobs is redirected in the crontab files
+under :file:`docker/services/cron/`.
+
+For full dumps, inspect :file:`/logs/full_dumps.log` inside the full-dumps cron container:
+:code:`docker exec -it listenbrainz-full-dumps-cron-prod bash`. For other dump jobs, open a bash shell in the regular
+cron container by running :code:`docker exec -it listenbrainz-cron-prod bash`.
 
 This file is large, so use :command:`tail` instead of :command:`cat` to view the logs. For example:
-:code:`tail -n 500 /logs/dumps.log` will list the last 500 lines of the log file.
+:code:`tail -n 500 /logs/full_dumps.log` will list the last 500 lines of the full dumps log file.
 
 From the log file, you should probably be able to see whether the error occurred in python part of the code or bash
 script. If you see a python stack trace, it is likely that sentry recorded the error too. The `sentry view <https://sentry.metabrainz.org/organizations/metabrainz/issues/?project=15>`_
@@ -41,13 +46,14 @@ before failing. To be sure, check the :code:`data_dump` table in the database. I
 
 Also the bash script to create dumps performs setup, cleanup and syncing to FTP tasks so do not invoke the python
 command directly. The bash script forwards arguments to the python command so you can pass any arguments that the python
-command accepts to it as well. See the current version of the script in the repository for more details. Here is an
-example of how you can manually specify the id of the dump (copied the cronjob command at the time of writing and
-added the argument before redirecting):
+command accepts to it as well. Run full dump commands from :code:`listenbrainz-full-dumps-cron-prod`; run other dump
+commands from :code:`listenbrainz-cron-prod`. See the current version of the script in the repository for more details.
+Here is an example of how you can manually specify the id of the dump (copied the cronjob command at the time of writing
+and added the argument before redirecting):
 
 .. code:: bash
 
-    flock -x -n /var/lock/lb-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental --dump-id 700 >> /logs/dumps.log 2>&1
+    flock -x -n /var/lock/lb-incremental-dumps.lock /code/listenbrainz/admin/create-dumps.sh incremental --dump-id 700 >> /logs/incremental_dumps.log 2>&1
 
 .. note::
 


### PR DESCRIPTION
To run on a different node and stop bringing down other services because of disk space issues.