### PR TITLE
Add schema and builder for events cache

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,8 +37,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Create configuration file
-      run: cp listenbrainz/config.py.sample listenbrainz/config.py
+    - name: Create configuration files
+      run: |
+        cp listenbrainz/config.py.sample listenbrainz/config.py
+        cp mbid_mapping/config.py.sample mbid_mapping/config.py
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -40,6 +40,15 @@ CREATE INDEX mb_metadata_cache_idx_artist_mbids ON mapping.mb_metadata_cache USI
 CREATE INDEX mb_metadata_cache_idx_artist_ids ON mapping.mb_metadata_cache USING gin(artist_ids);
 CREATE INDEX mb_metadata_cache_idx_dirty ON mapping.mb_metadata_cache (dirty);
 
+CREATE UNIQUE INDEX mb_event_cache_idx_event_id ON mapping.mb_event_cache (event_id);
+CREATE INDEX mb_event_cache_idx_date ON mapping.mb_event_cache (begin_date_year, begin_date_month, begin_date_day);
+CREATE INDEX mb_event_cache_idx_dirty ON mapping.mb_event_cache (dirty);
+
+CREATE INDEX mb_event_artist_cache_idx_artist_id_event_id ON mapping.mb_event_artist_cache (artist_id, event_id);
+CREATE INDEX mb_event_artist_cache_idx_artist_mbid ON mapping.mb_event_artist_cache (artist_mbid);
+CREATE INDEX mb_event_artist_cache_idx_event_id ON mapping.mb_event_artist_cache (event_id);
+CREATE INDEX mb_event_artist_cache_idx_link_type_gid ON mapping.mb_event_artist_cache (link_type_gid);
+
 CREATE UNIQUE INDEX recording_msid_ndx_mbid_mapping ON mbid_mapping (recording_msid);
 CREATE INDEX recording_mbid_ndx_mbid_mapping ON mbid_mapping (recording_mbid);
 CREATE INDEX match_type_ndx_mbid_mapping ON mbid_mapping (match_type);

--- a/admin/timescale/create_primary_keys.sql
+++ b/admin/timescale/create_primary_keys.sql
@@ -4,6 +4,8 @@ ALTER TABLE playlist.playlist ADD CONSTRAINT playlist_pkey PRIMARY KEY (id);
 ALTER TABLE playlist.playlist_recording ADD CONSTRAINT playlist_recording_pkey PRIMARY KEY (id);
 ALTER TABLE mbid_mapping_metadata ADD CONSTRAINT mbid_mapping_metadata_pkey PRIMARY KEY (recording_mbid);
 ALTER TABLE mapping.mb_metadata_cache ADD CONSTRAINT mb_metadata_cache_pkey PRIMARY KEY (recording_mbid);
+ALTER TABLE mapping.mb_event_cache ADD CONSTRAINT mb_event_cache_pkey PRIMARY KEY (event_mbid);
+ALTER TABLE mapping.mb_event_artist_cache ADD CONSTRAINT mb_event_artist_cache_pkey PRIMARY KEY (event_id, artist_id, link_id);
 ALTER TABLE background_worker_state ADD CONSTRAINT background_worker_state_pkey PRIMARY KEY (key);
 
 ALTER TABLE statistics.year_in_music_cover ADD CONSTRAINT year_in_music_cover_pkey PRIMARY KEY (id);

--- a/admin/timescale/create_primary_keys.sql
+++ b/admin/timescale/create_primary_keys.sql
@@ -5,7 +5,7 @@ ALTER TABLE playlist.playlist_recording ADD CONSTRAINT playlist_recording_pkey P
 ALTER TABLE mbid_mapping_metadata ADD CONSTRAINT mbid_mapping_metadata_pkey PRIMARY KEY (recording_mbid);
 ALTER TABLE mapping.mb_metadata_cache ADD CONSTRAINT mb_metadata_cache_pkey PRIMARY KEY (recording_mbid);
 ALTER TABLE mapping.mb_event_cache ADD CONSTRAINT mb_event_cache_pkey PRIMARY KEY (event_mbid);
-ALTER TABLE mapping.mb_event_artist_cache ADD CONSTRAINT mb_event_artist_cache_pkey PRIMARY KEY (event_id, artist_id, link_id);
+ALTER TABLE mapping.mb_event_artist_cache ADD CONSTRAINT mb_event_artist_cache_pkey PRIMARY KEY (event_id, artist_id, link_id, link_order);
 ALTER TABLE background_worker_state ADD CONSTRAINT background_worker_state_pkey PRIMARY KEY (key);
 
 ALTER TABLE statistics.year_in_music_cover ADD CONSTRAINT year_in_music_cover_pkey PRIMARY KEY (id);

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -166,7 +166,7 @@ CREATE TABLE mapping.mb_event_cache (
     area_mbid            UUID,
     rating               SMALLINT,
     rating_count         INTEGER,
-    event_data           JSONB NOT NULL DEFAULT '{}'::jsonb
+    event_data           JSONB NOT NULL
 );
 
 CREATE TABLE mapping.mb_event_artist_cache (
@@ -177,7 +177,7 @@ CREATE TABLE mapping.mb_event_artist_cache (
     link_id              INTEGER NOT NULL,
     link_type_gid        UUID NOT NULL,  
     link_type_name       TEXT NOT NULL,
-    relationship_data    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    relationship_data    JSONB NOT NULL,
     last_updated         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -144,6 +144,41 @@ CREATE TABLE mapping.mb_artist_metadata_cache (
     release_group_data      JSONB NOT NULL
 );
 
+CREATE TABLE mapping.mb_event_cache (
+    dirty                BOOLEAN DEFAULT FALSE,
+    last_updated         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    event_mbid           UUID NOT NULL,
+    event_id             INTEGER NOT NULL,
+    event_name           TEXT NOT NULL,
+    begin_date_year      SMALLINT,
+    begin_date_month     SMALLINT,
+    begin_date_day       SMALLINT,
+    end_date_year        SMALLINT,
+    end_date_month       SMALLINT,
+    end_date_day         SMALLINT,
+    event_time           TIMESTAMPTZ,
+    cancelled            BOOLEAN NOT NULL DEFAULT FALSE,
+    ended                BOOLEAN NOT NULL DEFAULT FALSE,
+    event_type_gid       UUID,
+    event_art_presence   TEXT NOT NULL DEFAULT 'absent',
+    place_mbid           UUID,
+    place_name           TEXT,
+    area_mbid            UUID,
+    event_data           JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE mapping.mb_event_artist_cache (
+    event_mbid           UUID NOT NULL,
+    event_id             INTEGER NOT NULL,
+    artist_mbid          UUID NOT NULL,
+    artist_id            INTEGER NOT NULL,
+    link_id              INTEGER NOT NULL,
+    link_type_gid        UUID NOT NULL,  
+    link_type_name       TEXT NOT NULL,
+    relationship_data    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    last_updated         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 -- the various mapping columns should only be null if the match_type is no_match, otherwise the columns should be
 -- non null. we have had bugs where we completely forgot to insert values for a column and it went unchecked because
 -- it is not possible to mark the column as NOT NULL. however, we can use this constraint to enforce the NOT NULL

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -164,6 +164,8 @@ CREATE TABLE mapping.mb_event_cache (
     place_mbid           UUID,
     place_name           TEXT,
     area_mbid            UUID,
+    rating               SMALLINT,
+    rating_count         INTEGER,
     event_data           JSONB NOT NULL DEFAULT '{}'::jsonb
 );
 

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -175,6 +175,7 @@ CREATE TABLE mapping.mb_event_artist_cache (
     artist_mbid          UUID NOT NULL,
     artist_id            INTEGER NOT NULL,
     link_id              INTEGER NOT NULL,
+    link_order           INTEGER NOT NULL DEFAULT 0,
     link_type_gid        UUID NOT NULL,  
     link_type_name       TEXT NOT NULL,
     relationship_data    JSONB NOT NULL,

--- a/admin/timescale/reset_tables.sql
+++ b/admin/timescale/reset_tables.sql
@@ -5,6 +5,8 @@ DELETE FROM listen_delete_metadata      CASCADE;
 DELETE FROM listen_user_metadata        CASCADE;
 DELETE FROM mbid_mapping                CASCADE;
 DELETE FROM mapping.mb_metadata_cache   CASCADE;
+DELETE FROM mapping.mb_event_artist_cache CASCADE;
+DELETE FROM mapping.mb_event_cache      CASCADE;
 DELETE FROM messybrainz.submissions     CASCADE;
 DELETE FROM mbid_manual_mapping         CASCADE;
 DELETE FROM playlist.playlist           CASCADE;

--- a/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
+++ b/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
@@ -1,0 +1,61 @@
+BEGIN;
+
+CREATE TABLE mapping.mb_event_cache (
+    dirty                BOOLEAN DEFAULT FALSE,
+    last_updated         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    event_mbid           UUID NOT NULL,
+    event_id             INTEGER NOT NULL,
+    event_name           TEXT NOT NULL,
+
+    begin_date_year      SMALLINT,
+    begin_date_month     SMALLINT,
+    begin_date_day       SMALLINT,
+    end_date_year        SMALLINT,
+    end_date_month       SMALLINT,
+    end_date_day         SMALLINT,
+    event_time           TIMESTAMPTZ,
+    cancelled            BOOLEAN NOT NULL DEFAULT FALSE,
+    ended                BOOLEAN NOT NULL DEFAULT FALSE,
+
+    event_type_gid       UUID,
+    event_art_presence   TEXT NOT NULL DEFAULT 'absent',
+
+    place_mbid           UUID,
+    place_name           TEXT,
+    area_mbid            UUID,
+
+    event_data           JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE mapping.mb_event_cache
+    ADD CONSTRAINT mb_event_cache_pkey PRIMARY KEY (event_mbid);
+
+CREATE UNIQUE INDEX mb_event_cache_idx_event_id ON mapping.mb_event_cache (event_id);
+CREATE INDEX mb_event_cache_idx_date ON mapping.mb_event_cache (begin_date_year, begin_date_month, begin_date_day);
+CREATE INDEX mb_event_cache_idx_dirty ON mapping.mb_event_cache (dirty);
+
+CREATE TABLE mapping.mb_event_artist_cache (
+    event_mbid           UUID NOT NULL,
+    event_id             INTEGER NOT NULL,
+    artist_mbid          UUID NOT NULL,
+    artist_id            INTEGER NOT NULL,
+
+    link_id              INTEGER NOT NULL,
+    link_type_gid        UUID NOT NULL,  
+    link_type_name       TEXT NOT NULL,
+
+    relationship_data    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    last_updated         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE mapping.mb_event_artist_cache
+    ADD CONSTRAINT mb_event_artist_cache_pkey
+    PRIMARY KEY (event_id, artist_id, link_id);
+
+CREATE INDEX mb_event_artist_cache_idx_artist_id_event_id ON mapping.mb_event_artist_cache (artist_id, event_id);
+CREATE INDEX mb_event_artist_cache_idx_artist_mbid ON mapping.mb_event_artist_cache (artist_mbid);
+CREATE INDEX mb_event_artist_cache_idx_event_id ON mapping.mb_event_artist_cache (event_id);
+CREATE INDEX mb_event_artist_cache_idx_link_type_gid ON mapping.mb_event_artist_cache (link_type_gid);
+
+COMMIT;

--- a/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
+++ b/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
@@ -28,7 +28,7 @@ CREATE TABLE mapping.mb_event_cache (
     rating               SMALLINT,
     rating_count         INTEGER,
 
-    event_data           JSONB NOT NULL DEFAULT '{}'::jsonb
+    event_data           JSONB NOT NULL
 );
 
 ALTER TABLE mapping.mb_event_cache
@@ -48,7 +48,7 @@ CREATE TABLE mapping.mb_event_artist_cache (
     link_type_gid        UUID NOT NULL,  
     link_type_name       TEXT NOT NULL,
 
-    relationship_data    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    relationship_data    JSONB NOT NULL,
     last_updated         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
+++ b/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
@@ -45,6 +45,7 @@ CREATE TABLE mapping.mb_event_artist_cache (
     artist_id            INTEGER NOT NULL,
 
     link_id              INTEGER NOT NULL,
+    link_order           INTEGER NOT NULL DEFAULT 0,
     link_type_gid        UUID NOT NULL,  
     link_type_name       TEXT NOT NULL,
 
@@ -54,7 +55,7 @@ CREATE TABLE mapping.mb_event_artist_cache (
 
 ALTER TABLE mapping.mb_event_artist_cache
     ADD CONSTRAINT mb_event_artist_cache_pkey
-    PRIMARY KEY (event_id, artist_id, link_id);
+    PRIMARY KEY (event_id, artist_id, link_id, link_order);
 
 CREATE INDEX mb_event_artist_cache_idx_artist_id_event_id ON mapping.mb_event_artist_cache (artist_id, event_id);
 CREATE INDEX mb_event_artist_cache_idx_artist_mbid ON mapping.mb_event_artist_cache (artist_mbid);

--- a/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
+++ b/admin/timescale/updates/2026-05-28-add-mb-events-cache.sql
@@ -25,6 +25,9 @@ CREATE TABLE mapping.mb_event_cache (
     place_name           TEXT,
     area_mbid            UUID,
 
+    rating               SMALLINT,
+    rating_count         INTEGER,
+
     event_data           JSONB NOT NULL DEFAULT '{}'::jsonb
 );
 

--- a/listenbrainz/db/tests/test_mb_event_metadata_cache.py
+++ b/listenbrainz/db/tests/test_mb_event_metadata_cache.py
@@ -1,0 +1,361 @@
+import datetime
+import uuid
+from psycopg2.extras import DictCursor
+
+from listenbrainz.db.testing import TimescaleTestCase
+from mbid_mapping.mapping.mb_event_metadata_cache import MusicBrainzEventMetadataCache
+from mbid_mapping.mapping.utils import insert_rows
+
+
+class TestMBEventMetadataCache(TimescaleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.cache = MusicBrainzEventMetadataCache(
+            select_conn=None, insert_conn=self.ts_conn.connection
+        )
+        self.cache.last_updated = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def test_process_row_comprehensive(self):
+        row = {
+            "area_mbid": uuid.UUID("edd27a39-ff8a-4af4-8bbf-f369b0fb1899"),
+            "area_name": "Midtown Manhattan",
+            "artist_edges": [
+                [
+                    "7cdb68bc-c4f1-4a92-9bd2-739641c5eff0",
+                    41094,
+                    231885,
+                    "9b2d5b96-b4d9-4bce-b056-c369ced25e81",
+                    "orchestra",
+                    "",
+                    0,
+                ],
+                [
+                    "2eac59bd-a1ff-403a-925d-3982a8794be7",
+                    436595,
+                    231886,
+                    "92873f0d-12a7-4fb3-9eac-ff06c38c6a60",
+                    "conductor",
+                    "",
+                    0,
+                ],
+                [
+                    "319e385f-bf48-4ea9-8328-1fff1b049e95",
+                    915750,
+                    203956,
+                    "936c7c95-3156-3889-a062-8a0cd57f8946",
+                    "main performer",
+                    "",
+                    0,
+                ],
+            ],
+            "begin_date_day": 16,
+            "begin_date_month": 12,
+            "begin_date_year": 1893,
+            "cancelled": False,
+            "disambiguation": "",
+            "end_date_day": 16,
+            "end_date_month": 12,
+            "end_date_year": 1893,
+            "ended": True,
+            "event_art_id": None,
+            "event_art_presence": "present",
+            "event_id": 3079,
+            "event_links": [
+                [
+                    "official homepage",
+                    "https://www.carnegiehall.org/About/History/Performance-History-Search?q=&dex=prod_PHS&page=47&event=6018",
+                ],
+                [
+                    "official homepage",
+                    "https://www.carnegiehall.org/Blog/2012/09/The-A-to-Z-of-Carnegie-Hall-N-is-for-New-World-Symphony",
+                ],
+                [
+                    "poster",
+                    "https://archives.nyphil.org/index.php/artifact/489b901d-bd34-40ce-82f2-250fb4757801-0.1/",
+                ],
+                [
+                    "review",
+                    "https://chroniclingamerica.loc.gov/lccn/sn83030272/1893-12-17/ed-1/seq-4/",
+                ],
+            ],
+            "event_mbid": "1bfefc05-dbbb-4aaa-8d1b-6ddc00114eb7",
+            "event_name": "Second Concert in the Fifty Second Season",
+            "event_part_of": None,
+            "event_parts": None,
+            "event_series": None,
+            "event_tags": [["classical", 1, "6ed4e4d1-9a97-4e2c-b8df-083754f154f4"]],
+            "event_time_raw": datetime.time(20, 15),
+            "event_type_gid": uuid.UUID("ef55e8d7-3d00-394a-8012-f5506a29ff0b"),
+            "event_type_name": "Concert",
+            "place_mbid": uuid.UUID("68b175f6-242d-40db-a376-ca0e2dd10c41"),
+            "place_name": "Carnegie Hall",
+            "rating": None,
+            "rating_count": None,
+            "setlist": (
+                "@ [319e385f-bf48-4ea9-8328-1fff1b049e95|Henri Marteau] - soloist\r\n\r\n"
+                "@ [0e85eb79-1c05-44ba-827c-7b259a3d941a|Felix Mendelssohn] - composer\r\n"
+                "* [e2a0b12c-c31c-4802-a57d-6bc2a9266e0f|Music to Shakespeare's “Midsummer Night's Dream”] - "
+                "[56f42454-be29-4a00-b1fd-4bef7ab8263c|Overture], [3ea58985-a8ca-4513-aa76-5698d4996588|Scherzo], "
+                "[44883862-fed5-4063-8a2a-924a918a3ad8|Notturno]\r\n\r\n"
+                "@ [c70d12a2-24fe-4f83-a6e6-57d84f8efb51|Johannes Brahms] - composer, "
+                "[319e385f-bf48-4ea9-8328-1fff1b049e95|Henri Marteau] - composer of cadenza\r\n"
+                "* [40215afd-f532-3cc5-8e69-db60650c526b|Concerto for Violin, D major, op. 77]\r\n\r\n"
+                "@ [819eaeb2-8dd8-48a5-ad07-0bcd137985ef|Antonín Dvořák] - composer\r\n"
+                "* [aacb1ab0-c740-436a-a782-ed60026cf82b|Symphony E minor, No. 5: “From the New World”] (currently known as no. 9)\r\n"
+                "# first performance"
+            ),
+        }
+
+        result = self.cache.process_row(row)
+
+        event_cache_rows = result["mapping.mb_event_cache"]
+        self.assertEqual(len(event_cache_rows), 1)
+
+        artist_cache_rows = result["mapping.mb_event_artist_cache"]
+        self.assertEqual(len(artist_cache_rows), 3)
+
+        with self.ts_conn.connection.cursor(cursor_factory=DictCursor) as curs:
+            insert_rows(curs, "mapping.mb_event_cache", event_cache_rows)
+            insert_rows(curs, "mapping.mb_event_artist_cache", artist_cache_rows)
+            self.ts_conn.connection.commit()
+
+            curs.execute(
+                "SELECT * FROM mapping.mb_event_cache WHERE event_mbid = %s",
+                ("1bfefc05-dbbb-4aaa-8d1b-6ddc00114eb7",),
+            )
+            db_row = curs.fetchone()
+
+            self.assertIsNotNone(db_row)
+            self.assertEqual(
+                db_row["event_name"], "Second Concert in the Fifty Second Season"
+            )
+            self.assertEqual(db_row["event_id"], 3079)
+            self.assertEqual(db_row["begin_date_year"], 1893)
+            self.assertEqual(
+                db_row["event_time"],
+                datetime.datetime(
+                    1893, 12, 16, 20, 15, 0, tzinfo=datetime.timezone.utc
+                ),
+            )
+            self.assertEqual(db_row["event_art_presence"], "present")
+            self.assertEqual(
+                str(db_row["event_type_gid"]), "ef55e8d7-3d00-394a-8012-f5506a29ff0b"
+            )
+            self.assertEqual(
+                str(db_row["place_mbid"]), "68b175f6-242d-40db-a376-ca0e2dd10c41"
+            )
+            self.assertEqual(db_row["place_name"], "Carnegie Hall")
+            self.assertEqual(
+                str(db_row["area_mbid"]), "edd27a39-ff8a-4af4-8bbf-f369b0fb1899"
+            )
+
+            db_json = db_row["event_data"]
+            self.assertEqual(db_json["type"], "Concert")
+            self.assertEqual(db_json["area_name"], "Midtown Manhattan")
+            self.assertEqual(db_json["setlist"], row["setlist"])
+            self.assertEqual(db_json["tags"][0]["tag"], "classical")
+            self.assertEqual(
+                db_json["tags"][0]["genre_mbid"], "6ed4e4d1-9a97-4e2c-b8df-083754f154f4"
+            )
+            self.assertEqual(
+                db_json["rels"]["poster"][0],
+                "https://archives.nyphil.org/index.php/artifact/489b901d-bd34-40ce-82f2-250fb4757801-0.1/",
+            )
+
+            curs.execute(
+                "SELECT * FROM mapping.mb_event_artist_cache WHERE event_mbid = %s ORDER BY artist_mbid",
+                ("1bfefc05-dbbb-4aaa-8d1b-6ddc00114eb7",),
+            )
+            db_artist_rows = curs.fetchall()
+            self.assertEqual(len(db_artist_rows), 3)
+            self.assertEqual(
+                str(db_artist_rows[0]["artist_mbid"]),
+                "2eac59bd-a1ff-403a-925d-3982a8794be7",
+            )
+            self.assertEqual(db_artist_rows[0]["link_type_name"], "conductor")
+
+    def test_process_row_parts(self):
+        row = {
+            "area_mbid": uuid.UUID("b9576171-3434-4d1b-8883-165ed6e65d2f"),
+            "area_name": "Kensington and Chelsea",
+            "artist_edges": None,
+            "begin_date_day": 14,
+            "begin_date_month": 7,
+            "begin_date_year": 2000,
+            "cancelled": False,
+            "disambiguation": "",
+            "end_date_day": 9,
+            "end_date_month": 9,
+            "end_date_year": 2000,
+            "ended": True,
+            "event_art_id": None,
+            "event_art_presence": "absent",
+            "event_id": 2624,
+            "event_links": None,
+            "event_mbid": "4ff6bf2a-ff96-405c-ae4d-b79c2373c775",
+            "event_name": "The Proms 2000",
+            "event_part_of": [
+                ["f5222627-58e6-4883-a189-f5ea486b61c6", "Woodstock \u201994"]
+            ],
+            "event_parts": [
+                ["82acd8f8-afa4-45cd-b669-c08a2abd58fc", "2000 BBC Prom 08"],
+                ["a37015fc-035a-4de7-9c5e-dd7707b54ec5", "The Proms 2000: Prom 07"],
+                [
+                    "0a5a3441-bb4b-4a83-813c-c79be0428ae1",
+                    "Prom 72: Last Night of the Proms",
+                ],
+            ],
+            "event_series": [["02c9a5b9-6b2c-461e-953d-6d4f6a9cc2d2", "The Proms"]],
+            "event_tags": None,
+            "event_time_raw": None,
+            "event_type_gid": uuid.UUID("b6ded574-b592-3f0e-b56e-5b5f06aa0678"),
+            "event_type_name": "Festival",
+            "place_mbid": uuid.UUID("4352063b-a833-421b-a420-e7fb295dece0"),
+            "place_name": "Royal Albert Hall",
+            "rating": None,
+            "rating_count": None,
+            "setlist": "",
+        }
+
+        result = self.cache.process_row(row)
+
+        event_cache_rows = result["mapping.mb_event_cache"]
+
+        with self.ts_conn.connection.cursor(cursor_factory=DictCursor) as curs:
+            insert_rows(curs, "mapping.mb_event_cache", event_cache_rows)
+            self.ts_conn.connection.commit()
+
+            curs.execute(
+                "SELECT * FROM mapping.mb_event_cache WHERE event_mbid = %s",
+                ("4ff6bf2a-ff96-405c-ae4d-b79c2373c775",),
+            )
+            db_row = curs.fetchone()
+
+            self.assertIsNotNone(db_row)
+            self.assertEqual(db_row["event_name"], "The Proms 2000")
+            self.assertEqual(
+                str(db_row["event_type_gid"]), "b6ded574-b592-3f0e-b56e-5b5f06aa0678"
+            )
+            self.assertEqual(
+                str(db_row["place_mbid"]), "4352063b-a833-421b-a420-e7fb295dece0"
+            )
+            self.assertEqual(db_row["event_art_presence"], "absent")
+
+            db_json = db_row["event_data"]
+            self.assertEqual(len(db_json["parts"]), 3)
+            self.assertEqual(
+                db_json["parts"][0]["mbid"], "82acd8f8-afa4-45cd-b669-c08a2abd58fc"
+            )
+            self.assertEqual(db_json["parts"][0]["name"], "2000 BBC Prom 08")
+
+            self.assertEqual(
+                db_json["series"][0]["mbid"], "02c9a5b9-6b2c-461e-953d-6d4f6a9cc2d2"
+            )
+            self.assertEqual(db_json["series"][0]["name"], "The Proms")
+
+            self.assertEqual(
+                db_json["part_of"][0]["mbid"], "f5222627-58e6-4883-a189-f5ea486b61c6"
+            )
+            self.assertEqual(db_json["part_of"][0]["name"], "Woodstock \u201994")
+
+    def test_process_row_tags_ratings(self):
+        row = {
+            "area_mbid": None,
+            "area_name": None,
+            "artist_edges": [
+                [
+                    "7216002f-aacb-4f95-8e1d-41214bcf53f2",
+                    2509642,
+                    203031,
+                    "936c7c95-3156-3889-a062-8a0cd57f8946",
+                    "main performer",
+                    "",
+                    0,
+                ],
+                [
+                    "e30933ad-7cf3-4807-9019-caa525a60a92",
+                    2390453,
+                    1076385,
+                    "936c7c95-3156-3889-a062-8a0cd57f8946",
+                    "main performer",
+                    "",
+                    0,
+                ],
+            ],
+            "begin_date_day": 4,
+            "begin_date_month": 2,
+            "begin_date_year": 2024,
+            "cancelled": False,
+            "disambiguation": "",
+            "end_date_day": 5,
+            "end_date_month": 2,
+            "end_date_year": 2024,
+            "ended": True,
+            "event_art_id": None,
+            "event_art_presence": "present",
+            "event_id": 78992,
+            "event_links": None,
+            "event_mbid": "9c81bb52-87be-48d5-a7cb-da91f6c94b5e",
+            "event_name": "TSUNGEDDON",
+            "event_part_of": None,
+            "event_parts": None,
+            "event_series": None,
+            "event_tags": [
+                ["hardcore techno", 1, "3308d0b0-3c7f-45e2-b835-5c2a0d433f02"],
+                ["broadcast", 1, None],
+                ["virtual event", 1, None],
+            ],
+            "event_time_raw": datetime.time(6, 45),
+            "event_type_gid": None,
+            "event_type_name": None,
+            "place_mbid": None,
+            "place_name": None,
+            "rating": 100,
+            "rating_count": 1,
+            "setlist": "",
+        }
+
+        result = self.cache.process_row(row)
+
+        event_cache_rows = result["mapping.mb_event_cache"]
+        artist_cache_rows = result["mapping.mb_event_artist_cache"]
+
+        with self.ts_conn.connection.cursor(cursor_factory=DictCursor) as curs:
+            insert_rows(curs, "mapping.mb_event_cache", event_cache_rows)
+            insert_rows(curs, "mapping.mb_event_artist_cache", artist_cache_rows)
+            self.ts_conn.connection.commit()
+
+            curs.execute(
+                "SELECT * FROM mapping.mb_event_cache WHERE event_mbid = %s",
+                ("9c81bb52-87be-48d5-a7cb-da91f6c94b5e",),
+            )
+            db_row = curs.fetchone()
+
+            self.assertIsNotNone(db_row)
+            self.assertEqual(db_row["event_name"], "TSUNGEDDON")
+            self.assertEqual(
+                db_row["event_time"],
+                datetime.datetime(2024, 2, 4, 6, 45, 0, tzinfo=datetime.timezone.utc),
+            )
+
+            self.assertIsNone(db_row["event_type_gid"])
+            self.assertIsNone(db_row["place_mbid"])
+            self.assertIsNone(db_row["place_name"])
+            self.assertIsNone(db_row["area_mbid"])
+
+            self.assertEqual(db_row["rating"], 100)
+            self.assertEqual(db_row["rating_count"], 1)
+            self.assertEqual(db_row["event_art_presence"], "present")
+
+            db_json = db_row["event_data"]
+            self.assertNotIn("type", db_json)
+            self.assertNotIn("area_name", db_json)
+
+            self.assertEqual(len(db_json["tags"]), 3)
+            self.assertEqual(db_json["tags"][0]["tag"], "hardcore techno")
+            self.assertEqual(
+                db_json["tags"][0]["genre_mbid"], "3308d0b0-3c7f-45e2-b835-5c2a0d433f02"
+            )
+
+            self.assertEqual(db_json["tags"][1]["tag"], "broadcast")
+            self.assertNotIn("genre_mbid", db_json["tags"][1])

--- a/mbid_mapping/manage.py
+++ b/mbid_mapping/manage.py
@@ -9,6 +9,8 @@ import click
 from mapping.canonical_musicbrainz_data import create_canonical_musicbrainz_data, update_canonical_release_data
 from mapping.mb_artist_metadata_cache import create_mb_artist_metadata_cache, \
     incremental_update_mb_artist_metadata_cache
+from mapping.mb_event_metadata_cache import create_mb_event_metadata_cache, \
+    incremental_update_mb_event_metadata_cache
 from mapping.soundcloud_metadata_index import create_soundcloud_metadata_index
 from mapping.typesense_index import build_all as action_build_index
 from mapping.mapping_test.mapping_test import test_mapping as action_test_mapping
@@ -159,6 +161,24 @@ def update_mb_artist_metadata_cache(use_lb_conn):
         Update the MB metadata cache that LB uses incrementally.
     """
     incremental_update_mb_artist_metadata_cache(use_lb_conn)
+
+
+@cli.command()
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def build_mb_event_cache(use_lb_conn):
+    """
+        Build the MB event metadata cache that LB uses
+    """
+    create_mb_event_metadata_cache(use_lb_conn)
+
+
+@cli.command()
+@click.option("--use-lb-conn/--use-mb-conn", default=True, help="whether to create the tables in LB or MB")
+def update_mb_event_cache(use_lb_conn):
+    """
+        Update the MB event metadata cache that LB uses incrementally.
+    """
+    incremental_update_mb_event_metadata_cache(use_lb_conn)
 
 
 @cli.command()

--- a/mbid_mapping/manage_cron.py
+++ b/mbid_mapping/manage_cron.py
@@ -20,6 +20,8 @@ from mapping.soundcloud_metadata_index import create_soundcloud_metadata_index
 from mapping.mb_metadata_cache import cleanup_mbid_mapping_table, create_mb_metadata_cache, incremental_update_mb_metadata_cache
 from mapping.mb_artist_metadata_cache import create_mb_artist_metadata_cache, \
     incremental_update_mb_artist_metadata_cache
+from mapping.mb_event_metadata_cache import create_mb_event_metadata_cache, \
+    incremental_update_mb_event_metadata_cache
 from mapping.mb_release_group_cache import create_mb_release_group_cache, incremental_update_mb_release_group_cache
 from similar.tag_similarity import create_tag_similarity
 from mapping.utils import log
@@ -96,6 +98,7 @@ def cron_build_all_mb_caches():
         cleanup_mbid_mapping_table()
         create_mb_artist_metadata_cache(True)
         create_mb_release_group_cache(True)
+        create_mb_event_metadata_cache(True)
 
     else:
         log("day %d: skipping cron job" % dt.day)
@@ -110,6 +113,7 @@ def cron_update_all_mb_caches():
     incremental_update_mb_metadata_cache(True)
     incremental_update_mb_artist_metadata_cache(True)
     incremental_update_mb_release_group_cache(True)
+    incremental_update_mb_event_metadata_cache(True)
 
 
 @cli.command()

--- a/mbid_mapping/mapping/mb_cache_base.py
+++ b/mbid_mapping/mapping/mb_cache_base.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import List, Set
 import uuid
 
+import traceback
+
 import psycopg2
 import psycopg2.extras
 from psycopg2.extras import execute_values
@@ -227,7 +229,7 @@ def create_metadata_cache(cache_cls, cache_key, required_tables, use_lb_conn: bo
                 cache.run()
                 success = True
             except Exception:
-                log(format_exc())
+                log(traceback.format_exc())
 
     except psycopg2.OperationalError:
         if not success:

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -1,0 +1,714 @@
+import uuid
+from datetime import datetime, timezone
+from typing import List, Set
+
+import psycopg2
+import psycopg2.extras
+import ujson
+
+import config
+from mapping.mb_cache_base import (
+    create_metadata_cache,
+    incremental_update_metadata_cache,
+    MusicBrainzEntityMetadataCache,
+)
+from mapping.bulk_table import BulkInsertTable
+from mapping.utils import insert_rows, log
+
+MB_EVENT_METADATA_CACHE_TIMESTAMP_KEY = "mb_event_metadata_cache_last_update_timestamp"
+
+ARTIST_EVENT_LINK_GIDS = (
+    "936c7c95-3156-3889-a062-8a0cd57f8946",  # main performer
+    "492a850e-97eb-306a-a85e-4b6d98527796",  # support act
+    "292df906-98a6-307e-86e8-df01a579a321",  # guest performer
+)
+ARTIST_EVENT_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in ARTIST_EVENT_LINK_GIDS])
+
+EVENT_URL_LINK_GIDS = ()
+EVENT_URL_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in EVENT_URL_LINK_GIDS])
+
+EVENT_PLACE_LINK_GID = "e2c6f697-07dc-38b1-be0b-83d740165532"
+
+# falls back to area if no place
+AREA_EVENT_LINK_GID = "542f8484-8bc7-3ce5-a022-747850b2b928"
+
+
+class MusicBrainzEventArtistCache(BulkInsertTable):
+    """
+        This class creates the artist-event edge cache, driven by the
+        primary MusicBrainzEventMetadataCache table.
+    """
+
+    def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
+        super().__init__(
+            "mapping.mb_event_artist_cache",
+            select_conn,
+            insert_conn,
+            batch_size,
+            unlogged,
+        )
+
+    def get_create_table_columns(self):
+        # this table is created in local development and tests using admin/timescale/create_tables.sql.
+        # remember to keep both in sync.
+        return [
+            ("event_mbid ", "UUID NOT NULL"),
+            ("event_id ", "INTEGER NOT NULL"),
+            ("artist_mbid ", "UUID NOT NULL"),
+            ("artist_id ", "INTEGER NOT NULL"),
+            ("link_id ", "INTEGER NOT NULL"),
+            ("link_type_gid ", "UUID NOT NULL"),
+            ("link_type_name ", "TEXT NOT NULL"),
+            ("relationship_data ", "JSONB NOT NULL DEFAULT '{}'::jsonb"),
+            ("last_updated ", "TIMESTAMPTZ NOT NULL DEFAULT NOW()"),
+        ]
+
+    def get_insert_queries(self):
+        return []
+
+    def get_insert_queries_test_values(self):
+        return []
+
+    def get_post_process_queries(self):
+        return []
+
+    def get_index_names(self):
+        return [
+            (
+                "mb_event_artist_cache_idx_artist_id_event_id",
+                "artist_id, event_id",
+                False,
+            ),
+            ("mb_event_artist_cache_idx_artist_mbid", "artist_mbid", False),
+            ("mb_event_artist_cache_idx_event_id", "event_id", False),
+            ("mb_event_artist_cache_idx_link_type_gid", "link_type_gid", False),
+            ("mb_event_artist_cache_pkey", "event_id, artist_id, link_id", True),
+        ]
+
+    def process_row(self, row):
+        return []
+
+    def process_row_complete(self):
+        return []
+
+
+class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
+    """
+        This class creates the MB event metadata cache and its associated
+        artist-event edge table.
+    """
+
+    def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
+        super().__init__(
+            "mapping.mb_event_cache", select_conn, insert_conn, batch_size, unlogged
+        )
+        self.artist_cache = MusicBrainzEventArtistCache(
+            select_conn, insert_conn, batch_size, unlogged
+        )
+        self.add_additional_bulk_table(self.artist_cache)
+
+    def get_create_table_columns(self):
+        # this table is created in local development and tests using admin/timescale/create_tables.sql.
+        # remember to keep both in sync.
+        return [
+            ("dirty ", "BOOLEAN DEFAULT FALSE"),
+            ("last_updated ", "TIMESTAMPTZ NOT NULL DEFAULT NOW()"),
+            ("event_mbid ", "UUID NOT NULL"),
+            ("event_id ", "INTEGER NOT NULL"),
+            ("event_name ", "TEXT NOT NULL"),
+            ("begin_date_year ", "SMALLINT"),
+            ("begin_date_month ", "SMALLINT"),
+            ("begin_date_day ", "SMALLINT"),
+            ("end_date_year ", "SMALLINT"),
+            ("end_date_month ", "SMALLINT"),
+            ("end_date_day ", "SMALLINT"),
+            ("event_time ", "TIMESTAMPTZ"),
+            ("cancelled ", "BOOLEAN NOT NULL DEFAULT FALSE"),
+            ("ended ", "BOOLEAN NOT NULL DEFAULT FALSE"),
+            ("event_type_gid ", "UUID"),
+            ("event_art_presence ", "TEXT NOT NULL DEFAULT 'absent'"),
+            ("place_mbid ", "UUID"),
+            ("place_name ", "TEXT"),
+            ("area_mbid ", "UUID"),
+            ("rating ", "SMALLINT"),
+            ("rating_count ", "INTEGER"),
+            ("event_data ", "JSONB NOT NULL DEFAULT '{}'::jsonb"),
+        ]
+
+    def get_insert_queries_test_values(self):
+        if config.USE_MINIMAL_DATASET:
+            return [
+                [
+                    (uuid.UUID(u),)
+                    for u in (
+                        "1bfefc05-dbbb-4aaa-8d1b-6ddc00114eb7",
+                        "9c81bb52-87be-48d5-a7cb-da91f6c94b5e",
+                        "a777f05b-a934-4648-9a5c-60284b588c0e",
+                        "4996ec02-a2c6-405d-99b7-c545e3ad040a"
+                    )
+                ]
+            ]
+        else:
+            return [[]]
+
+    def get_post_process_queries(self):
+        return []
+
+    def get_index_names(self):
+        return [
+            ("mb_event_cache_idx_event_mbid", "event_mbid", True),
+            ("mb_event_cache_idx_event_id", "event_id", True),
+            (
+                "mb_event_cache_idx_date",
+                "begin_date_year, begin_date_month, begin_date_day",
+                False,
+            ),
+            ("mb_event_cache_idx_dirty", "dirty", False),
+        ]
+
+    def process_row(self, row):
+        event_row = ("false", self.last_updated, *self.create_json_data(row))
+        artist_rows = self._create_artist_edge_rows(row)
+        return {
+            "mapping.mb_event_cache": [event_row],
+            "mapping.mb_event_artist_cache": artist_rows,
+        }
+
+    def _assemble_event_time(self, row):
+        """ Combine event.time with begin_date into a full timestamp.
+            Returns None if either part is missing. Assuming UTC.
+        """
+        event_time_raw = row["event_time_raw"]
+        if event_time_raw is None:
+            return None
+
+        year = row["begin_date_year"]
+        month = row["begin_date_month"]
+        day = row["begin_date_day"]
+        if year is None or month is None or day is None:
+            return None
+
+        try:
+            return datetime(
+                year,
+                month,
+                day,
+                event_time_raw.hour,
+                event_time_raw.minute,
+                event_time_raw.second,
+                tzinfo=timezone.utc,
+            )
+        except (ValueError, AttributeError):
+            return None
+
+    def create_json_data(self, row):
+        event_mbid = row["event_mbid"]
+        event_time = self._assemble_event_time(row)
+
+        event_data = {}
+
+        if row["event_type_name"] is not None:
+            event_data["type"] = row["event_type_name"]
+
+        if row["disambiguation"]:
+            event_data["disambiguation"] = row["disambiguation"]
+
+        if row["setlist"]:
+            event_data["setlist"] = row["setlist"]
+
+        if row["area_name"]:
+            event_data["area_name"] = row["area_name"]
+
+        if row["event_links"]:
+            filtered = {}
+            for name, url in row["event_links"]:
+                if name is None or url is None:
+                    continue
+                filtered[name] = url
+            if filtered:
+                event_data["rels"] = filtered
+
+        event_tags = []
+        for tag, count, genre_mbid in row["event_tags"] or []:
+            tag_entry = {"tag": tag, "count": count}
+            if genre_mbid is not None:
+                tag_entry["genre_mbid"] = genre_mbid
+            event_tags.append(tag_entry)
+        if event_tags:
+            event_data["tags"] = event_tags
+
+        if row["event_art_id"] is not None:
+            event_data["event_art_id"] = row["event_art_id"]
+
+        return (
+            event_mbid,
+            row["event_id"],
+            row["event_name"],
+            row["begin_date_year"],
+            row["begin_date_month"],
+            row["begin_date_day"],
+            row["end_date_year"],
+            row["end_date_month"],
+            row["end_date_day"],
+            event_time,
+            row["cancelled"],
+            row["ended"],
+            row["event_type_gid"],
+            row["event_art_presence"] or "absent",
+            row["place_mbid"],
+            row["place_name"],
+            row["area_mbid"],
+            row["rating"],
+            row["rating_count"],
+            ujson.dumps(event_data),
+        )
+
+    def _create_artist_edge_rows(self, row):
+        rows = []
+        if not row["artist_edges"]:
+            return rows
+
+        for edge in row["artist_edges"]:
+            artist_mbid = edge[0]
+            artist_id = edge[1]
+            link_id = edge[2]
+            link_type_gid = edge[3]
+            link_type_name = edge[4]
+            entity0_credit = edge[5]
+
+            relationship_data = {}
+            if entity0_credit:
+                relationship_data["credited_as"] = entity0_credit
+
+            rows.append(
+                (
+                    row["event_mbid"],
+                    row["event_id"],
+                    artist_mbid,
+                    artist_id,
+                    link_id,
+                    link_type_gid,
+                    link_type_name,
+                    ujson.dumps(relationship_data),
+                    self.last_updated,
+                )
+            )
+
+        return rows
+
+    def get_metadata_cache_query(self, with_values=False):
+        values_cte = ""
+        values_join = ""
+        if with_values:
+            values_cte = "subset (subset_event_mbid) AS (values %s), "
+            values_join = "JOIN subset ON e.gid = subset.subset_event_mbid"
+
+        query = f"""WITH {values_cte} event_url_rels AS (
+                            SELECT e.gid AS event_mbid
+                                 , array_agg(DISTINCT ARRAY[lt.name, url]) AS event_links
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_event_url leu
+                                ON leu.entity0 = e.id
+                              JOIN musicbrainz.url u
+                                ON leu.entity1 = u.id
+                              JOIN musicbrainz.link l
+                                ON leu.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              {values_join}
+                             WHERE lt.gid IN ({EVENT_URL_LINK_GIDS_SQL})
+                               AND NOT l.ended
+                          GROUP BY e.gid
+                   ), event_tags AS (
+                            SELECT e.gid AS event_mbid
+                                 , array_agg(jsonb_build_array(t.name, et.count, g.gid)) AS event_tags
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.event_tag et
+                                ON et.event = e.id
+                              JOIN musicbrainz.tag t
+                                ON et.tag = t.id
+                         LEFT JOIN musicbrainz.genre g
+                                ON t.name = g.name
+                              {values_join}
+                             WHERE et.count > 0
+                          GROUP BY e.gid
+                   ), event_place AS (
+                            SELECT DISTINCT ON (e.id)
+                                   e.gid AS event_mbid
+                                 , p.gid AS place_gid
+                                 , p.name AS place_name
+                                 , ar.gid AS area_gid
+                                 , ar.name AS area_name
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_event_place lep
+                                ON lep.entity0 = e.id
+                              JOIN musicbrainz.link l
+                                ON lep.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              JOIN musicbrainz.place p
+                                ON lep.entity1 = p.id
+                         LEFT JOIN musicbrainz.area ar
+                                ON p.area = ar.id
+                              {values_join}
+                             WHERE lt.gid = '{EVENT_PLACE_LINK_GID}'
+                          ORDER BY e.id, lep.id
+                   ), event_area_fallback AS (
+                            SELECT DISTINCT ON (e.id)
+                                   e.gid AS event_mbid
+                                 , ar.gid AS area_gid
+                                 , ar.name AS area_name
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_area_event lae
+                                ON lae.entity1 = e.id
+                              JOIN musicbrainz.link l
+                                ON lae.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              JOIN musicbrainz.area ar
+                                ON lae.entity0 = ar.id
+                         LEFT JOIN event_place ep
+                                ON ep.event_mbid = e.gid
+                              {values_join}
+                             WHERE lt.gid = '{AREA_EVENT_LINK_GID}'
+                               AND ep.event_mbid IS NULL
+                          ORDER BY e.id, lae.id
+                   ), event_art AS (
+                            SELECT DISTINCT ON (ea.event)
+                                   ea.event AS event_id
+                                 , ea.id AS event_art_id
+                              FROM event_art_archive.event_art ea
+                              JOIN event_art_archive.event_art_type eat
+                                ON eat.id = ea.id
+                             WHERE eat.type_id = 1
+                               AND ea.mime_type != 'application/pdf'
+                          ORDER BY ea.event, ea.ordering
+                   ), artist_edges AS (
+                            SELECT e.gid AS event_mbid
+                                 , array_agg(
+                                        jsonb_build_array(
+                                            a.gid
+                                          , a.id
+                                          , l.id
+                                          , lt.gid
+                                          , lt.name
+                                          , lae.entity0_credit
+                                        )
+                                   ) AS edges
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_artist_event lae
+                                ON lae.entity1 = e.id
+                              JOIN musicbrainz.link l
+                                ON lae.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              JOIN musicbrainz.artist a
+                                ON lae.entity0 = a.id
+                              {values_join}
+                             WHERE lt.gid IN ({ARTIST_EVENT_LINK_GIDS_SQL})
+                          GROUP BY e.gid
+                   )
+                            SELECT e.gid::TEXT AS event_mbid
+                                 , e.id AS event_id
+                                 , e.name AS event_name
+                                 , e.begin_date_year
+                                 , e.begin_date_month
+                                 , e.begin_date_day
+                                 , e.end_date_year
+                                 , e.end_date_month
+                                 , e.end_date_day
+                                 , e.time AS event_time_raw
+                                 , e.cancelled
+                                 , e.ended
+                                 , et.gid AS event_type_gid
+                                 , et.name AS event_type_name
+                                 , COALESCE(em.event_art_presence::TEXT, 'absent') AS event_art_presence
+                                 , ep.place_gid AS place_mbid
+                                 , ep.place_name AS place_name
+                                 , COALESCE(ep.area_gid, eaf.area_gid) AS area_mbid
+                                 , COALESCE(ep.area_name, eaf.area_name) AS area_name
+                                 , e.comment AS disambiguation
+                                 , e.setlist
+                                 , eurl.event_links
+                                 , etags.event_tags
+                                 , ea.event_art_id
+                                 , em.rating
+                                 , em.rating_count
+                                 , ae.edges AS artist_edges
+                              FROM musicbrainz.event e
+                         LEFT JOIN musicbrainz.event_type et
+                                ON e.type = et.id
+                         LEFT JOIN musicbrainz.event_meta em
+                                ON em.id = e.id
+                         LEFT JOIN event_url_rels eurl
+                                ON eurl.event_mbid = e.gid
+                         LEFT JOIN event_tags etags
+                                ON etags.event_mbid = e.gid
+                         LEFT JOIN event_place ep
+                                ON ep.event_mbid = e.gid
+                         LEFT JOIN event_area_fallback eaf
+                                ON eaf.event_mbid = e.gid
+                         LEFT JOIN event_art ea
+                                ON ea.event_id = e.id
+                         LEFT JOIN artist_edges ae
+                                ON ae.event_mbid = e.gid
+                              {values_join}
+        """
+        return query
+
+    def query_last_updated_items(self, timestamp):
+        # 1. Event core data: event itself, type, meta
+        # |  CTE / table       |  purpose                    | last_updated considered
+        # |  event             |  name, dates, cancelled     | event.last_updated
+        event_mbids_query = """
+            SELECT e.gid
+              FROM musicbrainz.event e
+             WHERE e.last_updated > %(timestamp)s
+        """
+
+        # 2. Event tags
+        # |  CTE / table       |  purpose                    | last_updated considered
+        # |  event_tags        |  community tags             | event_tag.last_updated, genre.last_updated
+        event_tags_query = """
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.event_tag et
+                ON et.event = e.id
+              JOIN musicbrainz.tag t
+                ON et.tag = t.id
+         LEFT JOIN musicbrainz.genre g
+                ON t.name = g.name
+             WHERE et.last_updated > %(timestamp)s
+                OR g.last_updated > %(timestamp)s
+        """
+
+        # Event URL rels
+        # |  CTE / table       |  purpose                    | last_updated considered
+        # |  event_url_rels    |  external links             | l_event_url, url, link_type
+        event_url_rels_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_event_url leu
+                ON leu.entity0 = e.id
+              JOIN musicbrainz.url u
+                ON leu.entity1 = u.id
+              JOIN musicbrainz.link l
+                ON leu.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+             WHERE lt.gid IN ({EVENT_URL_LINK_GIDS_SQL})
+               AND (
+                    leu.last_updated > %(timestamp)s
+                 OR   u.last_updated > %(timestamp)s
+                 OR  lt.last_updated > %(timestamp)s
+               )
+        """
+
+        # Artist-event links
+        # |  CTE / table       |  purpose                    | last_updated considered
+        # |  artist_edges      |  performer relationships    | l_artist_event, link_type
+        artist_event_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_artist_event lae
+                ON lae.entity1 = e.id
+              JOIN musicbrainz.link l
+                ON lae.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+             WHERE lt.gid IN ({ARTIST_EVENT_LINK_GIDS_SQL})
+               AND (
+                    lae.last_updated > %(timestamp)s
+                 OR  lt.last_updated > %(timestamp)s
+               )
+        """
+
+        # Place and area data
+        # |  CTE / table       |  purpose                    | last_updated considered
+        # |  event_place       |  venue + area               | l_event_place, place, area
+        place_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_event_place lep
+                ON lep.entity0 = e.id
+              JOIN musicbrainz.link l
+                ON lep.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+              JOIN musicbrainz.place p
+                ON lep.entity1 = p.id
+         LEFT JOIN musicbrainz.area ar
+                ON p.area = ar.id
+             WHERE lt.gid = '{EVENT_PLACE_LINK_GID}'
+               AND (
+                    lep.last_updated > %(timestamp)s
+                 OR   p.last_updated > %(timestamp)s
+                 OR  ar.last_updated > %(timestamp)s
+               )
+        """
+
+        # Area fallback
+        area_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_area_event lae
+                ON lae.entity1 = e.id
+              JOIN musicbrainz.link l
+                ON lae.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+              JOIN musicbrainz.area ar
+                ON lae.entity0 = ar.id
+             WHERE lt.gid = '{AREA_EVENT_LINK_GID}'
+               AND (
+                    lae.last_updated > %(timestamp)s
+                 OR  ar.last_updated > %(timestamp)s
+               )
+        """
+
+        try:
+            with self.select_conn.cursor() as curs:
+                self.config_postgres_join_limit(curs)
+                event_mbids = set()
+
+                log("mb event metadata cache: querying event core changes")
+                curs.execute(event_mbids_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying event tag changes")
+                curs.execute(event_tags_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying event url rel changes")
+                curs.execute(event_url_rels_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying artist-event link changes")
+                curs.execute(artist_event_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying place changes")
+                curs.execute(place_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying area fallback changes")
+                curs.execute(area_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                return event_mbids
+        except psycopg2.errors.OperationalError as err:
+            log("mb event metadata cache: cannot query rows for update", err)
+            return None
+
+    def delete_rows(self, event_mbids: List[uuid.UUID]):
+        """Delete event MBIDs from both cache tables."""
+
+        conn = self.insert_conn if self.insert_conn is not None else self.select_conn
+        with conn.cursor() as curs:
+            curs.execute(
+                f"DELETE FROM {self.table_name} WHERE event_mbid IN %s",
+                (tuple(event_mbids),),
+            )
+            curs.execute(
+                f"DELETE FROM {self.artist_cache.table_name} WHERE event_mbid IN %s",
+                (tuple(event_mbids),),
+            )
+
+    def get_delete_rows_query(self):
+        return f"DELETE FROM {self.table_name} WHERE event_mbid IN %s"
+
+    def update_dirty_cache_items(self, event_mbids: Set[uuid.UUID]):
+        if not event_mbids:
+            log(f"{self.table_name} update: no dirty items found skipping update")
+            return
+
+        conn = self.insert_conn if self.insert_conn is not None else self.select_conn
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as lb_curs:
+            with self.select_conn.cursor(
+                cursor_factory=psycopg2.extras.DictCursor
+            ) as mb_curs:
+                self.pre_insert_queries_db_setup(mb_curs)
+
+                log(f"{self.table_name} update: Running query on dirty items")
+                query = self.get_metadata_cache_query(with_values=True)
+                values = [(mbid,) for mbid in event_mbids]
+                psycopg2.extras.execute_values(
+                    mb_curs, query, values, page_size=len(values)
+                )
+
+                rows = []
+                artist_rows = []
+                count = 0
+                total_rows = len(event_mbids)
+                for row in mb_curs:
+                    count += 1
+                    data = self.create_json_data(row)
+                    rows.append(("false", self.last_updated, *data))
+                    artist_rows.extend(self._create_artist_edge_rows(row))
+
+                    if len(rows) >= self.batch_size:
+                        batch_event_mbids = [row[2] for row in rows]
+                        self.delete_rows(batch_event_mbids)
+                        insert_rows(lb_curs, self.table_name, rows)
+                        if artist_rows:
+                            insert_rows(
+                                lb_curs,
+                                self.artist_cache.table_name,
+                                artist_rows,
+                                cols=self.artist_cache.insert_columns,
+                            )
+                        conn.commit()
+                        log(
+                            f"{self.table_name} update: inserted {count} rows. "
+                            f"{100.0 * count / total_rows:.1f}%"
+                        )
+                        rows = []
+                        artist_rows = []
+
+                if rows:
+                    batch_event_mbids = [row[2] for row in rows]
+                    self.delete_rows(batch_event_mbids)
+                    insert_rows(lb_curs, self.table_name, rows)
+                    if artist_rows:
+                        insert_rows(
+                            lb_curs,
+                            self.artist_cache.table_name,
+                            artist_rows,
+                            cols=self.artist_cache.insert_columns,
+                        )
+                    conn.commit()
+
+        log(
+            f"{self.table_name} update: inserted {count} rows. {100.0 * count / total_rows:.1f}%"
+        )
+        log(f"{self.table_name} update: Done!")
+
+
+def create_mb_event_metadata_cache(use_lb_conn: bool):
+    """
+        Main function for creating the MB event metadata cache and its related tables.
+
+        Arguments:
+            use_lb_conn: whether to use LB conn or not
+    """
+    create_metadata_cache(
+        MusicBrainzEventMetadataCache,
+        MB_EVENT_METADATA_CACHE_TIMESTAMP_KEY,
+        [],
+        use_lb_conn,
+    )
+
+
+def incremental_update_mb_event_metadata_cache(use_lb_conn: bool):
+    """Update the MB event metadata cache incrementally"""
+    incremental_update_metadata_cache(
+        MusicBrainzEventMetadataCache,
+        MB_EVENT_METADATA_CACHE_TIMESTAMP_KEY,
+        use_lb_conn,
+    )

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -39,6 +39,8 @@ EVENT_PLACE_LINK_GID = "e2c6f697-07dc-38b1-be0b-83d740165532"
 
 EVENT_PARTS_LINK_GID = "65742183-b25c-469e-b094-ff6739e6699c"
 
+EVENT_SERIES_LINK_GID = "707d947d-9563-328a-9a7d-0c5b9c3a9791"
+
 # falls back to area if no place
 AREA_EVENT_LINK_GID = "542f8484-8bc7-3ce5-a022-747850b2b928"
 
@@ -155,8 +157,8 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                         "9c81bb52-87be-48d5-a7cb-da91f6c94b5e",
                         "a777f05b-a934-4648-9a5c-60284b588c0e",
                         "4996ec02-a2c6-405d-99b7-c545e3ad040a",
-                        "ab234290-d27d-45b6-9778-d21945906996",
-                        "4ff6bf2a-ff96-405c-ae4d-b79c2373c775",
+                        "ab234290-d27d-45b6-9778-d21945906996",  # contains part of (parent)
+                        "4ff6bf2a-ff96-405c-ae4d-b79c2373c775",  # contains parts and series
                     )
                 ]
             ]
@@ -247,6 +249,20 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                 parts.append({"mbid": part_mbid, "name": part_name})
             if parts:
                 event_data["parts"] = parts
+
+        if row["event_part_of"]:
+            parts_of = []
+            for part_of_mbid, part_of_name in row["event_part_of"]:
+                parts_of.append({"mbid": part_of_mbid, "name": part_of_name})
+            if parts_of:
+                event_data["part_of"] = parts_of
+
+        if row["event_series"]:
+            series = []
+            for series_mbid, series_name in row["event_series"]:
+                series.append({"mbid": series_mbid, "name": series_name})
+            if series:
+                event_data["series"] = series
 
         event_tags = []
         for tag, count, genre_mbid in row["event_tags"] or []:
@@ -353,6 +369,38 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                                 ON lee.entity1 = e2.id
                               {values_join}
                              WHERE lt.gid = '{EVENT_PARTS_LINK_GID}'
+                               AND NOT l.ended
+                          GROUP BY e.gid
+                   ), event_part_of AS (
+                            SELECT e.gid AS event_mbid
+                                 , array_agg(jsonb_build_array(e2.gid, e2.name)) AS event_part_of
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_event_event lee
+                                ON lee.entity1 = e.id
+                              JOIN musicbrainz.link l
+                                ON lee.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              JOIN musicbrainz.event e2
+                                ON lee.entity0 = e2.id
+                              {values_join}
+                             WHERE lt.gid = '{EVENT_PARTS_LINK_GID}'
+                               AND NOT l.ended
+                          GROUP BY e.gid
+                   ), event_series AS (
+                            SELECT e.gid AS event_mbid
+                                 , array_agg(jsonb_build_array(s.gid, s.name)) AS event_series
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_event_series les
+                                ON les.entity0 = e.id
+                              JOIN musicbrainz.link l
+                                ON les.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              JOIN musicbrainz.series s
+                                ON les.entity1 = s.id
+                              {values_join}
+                             WHERE lt.gid = '{EVENT_SERIES_LINK_GID}'
                                AND NOT l.ended
                           GROUP BY e.gid
                    ), event_tags AS (
@@ -467,6 +515,8 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                                  , e.setlist
                                  , eurl.event_links
                                  , eparts.event_parts
+                                 , epartof.event_part_of
+                                 , eseries.event_series
                                  , etags.event_tags
                                  , ea.event_art_id
                                  , em.rating
@@ -481,6 +531,10 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                                 ON eurl.event_mbid = e.gid
                          LEFT JOIN event_parts eparts
                                 ON eparts.event_mbid = e.gid
+                         LEFT JOIN event_part_of epartof
+                                ON epartof.event_mbid = e.gid
+                         LEFT JOIN event_series eseries
+                                ON eseries.event_mbid = e.gid
                          LEFT JOIN event_tags etags
                                 ON etags.event_mbid = e.gid
                          LEFT JOIN event_place ep
@@ -562,6 +616,46 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                     lee.last_updated > %(timestamp)s
                  OR  lt.last_updated > %(timestamp)s
                  OR  e2.last_updated > %(timestamp)s
+               )
+        """
+
+        # Event-event part of
+        event_part_of_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_event_event lee
+                ON lee.entity1 = e.id
+              JOIN musicbrainz.link l
+                ON lee.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+              JOIN musicbrainz.event e2
+                ON lee.entity0 = e2.id
+             WHERE lt.gid = '{EVENT_PARTS_LINK_GID}'
+               AND (
+                    lee.last_updated > %(timestamp)s
+                 OR  lt.last_updated > %(timestamp)s
+                 OR  e2.last_updated > %(timestamp)s
+               )
+        """
+
+        # Event-series links
+        event_series_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_event_series les
+                ON les.entity0 = e.id
+              JOIN musicbrainz.link l
+                ON les.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+              JOIN musicbrainz.series s
+                ON les.entity1 = s.id
+             WHERE lt.gid = '{EVENT_SERIES_LINK_GID}'
+               AND (
+                    les.last_updated > %(timestamp)s
+                 OR  lt.last_updated > %(timestamp)s
+                 OR   s.last_updated > %(timestamp)s
                )
         """
 
@@ -649,6 +743,16 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
 
                 log("mb event metadata cache: querying event parts changes")
                 curs.execute(event_parts_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying event part_of changes")
+                curs.execute(event_part_of_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying event series changes")
+                curs.execute(event_series_query, {"timestamp": timestamp})
                 for row in curs.fetchall():
                     event_mbids.add(row[0])
 

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -239,7 +239,9 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
             for name, url in row["event_links"]:
                 if name is None or url is None:
                     continue
-                filtered[name] = url
+                if name not in filtered:
+                    filtered[name] = []
+                filtered[name].append(url)
             if filtered:
                 event_data["rels"] = filtered
 

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -17,12 +17,16 @@ from mapping.utils import insert_rows, log
 
 MB_EVENT_METADATA_CACHE_TIMESTAMP_KEY = "mb_event_metadata_cache_last_update_timestamp"
 
-ARTIST_EVENT_LINK_GIDS = (
-    "936c7c95-3156-3889-a062-8a0cd57f8946",  # main performer
-    "492a850e-97eb-306a-a85e-4b6d98527796",  # support act
-    "292df906-98a6-307e-86e8-df01a579a321",  # guest performer
+ARTIST_EVENT_LINK_BLOCKLIST = (
+    "a66ea135-5dd0-4dc2-8ecb-59e3026d1ecc",  # artwork
+    "c49495bf-71d0-4d5f-9121-c775cc33e940",  # design
+    "d3e1717b-6ab9-4fdb-bd77-0dba3f082a74",  # graphic design
+    "f10e1176-4644-4689-910f-16356946ff32",  # illustration
+    "5193f001-643f-44a1-9fad-0f6816e84a3d",  # jury member
 )
-ARTIST_EVENT_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in ARTIST_EVENT_LINK_GIDS])
+ARTIST_EVENT_LINK_BLOCKLIST_SQL = ", ".join(
+    [f"'{x}'" for x in ARTIST_EVENT_LINK_BLOCKLIST]
+)
 
 EVENT_URL_LINK_GIDS = (
     "c26808b0-4e67-31a7-a587-913720dfb3f3",  # official homepage
@@ -42,8 +46,8 @@ AREA_EVENT_LINK_GID = "542f8484-8bc7-3ce5-a022-747850b2b928"
 
 class MusicBrainzEventArtistCache(BulkInsertTable):
     """
-        This class creates the artist-event edge cache, driven by the
-        primary MusicBrainzEventMetadataCache table.
+    This class creates the artist-event edge cache, driven by the
+    primary MusicBrainzEventMetadataCache table.
     """
 
     def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
@@ -101,8 +105,8 @@ class MusicBrainzEventArtistCache(BulkInsertTable):
 
 class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
     """
-        This class creates the MB event metadata cache and its associated
-        artist-event edge table.
+    This class creates the MB event metadata cache and its associated
+    artist-event edge table.
     """
 
     def __init__(self, select_conn, insert_conn=None, batch_size=None, unlogged=False):
@@ -183,8 +187,9 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
         }
 
     def _assemble_event_time(self, row):
-        """ Combine event.time with begin_date into a full timestamp.
-            Returns None if either part is missing. Assuming UTC.
+        """
+        Combine event.time with begin_date into a full timestamp.
+        Returns None if either part is missing. Assuming UTC.
         """
         event_time_raw = row["event_time_raw"]
         if event_time_raw is None:
@@ -413,7 +418,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                               JOIN musicbrainz.artist a
                                 ON lae.entity0 = a.id
                               {values_join}
-                             WHERE lt.gid IN ({ARTIST_EVENT_LINK_GIDS_SQL})
+                             WHERE lt.gid NOT IN ({ARTIST_EVENT_LINK_BLOCKLIST_SQL})
                           GROUP BY e.gid
                    )
                             SELECT e.gid::TEXT AS event_mbid
@@ -524,7 +529,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                 ON lae.link = l.id
               JOIN musicbrainz.link_type lt
                 ON l.link_type = lt.id
-             WHERE lt.gid IN ({ARTIST_EVENT_LINK_GIDS_SQL})
+             WHERE lt.gid NOT IN ({ARTIST_EVENT_LINK_BLOCKLIST_SQL})
                AND (
                     lae.last_updated > %(timestamp)s
                  OR  lt.last_updated > %(timestamp)s
@@ -700,10 +705,10 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
 
 def create_mb_event_metadata_cache(use_lb_conn: bool):
     """
-        Main function for creating the MB event metadata cache and its related tables.
+    Main function for creating the MB event metadata cache and its related tables.
 
-        Arguments:
-            use_lb_conn: whether to use LB conn or not
+    Arguments:
+        use_lb_conn: whether to use LB conn or not
     """
     create_metadata_cache(
         MusicBrainzEventMetadataCache,

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -37,6 +37,8 @@ EVENT_URL_LINK_BLOCKLIST_SQL = ", ".join([f"'{x}'" for x in EVENT_URL_LINK_BLOCK
 
 EVENT_PLACE_LINK_GID = "e2c6f697-07dc-38b1-be0b-83d740165532"
 
+EVENT_PARTS_LINK_GID = "65742183-b25c-469e-b094-ff6739e6699c"
+
 # falls back to area if no place
 AREA_EVENT_LINK_GID = "542f8484-8bc7-3ce5-a022-747850b2b928"
 
@@ -154,6 +156,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                         "a777f05b-a934-4648-9a5c-60284b588c0e",
                         "4996ec02-a2c6-405d-99b7-c545e3ad040a",
                         "ab234290-d27d-45b6-9778-d21945906996",
+                        "4ff6bf2a-ff96-405c-ae4d-b79c2373c775",
                     )
                 ]
             ]
@@ -237,6 +240,13 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                 filtered[name] = url
             if filtered:
                 event_data["rels"] = filtered
+
+        if row["event_parts"]:
+            parts = []
+            for part_mbid, part_name in row["event_parts"]:
+                parts.append({"mbid": part_mbid, "name": part_name})
+            if parts:
+                event_data["parts"] = parts
 
         event_tags = []
         for tag, count, genre_mbid in row["event_tags"] or []:
@@ -327,6 +337,22 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                                 ON l.link_type = lt.id
                               {values_join}
                              WHERE lt.gid NOT IN ({EVENT_URL_LINK_BLOCKLIST_SQL})
+                               AND NOT l.ended
+                          GROUP BY e.gid
+                   ), event_parts AS (
+                            SELECT e.gid AS event_mbid
+                                 , array_agg(jsonb_build_array(e2.gid, e2.name)) AS event_parts
+                              FROM musicbrainz.event e
+                              JOIN musicbrainz.l_event_event lee
+                                ON lee.entity0 = e.id
+                              JOIN musicbrainz.link l
+                                ON lee.link = l.id
+                              JOIN musicbrainz.link_type lt
+                                ON l.link_type = lt.id
+                              JOIN musicbrainz.event e2
+                                ON lee.entity1 = e2.id
+                              {values_join}
+                             WHERE lt.gid = '{EVENT_PARTS_LINK_GID}'
                                AND NOT l.ended
                           GROUP BY e.gid
                    ), event_tags AS (
@@ -440,6 +466,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                                  , e.comment AS disambiguation
                                  , e.setlist
                                  , eurl.event_links
+                                 , eparts.event_parts
                                  , etags.event_tags
                                  , ea.event_art_id
                                  , em.rating
@@ -452,6 +479,8 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                                 ON em.id = e.id
                          LEFT JOIN event_url_rels eurl
                                 ON eurl.event_mbid = e.gid
+                         LEFT JOIN event_parts eparts
+                                ON eparts.event_mbid = e.gid
                          LEFT JOIN event_tags etags
                                 ON etags.event_mbid = e.gid
                          LEFT JOIN event_place ep
@@ -511,6 +540,28 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                     leu.last_updated > %(timestamp)s
                  OR   u.last_updated > %(timestamp)s
                  OR  lt.last_updated > %(timestamp)s
+               )
+        """
+
+        # Event-event parts
+        # |  CTE / table       |  purpose                    | last_updated considered
+        # |  event_parts       |  multi part events          | l_event_event, link_type, event
+        event_parts_query = f"""
+            SELECT e.gid
+              FROM musicbrainz.event e
+              JOIN musicbrainz.l_event_event lee
+                ON lee.entity0 = e.id
+              JOIN musicbrainz.link l
+                ON lee.link = l.id
+              JOIN musicbrainz.link_type lt
+                ON l.link_type = lt.id
+              JOIN musicbrainz.event e2
+                ON lee.entity1 = e2.id
+             WHERE lt.gid = '{EVENT_PARTS_LINK_GID}'
+               AND (
+                    lee.last_updated > %(timestamp)s
+                 OR  lt.last_updated > %(timestamp)s
+                 OR  e2.last_updated > %(timestamp)s
                )
         """
 
@@ -593,6 +644,11 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
 
                 log("mb event metadata cache: querying event url rel changes")
                 curs.execute(event_url_rels_query, {"timestamp": timestamp})
+                for row in curs.fetchall():
+                    event_mbids.add(row[0])
+
+                log("mb event metadata cache: querying event parts changes")
+                curs.execute(event_parts_query, {"timestamp": timestamp})
                 for row in curs.fetchall():
                     event_mbids.add(row[0])
 

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -28,15 +28,12 @@ ARTIST_EVENT_LINK_BLOCKLIST_SQL = ", ".join(
     [f"'{x}'" for x in ARTIST_EVENT_LINK_BLOCKLIST]
 )
 
-EVENT_URL_LINK_GIDS = (
-    "c26808b0-4e67-31a7-a587-913720dfb3f3",  # official homepage
-    "68f5fcaa-b58c-3bfe-9b7c-75c2b56e839a",  # social network
-    "125afc57-4d33-3b63-ab41-848a3a18d3a6",  # songkick
-    "b022d060-e6a8-340f-8c73-6b21b1d090b9",  # wikidata
-    "08a982f7-d754-39b2-8315-d7cae474c641",  # wikipedia
-    "fea46163-dc45-3af9-917e-1798f325d21a",  # youtube
+EVENT_URL_LINK_BLOCKLIST = (
+    # nil UUID till we need to add stuff
+    # prevents NOT IN from being empty
+    "00000000-0000-0000-0000-000000000000",
 )
-EVENT_URL_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in EVENT_URL_LINK_GIDS])
+EVENT_URL_LINK_BLOCKLIST_SQL = ", ".join([f"'{x}'" for x in EVENT_URL_LINK_BLOCKLIST])
 
 EVENT_PLACE_LINK_GID = "e2c6f697-07dc-38b1-be0b-83d740165532"
 
@@ -329,7 +326,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                               JOIN musicbrainz.link_type lt
                                 ON l.link_type = lt.id
                               {values_join}
-                             WHERE lt.gid IN ({EVENT_URL_LINK_GIDS_SQL})
+                             WHERE lt.gid NOT IN ({EVENT_URL_LINK_BLOCKLIST_SQL})
                                AND NOT l.ended
                           GROUP BY e.gid
                    ), event_tags AS (
@@ -509,7 +506,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                 ON leu.link = l.id
               JOIN musicbrainz.link_type lt
                 ON l.link_type = lt.id
-             WHERE lt.gid IN ({EVENT_URL_LINK_GIDS_SQL})
+             WHERE lt.gid NOT IN ({EVENT_URL_LINK_BLOCKLIST_SQL})
                AND (
                     leu.last_updated > %(timestamp)s
                  OR   u.last_updated > %(timestamp)s

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -69,6 +69,7 @@ class MusicBrainzEventArtistCache(BulkInsertTable):
             ("artist_mbid ", "UUID NOT NULL"),
             ("artist_id ", "INTEGER NOT NULL"),
             ("link_id ", "INTEGER NOT NULL"),
+            ("link_order ", "INTEGER NOT NULL DEFAULT 0"),
             ("link_type_gid ", "UUID NOT NULL"),
             ("link_type_name ", "TEXT NOT NULL"),
             ("relationship_data ", "JSONB NOT NULL"),
@@ -94,7 +95,11 @@ class MusicBrainzEventArtistCache(BulkInsertTable):
             ("mb_event_artist_cache_idx_artist_mbid", "artist_mbid", False),
             ("mb_event_artist_cache_idx_event_id", "event_id", False),
             ("mb_event_artist_cache_idx_link_type_gid", "link_type_gid", False),
-            ("mb_event_artist_cache_pkey", "event_id, artist_id, link_id", True),
+            (
+                "mb_event_artist_cache_pkey",
+                "event_id, artist_id, link_id, link_order",
+                True,
+            ),
         ]
 
     def process_row(self, row):
@@ -313,6 +318,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
             link_type_gid = edge[3]
             link_type_name = edge[4]
             entity0_credit = edge[5]
+            link_order = edge[6]
 
             relationship_data = {}
             if entity0_credit:
@@ -325,6 +331,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                     artist_mbid,
                     artist_id,
                     link_id,
+                    link_order,
                     link_type_gid,
                     link_type_name,
                     ujson.dumps(relationship_data),
@@ -472,15 +479,16 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                    ), artist_edges AS (
                             SELECT e.gid AS event_mbid
                                  , array_agg(
-                                        jsonb_build_array(
-                                            a.gid
-                                          , a.id
-                                          , l.id
-                                          , lt.gid
-                                          , lt.name
-                                          , lae.entity0_credit
-                                        )
-                                   ) AS edges
+                                         jsonb_build_array(
+                                             a.gid
+                                           , a.id
+                                           , l.id
+                                           , lt.gid
+                                           , lt.name
+                                           , lae.entity0_credit
+                                           , lae.link_order
+                                         )
+                                    ) AS edges
                               FROM musicbrainz.event e
                               JOIN musicbrainz.l_artist_event lae
                                 ON lae.entity1 = e.id

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -151,7 +151,8 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
                         "1bfefc05-dbbb-4aaa-8d1b-6ddc00114eb7",
                         "9c81bb52-87be-48d5-a7cb-da91f6c94b5e",
                         "a777f05b-a934-4648-9a5c-60284b588c0e",
-                        "4996ec02-a2c6-405d-99b7-c545e3ad040a"
+                        "4996ec02-a2c6-405d-99b7-c545e3ad040a",
+                        "ab234290-d27d-45b6-9778-d21945906996",
                     )
                 ]
             ]

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -24,7 +24,14 @@ ARTIST_EVENT_LINK_GIDS = (
 )
 ARTIST_EVENT_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in ARTIST_EVENT_LINK_GIDS])
 
-EVENT_URL_LINK_GIDS = ()
+EVENT_URL_LINK_GIDS = (
+    "c26808b0-4e67-31a7-a587-913720dfb3f3",  # official homepage
+    "68f5fcaa-b58c-3bfe-9b7c-75c2b56e839a",  # social network
+    "125afc57-4d33-3b63-ab41-848a3a18d3a6",  # songkick
+    "b022d060-e6a8-340f-8c73-6b21b1d090b9",  # wikidata
+    "08a982f7-d754-39b2-8315-d7cae474c641",  # wikipedia
+    "fea46163-dc45-3af9-917e-1798f325d21a",  # youtube
+)
 EVENT_URL_LINK_GIDS_SQL = ", ".join([f"'{x}'" for x in EVENT_URL_LINK_GIDS])
 
 EVENT_PLACE_LINK_GID = "e2c6f697-07dc-38b1-be0b-83d740165532"

--- a/mbid_mapping/mapping/mb_event_metadata_cache.py
+++ b/mbid_mapping/mapping/mb_event_metadata_cache.py
@@ -66,7 +66,7 @@ class MusicBrainzEventArtistCache(BulkInsertTable):
             ("link_id ", "INTEGER NOT NULL"),
             ("link_type_gid ", "UUID NOT NULL"),
             ("link_type_name ", "TEXT NOT NULL"),
-            ("relationship_data ", "JSONB NOT NULL DEFAULT '{}'::jsonb"),
+            ("relationship_data ", "JSONB NOT NULL"),
             ("last_updated ", "TIMESTAMPTZ NOT NULL DEFAULT NOW()"),
         ]
 
@@ -139,7 +139,7 @@ class MusicBrainzEventMetadataCache(MusicBrainzEntityMetadataCache):
             ("area_mbid ", "UUID"),
             ("rating ", "SMALLINT"),
             ("rating_count ", "INTEGER"),
-            ("event_data ", "JSONB NOT NULL DEFAULT '{}'::jsonb"),
+            ("event_data ", "JSONB NOT NULL"),
         ]
 
     def get_insert_queries_test_values(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 norecursedirs=listenbrainz_spark relations listenbrainz/mbid_mapping
 addopts = -W always::DeprecationWarning -W error::sqlalchemy.exc.Base20DeprecationWarning --cov=listenbrainz --no-cov-on-fail --timeout=300
+pythonpath = mbid_mapping


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# Problem

<!--
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

:beginner: This covers most of Week 1 and 2 of my GSoC proposal.

The goal was to build the events cache, this includes creating the schema, and writing the builder that will pull the data from MusicBrainz, and populate the ListenBrainz tables.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

The schema changes are in `admin/timescale/` which includes updating the `create_tables.sql` script as well as adding an update patch script. The schema is almost exactly the same as in my proposal, with the changes I remember making being as follows:
- Changing `area_mbid` from `UUID[]` to `UUID` as we are not doing the unpacking anymore.
- Adding `rating` and `rating_count` as I realized that they would be pretty handy for a feature to sort events by rating. I don't know if it definitely _will_ be used, but it seems useful to me.

The main changes are in `mbid_mapping/mapping/mb_event_metadata_cache.py` which handles both `mapping.mb_event_cache` and `mapping.mb_event_artist_cache`. The `MusicBrainzEventMetadataCache` is partially based on [the artist cache](https://github.com/metabrainz/listenbrainz-server/blob/master/mbid_mapping/mapping/mb_artist_metadata_cache.py).

* [X] I have run the code and manually tested the changes

The outputs of my Timescale database are available [as a gist](https://gist.github.com/shirsakm/9803a8cdaeb1d300dda082d8d1421829). Things seem to be working fine.

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [ ] I did not use any AI
* [X] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [X] I understand all the changes made in this PR

I used AI to find the event MBIDs to use for testing in the minimal dataset. Mostly because it was mind numbing to go through the awful formatting of the entries. Good thing AI's don't have eyes.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Specifically for Monkey, since I recall you mentioning checking the performer / artist types like "main performer", "support act" et al. this would be a great time to check the existing types in the whole MB database, to see if any others would make sense to include.

2. If any of the tables [here](https://github.com/metabrainz/musicbrainz-server/blob/90ba9db3919fea57621b99e146f3b844011b57e1/admin/sql/CreateTables.sql#L1514-L1656) seem to contain things that should be included, please let me know.

3. Please double check if the schema is fine, rather, if anything that is currently stored in the JSON blob should be stored directly as a column instead. None of the tables I have not included should be too difficult to add to the JSON blob later, if we need that data, so it seems fine to me.