### PR TITLE
Fix duration_ms fallback bug in timescale_writer

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -111,7 +111,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
                 data['duration'] = duration * 1000  # convert into ms
             else:  # try duration_ms field next
                 duration_ms = listen['track_metadata']['additional_info'].get('duration_ms')
-                if duration:
+                if duration_ms:
                     data['duration'] = duration_ms
 
             msb_listens.append(data)


### PR DESCRIPTION
LB-2004
The code incorrectly checks duration instead of duration_ms when using the fallback field from additional_info, preventing duration_ms values from being stored. This change updates the condition to use duration_ms correctly.