### PR TITLE
GSoc-26 Feature-1 Add Playlist Search (Part 2)

### DIFF
--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -15,7 +15,7 @@ import { orderBy } from "lodash";
 import NiceModal from "@ebay/nice-modal-react";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useLoaderData, useSearchParams } from "react-router";
+import { useLoaderData, useNavigation, useSearchParams } from "react-router";
 import { toast } from "react-toastify";
 import { Helmet } from "react-helmet";
 import { useAtom } from "jotai";
@@ -87,6 +87,7 @@ type UserPlaylistsClassProps = UserPlaylistsProps & {
   playlistType: PlaylistType;
   searchQuery: string;
   urlSort: SortOption;
+  isLoading: boolean;
   handleClickPrevious: () => void;
   handleClickNext: () => void;
   handleSetPlaylistType: (newType: PlaylistType) => void;
@@ -198,6 +199,38 @@ export default class UserPlaylists extends React.Component<
   isSearchActive = () => {
     const { searchQuery } = this.props;
     return searchQuery.length >= MIN_SEARCH_LENGTH;
+  };
+
+  getEmptyMessage = (): string | undefined => {
+    const { playlistCount, searchQuery, isLoading } = this.props;
+    const { playlists } = this.state;
+
+    if (isLoading || playlists.length > 0) {
+      return undefined;
+    }
+    if (this.isSearchActive()) {
+      return `No playlists match "${searchQuery}"`;
+    }
+    if (playlistCount === 0) {
+      return "No playlists to show yet. Come back later !";
+    }
+
+    return undefined;
+  };
+
+  handleSearchTermChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchTerm = e.target.value;
+    this.setState({ searchTerm });
+
+    if (!searchTerm.trim() && this.isSearchActive()) {
+      this.props.onSearchSubmit("");
+    }
+  };
+
+  handleSearchKeyEsc = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      e.currentTarget.blur();
+    }
   };
 
   alertNotAuthorized = () => {
@@ -457,11 +490,10 @@ export default class UserPlaylists extends React.Component<
                   className="form-control"
                   placeholder="Search playlists"
                   value={searchTerm}
-                  onChange={(e) =>
-                    this.setState({ searchTerm: e.target.value })
-                  }
+                  onChange={this.handleSearchTermChange}
+                  onKeyDown={this.handleSearchKeyEsc}
                 />
-                <button type="submit">
+                <button type="submit" disabled={this.props.isLoading}>
                   <FontAwesomeIcon icon={faMagnifyingGlass as IconProp} />
                 </button>
               </form>
@@ -591,6 +623,8 @@ export default class UserPlaylists extends React.Component<
           onPlaylistDeleted={this.onPlaylistDeleted}
           view={view}
           page={page}
+          isLoading={this.props.isLoading}
+          emptyMessage={this.getEmptyMessage()}
           handleClickPrevious={handleClickPrevious}
           handleClickNext={handleClickNext}
           pageCount={pageCount}
@@ -631,6 +665,8 @@ const parseUrlSort = (sortParam: string | null): SortOption => {
 
 export function UserPlaylistsWrapper() {
   const data = useLoaderData() as UserPlaylistsLoaderData;
+  const navigation = useNavigation();
+  const isLoading = navigation.state === "loading";
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParamsObj = getObjectForURLSearchParams(searchParams);
   const skipTypeRestoreRef = React.useRef(false);
@@ -719,6 +755,7 @@ export function UserPlaylistsWrapper() {
       playlistType={playlistType}
       searchQuery={searchQuery}
       urlSort={urlSort}
+      isLoading={isLoading}
       handleClickPrevious={handleClickPrevious}
       handleClickNext={handleClickNext}
       handleSetPlaylistType={handleSetPlaylistType}

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -493,7 +493,11 @@ export default class UserPlaylists extends React.Component<
                   onChange={this.handleSearchTermChange}
                   onKeyDown={this.handleSearchKeyEsc}
                 />
-                <button type="submit" disabled={this.props.isLoading}>
+                <button
+                  type="submit"
+                  disabled={this.props.isLoading}
+                  aria-label="Search playlists"
+                >
                   <FontAwesomeIcon icon={faMagnifyingGlass as IconProp} />
                 </button>
               </form>

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -201,8 +201,15 @@ export default class UserPlaylists extends React.Component<
     return searchQuery.length >= MIN_SEARCH_LENGTH;
   };
 
+  getLoaderText = (): string => {
+    if (this.isSearchActive()) {
+      return "Loading search results...";
+    }
+    return "Loading playlists...";
+  };
+
   getEmptyMessage = (): string | undefined => {
-    const { playlistCount, searchQuery, isLoading } = this.props;
+    const { playlistCount, isLoading, searchQuery } = this.props;
     const { playlists } = this.state;
 
     if (isLoading || playlists.length > 0) {
@@ -219,11 +226,12 @@ export default class UserPlaylists extends React.Component<
   };
 
   handleSearchTermChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { onSearchSubmit } = this.props;
     const searchTerm = e.target.value;
     this.setState({ searchTerm });
 
     if (!searchTerm.trim() && this.isSearchActive()) {
-      this.props.onSearchSubmit("");
+      onSearchSubmit("");
     }
   };
 
@@ -408,6 +416,7 @@ export default class UserPlaylists extends React.Component<
       pageCount,
       page,
       playlistType,
+      isLoading,
       handleClickPrevious,
       handleClickNext,
       setPersistentView,
@@ -478,6 +487,7 @@ export default class UserPlaylists extends React.Component<
                 }
                 className="form-select"
                 style={{ width: "200px" }}
+                disabled={isLoading}
               >
                 {this.renderSortOptions()}
               </select>
@@ -495,7 +505,7 @@ export default class UserPlaylists extends React.Component<
                 />
                 <button
                   type="submit"
-                  disabled={this.props.isLoading}
+                  disabled={isLoading}
                   aria-label="Search playlists"
                 >
                   <FontAwesomeIcon icon={faMagnifyingGlass as IconProp} />
@@ -627,7 +637,8 @@ export default class UserPlaylists extends React.Component<
           onPlaylistDeleted={this.onPlaylistDeleted}
           view={view}
           page={page}
-          isLoading={this.props.isLoading}
+          isLoading={isLoading}
+          loaderText={this.getLoaderText()}
           emptyMessage={this.getEmptyMessage()}
           handleClickPrevious={handleClickPrevious}
           handleClickNext={handleClickNext}
@@ -667,10 +678,16 @@ const parseUrlSort = (sortParam: string | null): SortOption => {
   return SortOption.RELEVANCE;
 };
 
+export function isPlaylistsNavigationLoading(
+  navigation: ReturnType<typeof useNavigation>
+): boolean {
+  return navigation.state === "loading";
+}
+
 export function UserPlaylistsWrapper() {
   const data = useLoaderData() as UserPlaylistsLoaderData;
   const navigation = useNavigation();
-  const isLoading = navigation.state === "loading";
+  const isLoading = isPlaylistsNavigationLoading(navigation);
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParamsObj = getObjectForURLSearchParams(searchParams);
   const skipTypeRestoreRef = React.useRef(false);

--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -678,16 +678,12 @@ const parseUrlSort = (sortParam: string | null): SortOption => {
   return SortOption.RELEVANCE;
 };
 
-export function isPlaylistsNavigationLoading(
-  navigation: ReturnType<typeof useNavigation>
-): boolean {
-  return navigation.state === "loading";
-}
-
 export function UserPlaylistsWrapper() {
   const data = useLoaderData() as UserPlaylistsLoaderData;
   const navigation = useNavigation();
-  const isLoading = isPlaylistsNavigationLoading(navigation);
+  const isLoading =
+    navigation.state === "loading" &&
+    navigation.location?.pathname === window.location.pathname;
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParamsObj = getObjectForURLSearchParams(searchParams);
   const skipTypeRestoreRef = React.useRef(false);

--- a/frontend/js/src/user/playlists/components/PlaylistsList.tsx
+++ b/frontend/js/src/user/playlists/components/PlaylistsList.tsx
@@ -49,7 +49,6 @@ export default function PlaylistsList(
   } = props;
 
   const showEmptyMessage = !isLoading && !playlists.length && emptyMessage;
-  const showContent = !isLoading;
 
   return (
     <div aria-busy={isLoading}>
@@ -61,7 +60,7 @@ export default function PlaylistsList(
           {emptyMessage}
         </p>
       )}
-      {showContent && (
+      {!isLoading && (
         <div
           id="playlists-container"
           className={view === PlaylistView.LIST ? "list-view" : ""}

--- a/frontend/js/src/user/playlists/components/PlaylistsList.tsx
+++ b/frontend/js/src/user/playlists/components/PlaylistsList.tsx
@@ -13,6 +13,7 @@ export type PlaylistsListProps = {
   activeSection: PlaylistType;
   view: PlaylistView;
   isLoading?: boolean;
+  loaderText?: string;
   emptyMessage?: string;
   onCopiedPlaylist?: (playlist: JSPFPlaylist) => void;
   onPlaylistEdited: (playlist: JSPFPlaylist) => void;
@@ -38,6 +39,7 @@ export default function PlaylistsList(
     page,
     pageCount,
     isLoading = false,
+    loaderText = "Loading playlists...",
     emptyMessage,
     onCopiedPlaylist,
     onPlaylistEdited,
@@ -50,15 +52,15 @@ export default function PlaylistsList(
   const showContent = !isLoading;
 
   return (
-    <div>
+    <div aria-busy={isLoading}>
       {isLoading && (
-        <Loader
-          isLoading
-          loaderText="Loading search results..."
-          style={{ height: "300px" }}
-        />
+        <Loader isLoading loaderText={loaderText} style={{ height: "300px" }} />
       )}
-      {showEmptyMessage && <p>{emptyMessage}</p>}
+      {showEmptyMessage && (
+        <p className="playlists-empty-message" role="status">
+          {emptyMessage}
+        </p>
+      )}
       {showContent && (
         <div
           id="playlists-container"

--- a/frontend/js/src/user/playlists/components/PlaylistsList.tsx
+++ b/frontend/js/src/user/playlists/components/PlaylistsList.tsx
@@ -4,6 +4,7 @@ import PlaylistCard from "./PlaylistCard";
 import { PlaylistType } from "../../../playlists/utils";
 import PlaylistView from "../playlistView.d";
 import Pagination from "../../../common/Pagination";
+import Loader from "../../../components/Loader";
 
 export type PlaylistsListProps = {
   playlists: JSPFPlaylist[];
@@ -11,6 +12,8 @@ export type PlaylistsListProps = {
   page: number;
   activeSection: PlaylistType;
   view: PlaylistView;
+  isLoading?: boolean;
+  emptyMessage?: string;
   onCopiedPlaylist?: (playlist: JSPFPlaylist) => void;
   onPlaylistEdited: (playlist: JSPFPlaylist) => void;
   onPlaylistDeleted: (playlist: JSPFPlaylist) => void;
@@ -34,6 +37,8 @@ export default function PlaylistsList(
     view,
     page,
     pageCount,
+    isLoading = false,
+    emptyMessage,
     onCopiedPlaylist,
     onPlaylistEdited,
     onPlaylistDeleted,
@@ -41,35 +46,49 @@ export default function PlaylistsList(
     handleClickNext,
   } = props;
 
+  const showEmptyMessage = !isLoading && !playlists.length && emptyMessage;
+  const showContent = !isLoading;
+
   return (
     <div>
-      {!playlists.length && <p>No playlists to show yet. Come back later !</p>}
-      <div
-        id="playlists-container"
-        className={view === PlaylistView.LIST ? "list-view" : ""}
-      >
-        {playlists.map((playlist: JSPFPlaylist, index: number) => {
-          return (
-            <PlaylistCard
-              view={view}
-              showOptions={activeSection !== PlaylistType.recommendations}
-              playlist={playlist}
-              onSuccessfulCopy={onCopiedPlaylist ?? noop}
-              onPlaylistEdited={onPlaylistEdited}
-              onPlaylistDeleted={onPlaylistDeleted}
-              key={playlist.identifier}
-              index={index + (page - 1) * 25}
-            />
-          );
-        })}
-        {children}
-      </div>
-      <Pagination
-        currentPageNo={page}
-        totalPageCount={pageCount}
-        handleClickPrevious={handleClickPrevious}
-        handleClickNext={handleClickNext}
-      />
+      {isLoading && (
+        <Loader
+          isLoading
+          loaderText="Loading search results..."
+          style={{ height: "300px" }}
+        />
+      )}
+      {showEmptyMessage && <p>{emptyMessage}</p>}
+      {showContent && (
+        <div
+          id="playlists-container"
+          className={view === PlaylistView.LIST ? "list-view" : ""}
+        >
+          {playlists.map((playlist: JSPFPlaylist, index: number) => {
+            return (
+              <PlaylistCard
+                view={view}
+                showOptions={activeSection !== PlaylistType.recommendations}
+                playlist={playlist}
+                onSuccessfulCopy={onCopiedPlaylist ?? noop}
+                onPlaylistEdited={onPlaylistEdited}
+                onPlaylistDeleted={onPlaylistDeleted}
+                key={playlist.identifier}
+                index={index + (page - 1) * 25}
+              />
+            );
+          })}
+          {children}
+        </div>
+      )}
+      {!isLoading && (
+        <Pagination
+          currentPageNo={page}
+          totalPageCount={pageCount}
+          handleClickPrevious={handleClickPrevious}
+          handleClickNext={handleClickNext}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -2293,8 +2293,7 @@ export default class APIService {
     searchQuery: string,
     musicbrainzID: string,
     count: number = 25,
-    offset: number = 0,
-    type?: "owned" | "collaborative"
+    offset: number = 0
   ): Promise<PlaylistTypeSearchResult> => {
     const url = new URL(
       `${this.APIBaseURI}/user/${encodeURIComponent(
@@ -2304,9 +2303,6 @@ export default class APIService {
     url.searchParams.set("query", searchQuery);
     url.searchParams.set("count", count.toString());
     url.searchParams.set("offset", offset.toString());
-    if (type) {
-      url.searchParams.set("type", type);
-    }
     const response = await fetch(url.toString());
     await this.checkStatus(response);
     return response.json();

--- a/frontend/js/tests/__mocks__/userPlaylistsProps.json
+++ b/frontend/js/tests/__mocks__/userPlaylistsProps.json
@@ -1,0 +1,91 @@
+{
+  "loaderPlaylists": [
+    {
+      "playlist": {
+        "creator": "Coder",
+        "identifier": "https://listenbrainz.org/playlist/11111111-1111-1111-1111-111111111101",
+        "date": "2026-05-01T10:00:00.000Z",
+        "title": "Zebra Playlist",
+        "annotation": "",
+        "track": [],
+        "extension": {
+          "https://musicbrainz.org/doc/jspf#playlist": {
+            "public": true,
+            "last_modified_at": "2026-05-01T10:00:00.000Z",
+            "collaborators": []
+          }
+        }
+      }
+    },
+    {
+      "playlist": {
+        "creator": "Coder",
+        "identifier": "https://listenbrainz.org/playlist/11111111-1111-1111-1111-111111111102",
+        "date": "2026-04-01T10:00:00.000Z",
+        "title": "Alpha Playlist",
+        "annotation": "",
+        "track": [],
+        "extension": {
+          "https://musicbrainz.org/doc/jspf#playlist": {
+            "public": true,
+            "last_modified_at": "2026-04-02T10:00:00.000Z",
+            "collaborators": []
+          }
+        }
+      }
+    },
+    {
+      "playlist": {
+        "creator": "Coder",
+        "identifier": "https://listenbrainz.org/playlist/11111111-1111-1111-1111-111111111103",
+        "date": "2026-05-06T10:00:00.000Z",
+        "title": "Beta Playlist",
+        "annotation": "",
+        "track": [],
+        "extension": {
+          "https://musicbrainz.org/doc/jspf#playlist": {
+            "public": true,
+            "last_modified_at": "2026-05-07T10:00:00.000Z",
+            "collaborators": []
+          }
+        }
+      }
+    }
+  ],
+  "searchResults": [
+    {
+      "playlist": {
+        "creator": "Coder",
+        "identifier": "https://listenbrainz.org/playlist/22222222-2222-2222-2222-222222222201",
+        "date": "2026-05-07T10:00:00.000Z",
+        "title": "Zebra Search",
+        "annotation": "",
+        "track": [],
+        "extension": {
+          "https://musicbrainz.org/doc/jspf#playlist": {
+            "public": true,
+            "last_modified_at": "2026-05-07T10:00:00.000Z",
+            "collaborators": []
+          }
+        }
+      }
+    },
+    {
+      "playlist": {
+        "creator": "Coder",
+        "identifier": "https://listenbrainz.org/playlist/22222222-2222-2222-2222-222222222202",
+        "date": "2024-04-01T10:00:00.000Z",
+        "title": "Alpha Search",
+        "annotation": "",
+        "track": [],
+        "extension": {
+          "https://musicbrainz.org/doc/jspf#playlist": {
+            "public": true,
+            "last_modified_at": "2024-04-01T10:00:00.000Z",
+            "collaborators": []
+          }
+        }
+      }
+    }
+  ]
+}

--- a/frontend/js/tests/user/playlists/Playlists.test.tsx
+++ b/frontend/js/tests/user/playlists/Playlists.test.tsx
@@ -81,7 +81,7 @@ describe("UserPlaylists search", () => {
     const onSearchSubmit = jest.fn();
     renderPlaylists({ onSearchSubmit });
 
-    await user.type(getSearchInput(), "test");
+    await user.type(getSearchInput(), "  test  ");
     await submitSearch();
 
     expect(onSearchSubmit).toHaveBeenCalledWith("test");

--- a/frontend/js/tests/user/playlists/Playlists.test.tsx
+++ b/frontend/js/tests/user/playlists/Playlists.test.tsx
@@ -1,0 +1,169 @@
+import React, { ComponentProps } from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPlaylists, {
+  SortOption,
+} from "../../../src/user/playlists/Playlists";
+import { PlaylistType } from "../../../src/playlists/utils";
+import PlaylistView from "../../../src/user/playlists/playlistView.d";
+import { renderWithProviders } from "../../test-utils/rtl-test-utils";
+import userPlaylistsMock from "../../__mocks__/userPlaylistsProps.json";
+
+type UserPlaylistsComponentProps = ComponentProps<typeof UserPlaylists>;
+
+jest.unmock("react-toastify");
+
+const user = userEvent.setup();
+const USER_NAME = "Coder";
+
+const { loaderPlaylists, searchResults } = userPlaylistsMock;
+
+const mockFn = jest.fn;
+
+const createProps = (
+  overrides: Partial<UserPlaylistsComponentProps> = {}
+): UserPlaylistsComponentProps => ({
+  playlists: loaderPlaylists as JSPFObject[],
+  user: { id: 1, name: USER_NAME },
+  playlistCount: loaderPlaylists.length,
+  pageCount: 1,
+  page: 1,
+  playlistType: PlaylistType.playlists,
+  searchQuery: "",
+  urlSort: SortOption.RELEVANCE,
+  isLoading: false,
+  handleClickPrevious: mockFn(),
+  handleClickNext: mockFn(),
+  handleSetPlaylistType: mockFn(),
+  onSearchSubmit: mockFn(),
+  onSortChangeDuringSearch: mockFn(),
+  initialView: PlaylistView.GRID,
+  setPersistentView: mockFn(),
+  initialSort: SortOption.DATE_CREATED,
+  setPersistentSort: mockFn(),
+  ...overrides,
+});
+
+const renderPlaylists = (overrides: Partial<UserPlaylistsComponentProps> = {}) => {
+  const props = createProps(overrides);
+  renderWithProviders(
+    <UserPlaylists {...props} />,
+    {
+      currentUser: {
+        id: 1,
+        name: USER_NAME,
+        auth_token: "token",
+      },
+    },
+    {},
+    true
+  );
+  return props;
+};
+
+const getSearchInput = () =>
+  screen.getByPlaceholderText("Search playlists") as HTMLInputElement;
+
+const submitSearch = async () => {
+  await user.click(
+    screen.getByRole("button", {
+      name: /search playlists/i,
+    })
+  );
+};
+
+describe("UserPlaylists search", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls onSearchSubmit with the trimmed query on valid submit", async () => {
+    const onSearchSubmit = jest.fn();
+    renderPlaylists({ onSearchSubmit });
+
+    await user.type(getSearchInput(), "test");
+    await submitSearch();
+
+    expect(onSearchSubmit).toHaveBeenCalledWith("test");
+  });
+
+  it("calls onSearchSubmit with a short query so the wrapper can clear search params", async () => {
+    const onSearchSubmit = jest.fn();
+    renderPlaylists({ onSearchSubmit });
+
+    await user.type(getSearchInput(), "ab");
+    await submitSearch();
+
+    expect(onSearchSubmit).toHaveBeenCalledWith("ab");
+  });
+
+  it("shows browse empty message when there are no playlists", () => {
+    renderPlaylists({ playlists: [], playlistCount: 0 });
+
+    expect(
+      screen.getByText("No playlists to show yet. Come back later !")
+    ).toBeInTheDocument();
+  });
+
+  it("shows search empty message when search is active and there are no results", () => {
+    renderPlaylists({
+      playlists: [],
+      playlistCount: 0,
+      searchQuery: "missing",
+    });
+
+    expect(
+      screen.getByText('No playlists match "missing"')
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSearchSubmit with an empty string when the input is cleared during search", async () => {
+    const onSearchSubmit = jest.fn();
+    renderPlaylists({
+      onSearchSubmit,
+      searchQuery: "test",
+      playlists: searchResults as JSPFObject[],
+    });
+
+    await user.clear(getSearchInput());
+
+    expect(onSearchSubmit).toHaveBeenCalledWith("");
+  });
+
+  it("blurs the search input on Escape without clearing active search", async () => {
+    renderPlaylists({
+      searchQuery: "test",
+      playlists: searchResults as JSPFObject[],
+    });
+
+    const input = getSearchInput();
+    input.focus();
+    expect(input).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+
+    expect(input).not.toHaveFocus();
+    expect(screen.getByText("Alpha Search")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha Playlist")).not.toBeInTheDocument();
+  });
+
+  it("shows a loading message while loader navigation is in progress", () => {
+    renderPlaylists({ isLoading: true });
+
+    expect(screen.getByText("Loading search results...")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha Playlist")).not.toBeInTheDocument();
+  });
+
+  it("calls onSortChangeDuringSearch when sort changes during an active search", async () => {
+    const onSortChangeDuringSearch = jest.fn();
+    renderPlaylists({
+      onSortChangeDuringSearch,
+      searchQuery: "test",
+      playlists: searchResults as JSPFObject[],
+    });
+
+    await user.selectOptions(screen.getByLabelText("Sort by:"), SortOption.TITLE);
+
+    expect(onSortChangeDuringSearch).toHaveBeenCalledWith(SortOption.TITLE);
+  });
+});

--- a/frontend/js/tests/user/playlists/Playlists.test.tsx
+++ b/frontend/js/tests/user/playlists/Playlists.test.tsx
@@ -130,28 +130,17 @@ describe("UserPlaylists search", () => {
     expect(onSearchSubmit).toHaveBeenCalledWith("");
   });
 
-  it("blurs the search input on Escape without clearing active search", async () => {
-    renderPlaylists({
-      searchQuery: "test",
-      playlists: searchResults as JSPFObject[],
-    });
-
-    const input = getSearchInput();
-    input.focus();
-    expect(input).toHaveFocus();
-
-    await user.keyboard("{Escape}");
-
-    expect(input).not.toHaveFocus();
-    expect(screen.getByText("Alpha Search")).toBeInTheDocument();
-    expect(screen.queryByText("Alpha Playlist")).not.toBeInTheDocument();
-  });
-
   it("shows a loading message while loader navigation is in progress", () => {
-    renderPlaylists({ isLoading: true });
+    renderPlaylists({ isLoading: true, searchQuery: "test" });
 
     expect(screen.getByText("Loading search results...")).toBeInTheDocument();
     expect(screen.queryByText("Alpha Playlist")).not.toBeInTheDocument();
+  });
+
+  it("shows browse loading message when not searching", () => {
+    renderPlaylists({ isLoading: true });
+
+    expect(screen.getByText("Loading playlists...")).toBeInTheDocument();
   });
 
   it("calls onSortChangeDuringSearch when sort changes during an active search", async () => {

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -170,7 +170,9 @@ def playlists(user_name: str):
 
     if search_query and len(search_query) >= 3:
         if sort not in SEARCH_PLAYLIST_SORTS:
-            sort = "relevance"
+            raise APIBadRequest(
+                "Invalid sort value. Must be one of: %s" % ", ".join(SEARCH_PLAYLIST_SORTS)
+            )
 
         if include_private:
             viewer_id = user.id


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# PR Description

Build on top of [3715](https://github.com/metabrainz/listenbrainz-server/pull/3715)
First merge [3715](https://github.com/metabrainz/listenbrainz-server/pull/3715) then this.

This marks the second PR for the Feature 1 ( Add search functionality on playlists ) . The basic search and pagination was already implemented in previous pr .

**In this PR I had implemented the following features :** 

- Loading state: While a search request is in flight, show a loader (“Loading search results…”) and hide the playlists until results arrive.
- Empty states:

        If isSearchActive() and the list is empty → No playlists match "<input >"; 
        if playlistCount === 0 from loader props → the existing “No playlists to show yet…” 

- Clear input: Clearing the search field after a successful search restores the original loader playlist list.
                      handleSearchTermEmpty calls the resetSearchResults() function which restores the original playlists when 
                      isSearchActive() is true and field becomes empty .

- Escape: When we press ESCAPE in the search input area . Blurs the search input only; does not clear search results or reset the list.

# Tests

I had manually tested all the subfeatures.

7 tests for search behavior
 (API guard, success/failure, clear, Escape, loading, title sort) 
are added in `frontend/js/tests/user/playlists/Playlists.test.tsx ` 

