### PR TITLE
LB-1988: Center fresh releases page on large screens

### DIFF
--- a/frontend/css/sass/fresh-releases.scss
+++ b/frontend/css/sass/fresh-releases.scss
@@ -307,18 +307,16 @@
 .releases-page-container {
   display: flex;
   gap: 1.5em;
-  @media screen and (min-width: map.get($grid-breakpoints, "lg")) {
-    // make the sidebar flush with the right-hand side on larger sizes
-    margin-right: -15px !important;
-  }
   .releases-page {
     flex: 1;
   }
   .sidebar-fresh-releases {
     max-height: 85vh;
+    margin-right: -15px;
 
     @media screen and (max-width: map.get($grid-breakpoints, "lg")) {
       max-height: calc(100vh - $brainzplayer-height);
+      margin-right: -8px;
     }
   }
 }


### PR DESCRIPTION
Before:
<img width="2653" height="1378" alt="image" src="https://github.com/user-attachments/assets/df0598b8-984d-4799-9495-0aa5bcd4e1e0" />


After:
<img width="2649" height="1373" alt="image" src="https://github.com/user-attachments/assets/c4138688-e377-4d22-9099-6d43a99d7680" />
