### PR TITLE
RabbitMQ Updates

### DIFF
--- a/listenbrainz/mbid_mapping_writer/mbid_mapping_writer.py
+++ b/listenbrainz/mbid_mapping_writer/mbid_mapping_writer.py
@@ -18,7 +18,7 @@ class MBIDMappingWriter(ConsumerMixin):
         self.app = app
         self.queue = None
         self.connection = None
-        self.unique_exchange = Exchange(self.app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
+        self.unique_exchange = Exchange(self.app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
         self.unique_queue = Queue(self.app.config["UNIQUE_QUEUE"], exchange=self.unique_exchange, durable=True)
 
     def get_consumers(self, _, channel):

--- a/listenbrainz/metadata_cache/consumer.py
+++ b/listenbrainz/metadata_cache/consumer.py
@@ -18,7 +18,7 @@ class ServiceMetadataCache(ConsumerMixin):
 
         self.connection = None
         self.service_channel = None
-        self.unique_exchange = Exchange(self.app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
+        self.unique_exchange = Exchange(self.app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
         # this queue gets album ids from listens
         self.listens_queue = Queue(
             self.app.config["SPOTIFY_METADATA_QUEUE"],

--- a/listenbrainz/rabbitmq.py
+++ b/listenbrainz/rabbitmq.py
@@ -1,8 +1,23 @@
 from urllib.parse import quote
 
-from kombu import Connection
+from kombu import Connection, Exchange, Queue
 
 from listenbrainz.utils import get_fallback_connection_name
+
+QUORUM_QUEUE_ARGUMENTS = {"x-queue-type": "quorum"}
+
+
+def get_incoming_exchange(config):
+    return Exchange(config["INCOMING_EXCHANGE"], "fanout", durable=True)
+
+
+def get_incoming_queue(config):
+    return Queue(
+        config["INCOMING_QUEUE"],
+        exchange=get_incoming_exchange(config),
+        durable=True,
+        queue_arguments=QUORUM_QUEUE_ARGUMENTS,
+    )
 
 
 def _get_config_value(config, key, default=None):

--- a/listenbrainz/rabbitmq.py
+++ b/listenbrainz/rabbitmq.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote
-
 from kombu import Connection, Exchange, Queue
 
 from listenbrainz.utils import get_fallback_connection_name
@@ -25,9 +23,9 @@ def _get_config_value(config, key, default=None):
 
 
 def _rabbitmq_url(host, port, config):
-    username = quote(str(_get_config_value(config, "RABBITMQ_USERNAME", "")), safe="")
-    password = quote(str(_get_config_value(config, "RABBITMQ_PASSWORD", "")), safe="")
-    vhost = quote(str(_get_config_value(config, "RABBITMQ_VHOST", "/")), safe="")
+    username = _get_config_value(config, "RABBITMQ_USERNAME", "")
+    password = _get_config_value(config, "RABBITMQ_PASSWORD", "")
+    vhost = _get_config_value(config, "RABBITMQ_VHOST", "/")
     return f"amqp://{username}:{password}@{host}:{port}/{vhost}"
 
 

--- a/listenbrainz/spark/request_manage.py
+++ b/listenbrainz/spark/request_manage.py
@@ -70,7 +70,7 @@ def send_request_to_spark_cluster(query, **params):
         message = _prepare_query_message(query, **params)
         connection = create_rabbitmq_connection(app.config)
         producer = connection.Producer()
-        spark_request_exchange = Exchange(app.config["SPARK_REQUEST_EXCHANGE"], "fanout", durable=False)
+        spark_request_exchange = Exchange(app.config["SPARK_REQUEST_EXCHANGE"], "fanout", durable=True)
         producer.publish(
             message,
             routing_key="",

--- a/listenbrainz/spark/spark_reader.py
+++ b/listenbrainz/spark/spark_reader.py
@@ -16,7 +16,7 @@ class SparkReader(ConsumerMixin):
     def __init__(self, app):
         self.app = app
         self.connection: Connection | None = None
-        self.spark_result_exchange = Exchange(app.config["SPARK_RESULT_EXCHANGE"], "fanout", durable=False)
+        self.spark_result_exchange = Exchange(app.config["SPARK_RESULT_EXCHANGE"], "fanout", durable=True)
         self.spark_result_queue = Queue(app.config["SPARK_RESULT_QUEUE"], exchange=self.spark_result_exchange,
                                         durable=True)
         self.response_handlers = {}

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -27,9 +27,9 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
     def __init__(self):
         self.connection = None
 
-        self.incoming_exchange = Exchange(current_app.config["INCOMING_EXCHANGE"], "fanout", durable=False)
+        self.incoming_exchange = Exchange(current_app.config["INCOMING_EXCHANGE"], "fanout", durable=True)
         self.incoming_queue = Queue(current_app.config["INCOMING_QUEUE"], exchange=self.incoming_exchange, durable=True)
-        self.unique_exchange = Exchange(current_app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
+        self.unique_exchange = Exchange(current_app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
         self.unique_queue = Queue(current_app.config["UNIQUE_QUEUE"], exchange=self.unique_exchange, durable=True)
         self.rejection_exchange = Exchange(current_app.config["REJECTION_EXCHANGE"], "fanout", durable=True)
         self.rejection_queue = Queue(current_app.config["REJECTION_QUEUE"], exchange=self.rejection_exchange, durable=True)

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -14,7 +14,7 @@ from more_itertools import chunked
 
 from listenbrainz import messybrainz
 from listenbrainz.listen import Listen
-from listenbrainz.rabbitmq import create_rabbitmq_connection
+from listenbrainz.rabbitmq import create_rabbitmq_connection, get_incoming_exchange, get_incoming_queue
 from listenbrainz.webserver import create_app, redis_connection, timescale_connection
 from listenbrainz.webserver.listens_cache import invalidate_user_listen_caches
 from listenbrainz.webserver.views.api_tools import MAX_ITEMS_PER_MESSYBRAINZ_LOOKUP
@@ -27,8 +27,8 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
     def __init__(self):
         self.connection = None
 
-        self.incoming_exchange = Exchange(current_app.config["INCOMING_EXCHANGE"], "fanout", durable=True)
-        self.incoming_queue = Queue(current_app.config["INCOMING_QUEUE"], exchange=self.incoming_exchange, durable=True)
+        self.incoming_exchange = get_incoming_exchange(current_app.config)
+        self.incoming_queue = get_incoming_queue(current_app.config)
         self.unique_exchange = Exchange(current_app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
         self.unique_queue = Queue(current_app.config["UNIQUE_QUEUE"], exchange=self.unique_exchange, durable=True)
         self.rejection_exchange = Exchange(current_app.config["REJECTION_EXCHANGE"], "fanout", durable=True)

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -91,7 +91,13 @@ def check_ratelimit_token_whitelist(auth_token):
     return auth_token in current_app.config["WHITELISTED_AUTH_TOKENS"]
 
 
-def create_app(debug=None, bypass_pgbouncer=False, use_pool=False, pool_size_overrides=None):
+def create_app(
+        debug=None,
+        bypass_pgbouncer=False,
+        use_pool=False,
+        pool_size_overrides=None,
+        declare_incoming_queue=False,
+):
     """ Generate a Flask app for LB with all configurations done and connections established.
 
     In the Flask app returned, blueprints are not registered.
@@ -109,6 +115,10 @@ def create_app(debug=None, bypass_pgbouncer=False, use_pool=False, pool_size_ove
     `pool_size_overrides` (only used when `use_pool=True`) lets entry points
     shrink the per-worker pool below the consul-configured size. Keys: "db",
     "ts", "meb". Each value is a (pool_size, max_overflow) tuple.
+
+    When `declare_incoming_queue` is True, the RabbitMQ incoming listens queue
+    and its binding are declared during startup. This is intended for the main
+    web/API app so fanout publishes cannot happen before the queue exists.
     """
 
     app = CustomFlask(import_name=__name__)
@@ -228,7 +238,7 @@ def create_app(debug=None, bypass_pgbouncer=False, use_pool=False, pool_size_ove
     # RabbitMQ connection
     from listenbrainz.webserver.rabbitmq_connection import init_rabbitmq_connection
     try:
-        init_rabbitmq_connection(app)
+        init_rabbitmq_connection(app, declare_incoming_queue=declare_incoming_queue)
     except ConnectionError:
         app.logger.critical("RabbitMQ service is not up!", exc_info=True)
 
@@ -313,7 +323,7 @@ def init_admin(app):
 
 def create_web_app(debug=None):
     """ Generate a Flask app for LB with all configurations done, connections established and endpoints added."""
-    app = create_app(debug=debug, use_pool=True)
+    app = create_app(debug=debug, use_pool=True, declare_incoming_queue=True)
     htmx = HTMX(app)
 
     # Static files

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -34,6 +34,6 @@ def init_rabbitmq_connection(app):
     connection = create_rabbitmq_connection(app.config).ensure_connection(max_retries=CONNECTION_RETRIES)
     pools.set_limit(CONNECTION_LIMIT)
 
-    INCOMING_EXCHANGE = Exchange(app.config["INCOMING_EXCHANGE"], "fanout", durable=False)
-    PLAYING_NOW_EXCHANGE = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=False)
+    INCOMING_EXCHANGE = Exchange(app.config["INCOMING_EXCHANGE"], "fanout", durable=True)
+    PLAYING_NOW_EXCHANGE = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=True)
     rabbitmq = producers[connection]

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -3,17 +3,28 @@ from typing import Optional
 from kombu import pools, producers, Exchange
 from kombu.pools import ProducerPool
 
-from listenbrainz.rabbitmq import create_rabbitmq_connection
+from listenbrainz.rabbitmq import create_rabbitmq_connection, get_incoming_exchange, get_incoming_queue
 
 rabbitmq: Optional[ProducerPool] = None
 INCOMING_EXCHANGE: Optional[Exchange] = None
 PLAYING_NOW_EXCHANGE: Optional[Exchange] = None
+incoming_queue_declared = False
 
 CONNECTION_RETRIES = 10
 CONNECTION_LIMIT = 25
 
 
-def init_rabbitmq_connection(app):
+def _declare_incoming_queue(app, channel):
+    global incoming_queue_declared
+
+    if incoming_queue_declared:
+        return
+
+    get_incoming_queue(app.config).declare(channel=channel)
+    incoming_queue_declared = True
+
+
+def init_rabbitmq_connection(app, declare_incoming_queue=False):
     """Initialize the webserver rabbitmq connection.
 
     This initializes _rabbitmq as a connection pool from which new RabbitMQ
@@ -22,6 +33,9 @@ def init_rabbitmq_connection(app):
     global rabbitmq, INCOMING_EXCHANGE, PLAYING_NOW_EXCHANGE
 
     if rabbitmq is not None:
+        if declare_incoming_queue:
+            with rabbitmq.acquire(block=True, timeout=60) as producer:
+                _declare_incoming_queue(app, producer.channel)
         return
 
     # if RabbitMQ config values are not in the config file
@@ -34,6 +48,8 @@ def init_rabbitmq_connection(app):
     connection = create_rabbitmq_connection(app.config).ensure_connection(max_retries=CONNECTION_RETRIES)
     pools.set_limit(CONNECTION_LIMIT)
 
-    INCOMING_EXCHANGE = Exchange(app.config["INCOMING_EXCHANGE"], "fanout", durable=True)
+    INCOMING_EXCHANGE = get_incoming_exchange(app.config)
     PLAYING_NOW_EXCHANGE = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=True)
+    if declare_incoming_queue:
+        _declare_incoming_queue(app, connection.channel())
     rabbitmq = producers[connection]

--- a/listenbrainz/webserver/views/status_api.py
+++ b/listenbrainz/webserver/views/status_api.py
@@ -164,7 +164,7 @@ def get_incoming_listens_count():
     listen_count = cache.get(cache_key)
     if listen_count is None:
         try:
-            incoming_exchange = Exchange(current_app.config["INCOMING_EXCHANGE"], "fanout", durable=False)
+            incoming_exchange = Exchange(current_app.config["INCOMING_EXCHANGE"], "fanout", durable=True)
             incoming_queue = Queue(current_app.config["INCOMING_QUEUE"], exchange=incoming_exchange, durable=True)
 
             with create_rabbitmq_connection(current_app.config) as conn:

--- a/listenbrainz/websockets/listens_dispatcher.py
+++ b/listenbrainz/websockets/listens_dispatcher.py
@@ -20,8 +20,8 @@ class ListensDispatcher(ConsumerMixin):
         # we create the other channel here. we also need to handle its cleanup later
         self.playing_now_channel = None
 
-        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=False)
-        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=False)
+        self.unique_exchange = Exchange(app.config["UNIQUE_EXCHANGE"], "fanout", durable=True)
+        self.playing_now_exchange = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=True)
         self.websockets_queue = Queue(app.config["WEBSOCKETS_QUEUE"], exchange=self.unique_exchange, durable=True)
         self.playing_now_queue = Queue(app.config["PLAYING_NOW_QUEUE"], exchange=self.playing_now_exchange,
                                        durable=True)

--- a/listenbrainz_spark/rabbitmq.py
+++ b/listenbrainz_spark/rabbitmq.py
@@ -1,12 +1,10 @@
-from urllib.parse import quote
-
 from kombu import Connection
 
 
 def _rabbitmq_url(host, port, config):
-    username = quote(str(config.RABBITMQ_USERNAME), safe="")
-    password = quote(str(config.RABBITMQ_PASSWORD), safe="")
-    vhost = quote(str(config.RABBITMQ_VHOST), safe="")
+    username = config.RABBITMQ_USERNAME
+    password = config.RABBITMQ_PASSWORD
+    vhost = config.RABBITMQ_VHOST
     return f"amqp://{username}:{password}@{host}:{port}/{vhost}"
 
 

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -41,9 +41,9 @@ class RequestConsumer(ConsumerProducerMixin):
     def __init__(self):
         self.connection = None
 
-        self.spark_result_exchange = Exchange(config.SPARK_RESULT_EXCHANGE, "fanout", durable=False)
+        self.spark_result_exchange = Exchange(config.SPARK_RESULT_EXCHANGE, "fanout", durable=True)
         self.spark_result_queue = Queue(config.SPARK_REQUEST_QUEUE, exchange=self.spark_result_exchange, durable=True)
-        self.spark_request_exchange = Exchange(config.SPARK_REQUEST_EXCHANGE, "fanout", durable=False)
+        self.spark_request_exchange = Exchange(config.SPARK_REQUEST_EXCHANGE, "fanout", durable=True)
         self.spark_request_queue = Queue(config.SPARK_REQUEST_QUEUE, exchange=self.spark_request_exchange, durable=True)
 
     def get_result(self, request):


### PR DESCRIPTION
1. Make RabbitMQ exchanges and queues durable
2. Move incoming listens to a quorum queue
3. Ensure incoming queue is declared the web container to avoid lost listens