### PR TITLE
Declare RMQ queues on publish and enable publisher confirms

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -181,7 +181,8 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
             exchange=self.unique_exchange,
             routing_key="",
             body=orjson.dumps([listen.to_json() for listen in unique]).decode("utf-8"),
-            delivery_mode=PERSISTENT_DELIVERY_MODE
+            delivery_mode=PERSISTENT_DELIVERY_MODE,
+            declare=[self.unique_exchange, self.unique_queue]
         )
 
         if monotonic() > self.metric_submission_time:

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -96,7 +96,6 @@ def create_app(
         bypass_pgbouncer=False,
         use_pool=False,
         pool_size_overrides=None,
-        declare_incoming_queue=False,
 ):
     """ Generate a Flask app for LB with all configurations done and connections established.
 
@@ -115,10 +114,6 @@ def create_app(
     `pool_size_overrides` (only used when `use_pool=True`) lets entry points
     shrink the per-worker pool below the consul-configured size. Keys: "db",
     "ts", "meb". Each value is a (pool_size, max_overflow) tuple.
-
-    When `declare_incoming_queue` is True, the RabbitMQ incoming listens queue
-    and its binding are declared during startup. This is intended for the main
-    web/API app so fanout publishes cannot happen before the queue exists.
     """
 
     app = CustomFlask(import_name=__name__)
@@ -238,7 +233,7 @@ def create_app(
     # RabbitMQ connection
     from listenbrainz.webserver.rabbitmq_connection import init_rabbitmq_connection
     try:
-        init_rabbitmq_connection(app, declare_incoming_queue=declare_incoming_queue)
+        init_rabbitmq_connection(app)
     except ConnectionError:
         app.logger.critical("RabbitMQ service is not up!", exc_info=True)
 
@@ -323,7 +318,7 @@ def init_admin(app):
 
 def create_web_app(debug=None):
     """ Generate a Flask app for LB with all configurations done, connections established and endpoints added."""
-    app = create_app(debug=debug, use_pool=True, declare_incoming_queue=True)
+    app = create_app(debug=debug, use_pool=True)
     htmx = HTMX(app)
 
     # Static files

--- a/listenbrainz/webserver/rabbitmq_connection.py
+++ b/listenbrainz/webserver/rabbitmq_connection.py
@@ -1,41 +1,33 @@
 from typing import Optional
 
-from kombu import pools, producers, Exchange
+from kombu import pools, producers, Exchange, Queue
 from kombu.pools import ProducerPool
 
 from listenbrainz.rabbitmq import create_rabbitmq_connection, get_incoming_exchange, get_incoming_queue
 
 rabbitmq: Optional[ProducerPool] = None
 INCOMING_EXCHANGE: Optional[Exchange] = None
+INCOMING_QUEUE: Optional[Queue] = None
 PLAYING_NOW_EXCHANGE: Optional[Exchange] = None
-incoming_queue_declared = False
 
 CONNECTION_RETRIES = 10
 CONNECTION_LIMIT = 25
 
 
-def _declare_incoming_queue(app, channel):
-    global incoming_queue_declared
-
-    if incoming_queue_declared:
-        return
-
-    get_incoming_queue(app.config).declare(channel=channel)
-    incoming_queue_declared = True
-
-
-def init_rabbitmq_connection(app, declare_incoming_queue=False):
+def init_rabbitmq_connection(app):
     """Initialize the webserver rabbitmq connection.
 
-    This initializes _rabbitmq as a connection pool from which new RabbitMQ
-    connections can be acquired.
+    This initializes ``rabbitmq`` as a connection pool from which new RabbitMQ
+    producers can be acquired. ``confirm_publish`` is enabled on the connection so
+    every publish waits for a broker acknowledgement; this lets ``publish_data_to_queue``
+    retry/fail loudly instead of silently dropping listens. The incoming queue is no
+    longer declared here at startup: producers declare it themselves on publish (see
+    ``publish_data_to_queue``) so that every entry point writing listens (web, api_compat,
+    spotify/lastfm importers, ...) guarantees the queue and its binding exist.
     """
-    global rabbitmq, INCOMING_EXCHANGE, PLAYING_NOW_EXCHANGE
+    global rabbitmq, INCOMING_EXCHANGE, INCOMING_QUEUE, PLAYING_NOW_EXCHANGE
 
     if rabbitmq is not None:
-        if declare_incoming_queue:
-            with rabbitmq.acquire(block=True, timeout=60) as producer:
-                _declare_incoming_queue(app, producer.channel)
         return
 
     # if RabbitMQ config values are not in the config file
@@ -45,11 +37,13 @@ def init_rabbitmq_connection(app, declare_incoming_queue=False):
         app.logger.critical("RabbitMQ hosts not defined, cannot create RabbitMQ connection...")
         raise ConnectionError("RabbitMQ service is not up!")
 
-    connection = create_rabbitmq_connection(app.config).ensure_connection(max_retries=CONNECTION_RETRIES)
+    connection = create_rabbitmq_connection(
+        app.config,
+        transport_options={"confirm_publish": True},
+    ).ensure_connection(max_retries=CONNECTION_RETRIES)
     pools.set_limit(CONNECTION_LIMIT)
 
     INCOMING_EXCHANGE = get_incoming_exchange(app.config)
+    INCOMING_QUEUE = get_incoming_queue(app.config)
     PLAYING_NOW_EXCHANGE = Exchange(app.config["PLAYING_NOW_EXCHANGE"], "fanout", durable=True)
-    if declare_incoming_queue:
-        _declare_incoming_queue(app, connection.channel())
     rabbitmq = producers[connection]

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -121,11 +121,24 @@ def _send_listens_to_queue(listen_type, listens):
     if submit:
         if listen_type == LISTEN_TYPE_PLAYING_NOW:
             exchange = rabbitmq_connection.PLAYING_NOW_EXCHANGE
+            # playing_now is fire-and-forget: it is fine for the message to be dropped
+            # if no dispatcher is listening, so we only declare the exchange and don't
+            # require the message to be routable.
+            declare = [exchange]
+            mandatory = False
         else:
             exchange = rabbitmq_connection.INCOMING_EXCHANGE
+            # Declaring the queue also declares the incoming exchange and binds the two,
+            # so any producer (web, api_compat, spotify/lastfm importers, ...) guarantees
+            # the queue exists and is bound before publishing. Together with mandatory and
+            # the connection's publisher confirms this prevents silently dropping listens
+            # into an unrouted fanout exchange. kombu's maybe_declare caches the
+            # declaration per connection, so this is cheap after the first publish.
+            declare = [rabbitmq_connection.INCOMING_QUEUE]
+            mandatory = True
 
         for chunk in chunked(submit, MAX_LISTENS_PER_RMQ_MESSAGE):
-            publish_data_to_queue(chunk, exchange)
+            publish_data_to_queue(chunk, exchange, declare=declare, mandatory=mandatory)
 
 
 def _raise_error_if_has_unicode_null(value, listen):
@@ -366,12 +379,18 @@ def validate_listened_at(listen):
                                     "should be greater than 1033410600 (2002-10-01 00:00:00 UTC).", listen)
 
 
-def publish_data_to_queue(data, exchange):
-    """ Publish specified data to the specified queue.
+def publish_data_to_queue(data, exchange, declare, mandatory=False):
+    """ Publish specified data to the specified exchange.
 
     Args:
         data: the data to be published
-        exchange: the name of the exchange
+        exchange: the exchange to publish to
+        declare: the list of entities (exchanges/queues) to declare before publishing.
+            Declaring a queue also declares its exchange and binding, ensuring the
+            message is routable.
+        mandatory: if True, ask the broker to return the message if it cannot be routed
+            to any queue. Combined with the connection's publisher confirms, this surfaces
+            lost listens instead of silently dropping them.
     """
     try:
         with rabbitmq_connection.rabbitmq.acquire(block=True, timeout=60) as producer:
@@ -380,9 +399,10 @@ def publish_data_to_queue(data, exchange):
                 routing_key='',
                 body=orjson.dumps(data),
                 delivery_mode=PERSISTENT_DELIVERY_MODE,
+                mandatory=mandatory,
                 retry=True,
                 retry_policy={"max_retries": 5},
-                declare=[exchange]
+                declare=declare
             )
     except Exception:
         current_app.logger.error("Cannot publish to rabbitmq channel:", exc_info=True)


### PR DESCRIPTION
Listens were published into the `incoming` fanout exchange relying on the queue already existing. Only the main web app declared the incoming queue at startup (via the declare_incoming_queue flag); api_compat and the spotify/lastfm importers create their app without it, so they could silently drop listens into an unrouted exchange. The timescale writer also crashed publishing unique listens with "NOT_FOUND - no exchange 'unique'" because it never declared the unique exchange.

Move queue declaration into the publish path instead of per-entry-point startup. publish_data_to_queue now declares the incoming queue (which also declares its exchange and binding) so every producer guarantees a routable queue before publishing. kombu's maybe_declare caches this per connection, so it's a one-time declare per connection, not per publish.

Enable confirm_publish on the producer connection and publish incoming listens with mandatory=True so unroutable/lost listens raise loudly (surfaced as APIServiceUnavailable) instead of vanishing. Declare the unique exchange/queue in the timescale writer to fix the NOT_FOUND error. Remove the now-unused declare_incoming_queue startup flag.