### PR TITLE
GSoC-26 Feature-2 In Playlist Track sorting

### DIFF
--- a/frontend/css/sass/playlists.scss
+++ b/frontend/css/sass/playlists.scss
@@ -217,6 +217,12 @@ $long-description-lines: 8;
   min-width: 3em;
 }
 
+.playlist-item-card .main-content .drag-handle.disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
 /* Pure CSS multiline ellipsis by Sagi Shrieber:
     http://hackingui.com/a-pure-css-solution-for-multiline-text-truncation/
 */
@@ -258,8 +264,23 @@ $long-description-lines: 8;
   align-items: center;
   gap: 1rem;
 }
+
 .playlist-card-list-view .text-summary,
 .playlist .text-summary {
   mask-image: none;
   -webkit-mask-image: none;
+}
+
+#playlist .header .playlist-tracks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+#playlist .header .playlist-tracks-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
 }

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -145,75 +145,72 @@ export default function PlaylistPage() {
       const base = tracks ?? [];
       setSortKey(option);
 
-      if (option === "shuffle") {
-        // Keep the same shuffle logic as the main playlists page
-        setDisplayedTracks([...base].sort(() => Math.random() - 0.5));
-        return;
+      switch (option) {
+        case "shuffle": {
+          setDisplayedTracks([...base].sort(() => Math.random() - 0.5));
+          return;
+        }
+        case "default": {
+          setDisplayedTracks(base);
+          return;
+        }
+        case "title": {
+          setDisplayedTracks(
+            [...base].sort((a, b) => {
+              const titleA = a.title ?? "";
+              const titleB = b.title ?? "";
+              const cmp = titleA
+                .toLowerCase()
+                .localeCompare(titleB.toLowerCase());
+              return cmp !== 0 ? cmp : getTieBreaker(a, b);
+            })
+          );
+          return;
+        }
+        case "artist": {
+          setDisplayedTracks(
+            [...base].sort((a, b) => {
+              const artistA = a.creator ?? "";
+              const artistB = b.creator ?? "";
+              const cmp = artistA
+                .toLowerCase()
+                .localeCompare(artistB.toLowerCase());
+              return cmp !== 0 ? cmp : getTieBreaker(a, b);
+            })
+          );
+          return;
+        }
+        case "recently_added": {
+          setDisplayedTracks(
+            [...base].sort((a, b) => {
+              const aTs = Date.parse(getTrackExtension(a)?.added_at || "");
+              const bTs = Date.parse(getTrackExtension(b)?.added_at || "");
+
+              const aValid = !Number.isNaN(aTs);
+              const bValid = !Number.isNaN(bTs);
+
+              // Newest first
+              if (aValid && bValid) {
+                return aTs !== bTs ? bTs - aTs : getTieBreaker(a, b);
+              }
+
+              if (aValid) return -1;
+              if (bValid) return 1;
+
+              return getTieBreaker(a, b);
+            })
+          );
+          return;
+        }
+        default: {
+          setDisplayedTracks(base);
+        }
       }
-
-      if (option === "default") {
-        setDisplayedTracks(base);
-        return;
-      }
-
-      if (option === "title") {
-        setDisplayedTracks(
-          [...base].sort((a, b) => {
-            const titleA = a.title ?? "";
-            const titleB = b.title ?? "";
-            const cmp = titleA
-              .toLowerCase()
-              .localeCompare(titleB.toLowerCase());
-            return cmp !== 0 ? cmp : getTieBreaker(a, b);
-          })
-        );
-        return;
-      }
-
-      if (option === "artist") {
-        setDisplayedTracks(
-          [...base].sort((a, b) => {
-            const artistA = a.creator ?? "";
-            const artistB = b.creator ?? "";
-            const cmp = artistA
-              .toLowerCase()
-              .localeCompare(artistB.toLowerCase());
-            return cmp !== 0 ? cmp : getTieBreaker(a, b);
-          })
-        );
-        return;
-      }
-
-      if (option === "recently_added") {
-        setDisplayedTracks(
-          [...base].sort((a, b) => {
-            const aTs = Date.parse(getTrackExtension(a)?.added_at || "");
-            const bTs = Date.parse(getTrackExtension(b)?.added_at || "");
-
-            const aValid = !Number.isNaN(aTs);
-            const bValid = !Number.isNaN(bTs);
-
-            // Newest first
-            if (aValid && bValid) {
-              return aTs !== bTs ? bTs - aTs : getTieBreaker(a, b);
-            }
-
-            if (aValid) return -1;
-            if (bValid) return 1;
-
-            return getTieBreaker(a, b);
-          })
-        );
-
-        return;
-      }
-      // If we add more sort options in the future, fall back to default order.
-      setDisplayedTracks(base);
     },
     [getTieBreaker, tracks]
   );
 
-  // Keep displayedTracks in sync with playlist changes, while preserving current sortKey.
+  // Re-apply whatever sort option is currently selected when the tracks change.
   React.useEffect(() => {
     setTrackSortOption(sortKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -36,6 +36,7 @@ import {
   LISTENBRAINZ_URI_PREFIX,
   PLAYLIST_TRACK_URI_PREFIX,
   PLAYLIST_URI_PREFIX,
+  getTrackExtension,
 } from "./utils";
 import SyndicationFeedModal from "../components/SyndicationFeedModal";
 import { getBaseUrl } from "../utils/utils";
@@ -46,7 +47,6 @@ import {
   removeTrackFromAmbientQueueAtom,
   setAmbientQueueAtom,
 } from "../common/brainzplayer/BrainzPlayerAtoms";
-import { getTrackExtension } from "./utils";
 
 export type PlaylistPageProps = {
   playlist: JSPFObject & {
@@ -61,7 +61,12 @@ export interface PlaylistPageState {
   loading: boolean;
 }
 
-type TrackSortKey = "default" | "date_added" | "title" | "artist" | "shuffle";
+type TrackSortKey =
+  | "default"
+  | "recently_added"
+  | "title"
+  | "artist"
+  | "shuffle";
 
 const makeJSPFTrack = (trackMetadata: TrackMetadata): JSPFTrack => {
   return {
@@ -156,7 +161,9 @@ export default function PlaylistPage() {
           [...base].sort((a, b) => {
             const titleA = a.title ?? "";
             const titleB = b.title ?? "";
-            const cmp = titleA.toLowerCase().localeCompare(titleB.toLowerCase());
+            const cmp = titleA
+              .toLowerCase()
+              .localeCompare(titleB.toLowerCase());
             return cmp !== 0 ? cmp : getTieBreaker(a, b);
           })
         );
@@ -168,35 +175,37 @@ export default function PlaylistPage() {
           [...base].sort((a, b) => {
             const artistA = a.creator ?? "";
             const artistB = b.creator ?? "";
-            const cmp = artistA.toLowerCase().localeCompare(artistB.toLowerCase());
+            const cmp = artistA
+              .toLowerCase()
+              .localeCompare(artistB.toLowerCase());
             return cmp !== 0 ? cmp : getTieBreaker(a, b);
           })
         );
         return;
       }
 
-      if (option === "date_added") {
+      if (option === "recently_added") {
         setDisplayedTracks(
           [...base].sort((a, b) => {
-            const aTs = Date.parse(getTrackExtension(a)?.added_at || '');
-            const bTs = Date.parse(getTrackExtension(b)?.added_at || '');
-      
+            const aTs = Date.parse(getTrackExtension(a)?.added_at || "");
+            const bTs = Date.parse(getTrackExtension(b)?.added_at || "");
+
             const aValid = !Number.isNaN(aTs);
             const bValid = !Number.isNaN(bTs);
-      
+
             // Newest first
             if (aValid && bValid) {
               return aTs !== bTs ? bTs - aTs : getTieBreaker(a, b);
             }
-      
+
             if (aValid) return -1;
             if (bValid) return 1;
-      
+
             return getTieBreaker(a, b);
           })
         );
-      
-        return; 
+
+        return;
       }
       // If we add more sort options in the future, fall back to default order.
       setDisplayedTracks(base);
@@ -654,7 +663,7 @@ export default function PlaylistPage() {
                   }
                 >
                   <option value="default">Default</option>
-                  <option value="date_added">Recently Added</option>
+                  <option value="recently_added">Recently Added</option>
                   <option value="title">Title (A-Z)</option>
                   <option value="artist">Artist (A-Z)</option>
                   <option value="shuffle">Shuffle</option>

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -68,6 +68,40 @@ type TrackSortKey =
   | "artist"
   | "shuffle";
 
+function shuffleTracks(tracks: JSPFTrack[]): JSPFTrack[] {
+  const arr = [...tracks];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function getTrackId(track: JSPFTrack): string {
+  return track.id ?? getRecordingMBIDFromJSPFTrack(track);
+}
+
+// After add/remove: keep shuffle order, drop missing tracks, append new ones.
+function syncShuffledTracksWithPlaylist(
+  shuffledOrder: JSPFTrack[],
+  playlistTracks: JSPFTrack[]
+): JSPFTrack[] {
+  const playlistById = new Map(
+    playlistTracks.map((track) => [getTrackId(track), track])
+  );
+
+  const keptInShuffleOrder = shuffledOrder
+    .map((track) => playlistById.get(getTrackId(track)))
+    .filter((track) => track !== undefined); // remove wherever undefined
+
+  const keptIds = new Set(keptInShuffleOrder.map(getTrackId));
+  const newlyAdded = playlistTracks.filter(
+    (track) => !keptIds.has(getTrackId(track))
+  );
+
+  return [...keptInShuffleOrder, ...newlyAdded];
+}
+
 const makeJSPFTrack = (trackMetadata: TrackMetadata): JSPFTrack => {
   return {
     identifier: [
@@ -126,98 +160,86 @@ export default function PlaylistPage() {
   const { track: tracks } = playlist;
   const [dontAskAgain, setDontAskAgain] = React.useState(false);
   const [sortKey, setSortKey] = React.useState<TrackSortKey>("default");
-  const [displayedTracks, setDisplayedTracks] = React.useState<JSPFTrack[]>(
-    playlistProps?.playlist?.track ?? []
-  );
+  const [shuffledTracks, setShuffledTracks] = React.useState<
+    JSPFTrack[] | null
+  >(null);
 
   React.useEffect(() => {
     setPlaylist(playlistProps?.playlist || {});
   }, [playlistProps?.playlist]);
 
   const getTieBreaker = React.useCallback((a: JSPFTrack, b: JSPFTrack) => {
-    const aId = a.id ?? getRecordingMBIDFromJSPFTrack(a);
-    const bId = b.id ?? getRecordingMBIDFromJSPFTrack(b);
-    return aId.localeCompare(bId);
+    return getTrackId(a).localeCompare(getTrackId(b));
   }, []);
+
+  const sortedTracks = React.useMemo(() => {
+    const base = tracks ?? [];
+
+    switch (sortKey) {
+      case "title":
+        return [...base].sort((a, b) => {
+          const titleA = a.title ?? "";
+          const titleB = b.title ?? "";
+          const cmp = titleA.toLowerCase().localeCompare(titleB.toLowerCase());
+          return cmp !== 0 ? cmp : getTieBreaker(a, b);
+        });
+      case "artist":
+        return [...base].sort((a, b) => {
+          const artistA = a.creator ?? "";
+          const artistB = b.creator ?? "";
+          const cmp = artistA
+            .toLowerCase()
+            .localeCompare(artistB.toLowerCase());
+          return cmp !== 0 ? cmp : getTieBreaker(a, b);
+        });
+      case "recently_added":
+        return [...base].sort((a, b) => {
+          const aTs = Date.parse(getTrackExtension(a)?.added_at || "");
+          const bTs = Date.parse(getTrackExtension(b)?.added_at || "");
+
+          const aValid = !Number.isNaN(aTs);
+          const bValid = !Number.isNaN(bTs);
+
+          if (aValid && bValid) {
+            return aTs !== bTs ? bTs - aTs : getTieBreaker(a, b);
+          }
+
+          if (aValid) return -1;
+          if (bValid) return 1;
+
+          return getTieBreaker(a, b);
+        });
+      case "shuffle":
+      case "default":
+      default:
+        return base;
+    }
+  }, [sortKey, tracks]);
+
+  const displayedTracks =
+    sortKey === "shuffle" && shuffledTracks ? shuffledTracks : sortedTracks;
 
   const setTrackSortOption = React.useCallback(
     (option: TrackSortKey) => {
-      const base = tracks ?? [];
       setSortKey(option);
 
-      switch (option) {
-        case "shuffle": {
-          const arr = [...base];
-          for (let i = arr.length - 1; i > 0; i -= 1) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [arr[i], arr[j]] = [arr[j], arr[i]];
-          }
-          setDisplayedTracks(arr);
-          return;
-        }
-        case "default": {
-          setDisplayedTracks(base);
-          return;
-        }
-        case "title": {
-          setDisplayedTracks(
-            [...base].sort((a, b) => {
-              const titleA = a.title ?? "";
-              const titleB = b.title ?? "";
-              const cmp = titleA
-                .toLowerCase()
-                .localeCompare(titleB.toLowerCase());
-              return cmp !== 0 ? cmp : getTieBreaker(a, b);
-            })
-          );
-          return;
-        }
-        case "artist": {
-          setDisplayedTracks(
-            [...base].sort((a, b) => {
-              const artistA = a.creator ?? "";
-              const artistB = b.creator ?? "";
-              const cmp = artistA
-                .toLowerCase()
-                .localeCompare(artistB.toLowerCase());
-              return cmp !== 0 ? cmp : getTieBreaker(a, b);
-            })
-          );
-          return;
-        }
-        case "recently_added": {
-          setDisplayedTracks(
-            [...base].sort((a, b) => {
-              const aTs = Date.parse(getTrackExtension(a)?.added_at || "");
-              const bTs = Date.parse(getTrackExtension(b)?.added_at || "");
-
-              const aValid = !Number.isNaN(aTs);
-              const bValid = !Number.isNaN(bTs);
-
-              // Newest first
-              if (aValid && bValid) {
-                return aTs !== bTs ? bTs - aTs : getTieBreaker(a, b);
-              }
-
-              if (aValid) return -1;
-              if (bValid) return 1;
-
-              return getTieBreaker(a, b);
-            })
-          );
-          return;
-        }
-        default: {
-          setDisplayedTracks(base);
-        }
+      if (option === "shuffle") {
+        setShuffledTracks(shuffleTracks(tracks ?? []));
+      } else {
+        setShuffledTracks(null);
       }
     },
-    [getTieBreaker, tracks]
+    [tracks]
   );
 
-  // Re-apply whatever sort option is currently selected when the tracks change.
   React.useEffect(() => {
-    setTrackSortOption(sortKey);
+    if (sortKey !== "shuffle") {
+      return;
+    }
+
+    setShuffledTracks((prev) =>
+      prev === null ? null : syncShuffledTracksWithPlaylist(prev, tracks ?? [])
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tracks]);
 
@@ -681,7 +703,7 @@ export default function PlaylistPage() {
                     window.postMessage(
                       {
                         brainzplayer_event: "play-ambient-queue",
-                        payload: tracks,
+                        payload: displayedTracks,
                       },
                       window.location.origin
                     );

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -147,7 +147,12 @@ export default function PlaylistPage() {
 
       switch (option) {
         case "shuffle": {
-          setDisplayedTracks([...base].sort(() => Math.random() - 0.5));
+          const arr = [...base];
+          for (let i = arr.length - 1; i > 0; i -= 1) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [arr[i], arr[j]] = [arr[j], arr[i]];
+          }
+          setDisplayedTracks(arr);
           return;
         }
         case "default": {
@@ -654,6 +659,7 @@ export default function PlaylistPage() {
                   id="playlistTrackSort"
                   className="form-select"
                   style={{ width: "auto" }}
+                  aria-label="Sort playlist tracks by"
                   value={sortKey}
                   onChange={(e) =>
                     setTrackSortOption(e.target.value as TrackSortKey)

--- a/frontend/js/src/playlists/Playlist.tsx
+++ b/frontend/js/src/playlists/Playlist.tsx
@@ -46,6 +46,7 @@ import {
   removeTrackFromAmbientQueueAtom,
   setAmbientQueueAtom,
 } from "../common/brainzplayer/BrainzPlayerAtoms";
+import { getTrackExtension } from "./utils";
 
 export type PlaylistPageProps = {
   playlist: JSPFObject & {
@@ -59,6 +60,8 @@ export interface PlaylistPageState {
   playlist: JSPFPlaylist;
   loading: boolean;
 }
+
+type TrackSortKey = "default" | "date_added" | "title" | "artist" | "shuffle";
 
 const makeJSPFTrack = (trackMetadata: TrackMetadata): JSPFTrack => {
   return {
@@ -117,10 +120,95 @@ export default function PlaylistPage() {
   );
   const { track: tracks } = playlist;
   const [dontAskAgain, setDontAskAgain] = React.useState(false);
+  const [sortKey, setSortKey] = React.useState<TrackSortKey>("default");
+  const [displayedTracks, setDisplayedTracks] = React.useState<JSPFTrack[]>(
+    playlistProps?.playlist?.track ?? []
+  );
 
   React.useEffect(() => {
     setPlaylist(playlistProps?.playlist || {});
   }, [playlistProps?.playlist]);
+
+  const getTieBreaker = React.useCallback((a: JSPFTrack, b: JSPFTrack) => {
+    const aId = a.id ?? getRecordingMBIDFromJSPFTrack(a);
+    const bId = b.id ?? getRecordingMBIDFromJSPFTrack(b);
+    return aId.localeCompare(bId);
+  }, []);
+
+  const setTrackSortOption = React.useCallback(
+    (option: TrackSortKey) => {
+      const base = tracks ?? [];
+      setSortKey(option);
+
+      if (option === "shuffle") {
+        // Keep the same shuffle logic as the main playlists page
+        setDisplayedTracks([...base].sort(() => Math.random() - 0.5));
+        return;
+      }
+
+      if (option === "default") {
+        setDisplayedTracks(base);
+        return;
+      }
+
+      if (option === "title") {
+        setDisplayedTracks(
+          [...base].sort((a, b) => {
+            const titleA = a.title ?? "";
+            const titleB = b.title ?? "";
+            const cmp = titleA.toLowerCase().localeCompare(titleB.toLowerCase());
+            return cmp !== 0 ? cmp : getTieBreaker(a, b);
+          })
+        );
+        return;
+      }
+
+      if (option === "artist") {
+        setDisplayedTracks(
+          [...base].sort((a, b) => {
+            const artistA = a.creator ?? "";
+            const artistB = b.creator ?? "";
+            const cmp = artistA.toLowerCase().localeCompare(artistB.toLowerCase());
+            return cmp !== 0 ? cmp : getTieBreaker(a, b);
+          })
+        );
+        return;
+      }
+
+      if (option === "date_added") {
+        setDisplayedTracks(
+          [...base].sort((a, b) => {
+            const aTs = Date.parse(getTrackExtension(a)?.added_at || '');
+            const bTs = Date.parse(getTrackExtension(b)?.added_at || '');
+      
+            const aValid = !Number.isNaN(aTs);
+            const bValid = !Number.isNaN(bTs);
+      
+            // Newest first
+            if (aValid && bValid) {
+              return aTs !== bTs ? bTs - aTs : getTieBreaker(a, b);
+            }
+      
+            if (aValid) return -1;
+            if (bValid) return 1;
+      
+            return getTieBreaker(a, b);
+          })
+        );
+      
+        return; 
+      }
+      // If we add more sort options in the future, fall back to default order.
+      setDisplayedTracks(base);
+    },
+    [getTieBreaker, tracks]
+  );
+
+  // Keep displayedTracks in sync with playlist changes, while preserving current sortKey.
+  React.useEffect(() => {
+    setTrackSortOption(sortKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tracks]);
 
   // Functions
   const alertMustBeLoggedIn = () => {
@@ -371,6 +459,7 @@ export default function PlaylistPage() {
   const [showMore, setShowMore] = React.useState(false);
   const isLongDescription =
     playlist?.annotation && playlist.annotation.length > 400;
+  const dragEnabled = sortKey === "default";
   return (
     <div role="main">
       <Helmet>
@@ -548,27 +637,49 @@ export default function PlaylistPage() {
         className="col-md-8 offset-md-2"
       >
         <div className="header">
-          <h3 className="header-with-line">
-            Tracks
-            {Boolean(playlist.track?.length) && (
-              <button
-                type="button"
-                className="btn btn-info btn-rounded play-tracks-button"
-                title="Play all tracks"
-                onClick={() => {
-                  window.postMessage(
-                    {
-                      brainzplayer_event: "play-ambient-queue",
-                      payload: tracks,
-                    },
-                    window.location.origin
-                  );
-                }}
-              >
-                <FontAwesomeIcon icon={faPlayCircle} fixedWidth /> Play all
-              </button>
-            )}
-          </h3>
+          <div className="playlist-tracks-header">
+            <h3 className="header-with-line">Tracks</h3>
+            <div className="playlist-tracks-header-controls">
+              <div className="playlist-sort-controls">
+                <label htmlFor="playlistTrackSort" className="text-muted">
+                  Sort By:
+                </label>
+                <select
+                  id="playlistTrackSort"
+                  className="form-select"
+                  style={{ width: "auto" }}
+                  value={sortKey}
+                  onChange={(e) =>
+                    setTrackSortOption(e.target.value as TrackSortKey)
+                  }
+                >
+                  <option value="default">Default</option>
+                  <option value="date_added">Recently Added</option>
+                  <option value="title">Title (A-Z)</option>
+                  <option value="artist">Artist (A-Z)</option>
+                  <option value="shuffle">Shuffle</option>
+                </select>
+              </div>
+              {Boolean(playlist.track?.length) && (
+                <button
+                  type="button"
+                  className="btn btn-info btn-rounded play-tracks-button"
+                  title="Play all tracks"
+                  onClick={() => {
+                    window.postMessage(
+                      {
+                        brainzplayer_event: "play-ambient-queue",
+                        payload: tracks,
+                      },
+                      window.location.origin
+                    );
+                  }}
+                >
+                  <FontAwesomeIcon icon={faPlayCircle} fixedWidth /> Play all
+                </button>
+              )}
+            </div>
+          </div>
         </div>
         {userHasRightToEdit && tracks && tracks.length > 10 && (
           <div className="text-center">
@@ -587,25 +698,36 @@ export default function PlaylistPage() {
         )}
         <div id="listens row">
           {tracks && tracks.length > 0 ? (
-            <ReactSortable
-              handle=".drag-handle"
-              list={tracks as (JSPFTrack & { id: string })[]}
-              onEnd={movePlaylistItem}
-              setList={(newState) =>
-                setPlaylist({ ...playlist, track: newState })
-              }
-            >
-              {tracks.map((track: JSPFTrack, index) => {
-                return (
+            (() => {
+              const trackRows = displayedTracks.map(
+                (track: JSPFTrack, index) => (
                   <PlaylistItemCard
                     key={`${track.id}-${index.toString()}`}
                     canEdit={userHasRightToEdit}
+                    dragEnabled={dragEnabled}
                     track={track}
                     removeTrackFromPlaylist={deletePlaylistItem}
                   />
-                );
-              })}
-            </ReactSortable>
+                )
+              );
+
+              if (!dragEnabled) {
+                return trackRows;
+              }
+
+              return (
+                <ReactSortable
+                  handle=".drag-handle"
+                  list={displayedTracks as (JSPFTrack & { id: string })[]}
+                  onEnd={movePlaylistItem}
+                  setList={(newState) =>
+                    setPlaylist({ ...playlist, track: newState })
+                  }
+                >
+                  {trackRows}
+                </ReactSortable>
+              );
+            })()
           ) : (
             <div className="lead text-center">
               <p>Nothing in this playlist yet</p>

--- a/frontend/js/src/playlists/components/PlaylistItemCard.tsx
+++ b/frontend/js/src/playlists/components/PlaylistItemCard.tsx
@@ -52,9 +52,7 @@ export default class PlaylistItemCard extends React.Component<
             : "Switch to Default order to reorder tracks"
         }
       >
-        <FontAwesomeIcon
-          icon={faGripLines as IconProp}
-        />
+        <FontAwesomeIcon icon={faGripLines as IconProp} />
       </div>
     ) : undefined;
     let additionalMenuItems;

--- a/frontend/js/src/playlists/components/PlaylistItemCard.tsx
+++ b/frontend/js/src/playlists/components/PlaylistItemCard.tsx
@@ -11,6 +11,7 @@ import ListenControl from "../../common/listens/ListenControl";
 export type PlaylistItemCardProps = {
   track: JSPFTrack;
   canEdit: Boolean;
+  dragEnabled?: boolean;
   removeTrackFromPlaylist?: (track: JSPFTrack) => void;
   showTimestamp?: boolean;
   showUsername?: boolean;
@@ -30,6 +31,7 @@ export default class PlaylistItemCard extends React.Component<
     const {
       track,
       canEdit,
+      dragEnabled,
       showUsername,
       showTimestamp,
       removeTrackFromPlaylist,
@@ -39,11 +41,19 @@ export default class PlaylistItemCard extends React.Component<
     //   ? millisecondsToStr(track.duration)
     //   : null;
 
+    const isDragEnabled = dragEnabled ?? true;
     const dragHandle = canEdit ? (
-      <div className="drag-handle text-muted">
+      <div
+        className={`drag-handle text-muted ${isDragEnabled ? "" : "disabled"}`}
+        aria-disabled={!isDragEnabled}
+        title={
+          isDragEnabled
+            ? "Drag to reorder"
+            : "Switch to Default order to reorder tracks"
+        }
+      >
         <FontAwesomeIcon
           icon={faGripLines as IconProp}
-          title="Drag to reorder"
         />
       </div>
     ) : undefined;

--- a/frontend/js/tests/playlists/Playlist.test.tsx
+++ b/frontend/js/tests/playlists/Playlist.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { RouterProvider, createMemoryRouter } from "react-router";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import PlaylistPage from "../../src/playlists/Playlist";
 import * as playlistPageProps from "../__mocks__/playlistPageProps.json";
 import { MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION } from "../../src/playlists/utils";
@@ -48,10 +49,17 @@ describe("PlaylistPage", () => {
   });
 
   it("hides exportPlaylistToSpotify button if playlist permissions are absent", () => {
-    renderWithProviders(<RouterProvider router={router} />, {}, {}, false);
-    expect(
-      screen.queryByText("Export to Spotify", { exact: false })
-    ).not.toBeInTheDocument();
+    renderWithProviders(
+      <RouterProvider router={router} />,
+      {},
+      { wrapper: ReactQueryWrapper },
+      false
+    );
+    // Button exists but is disabled when permissions are missing
+    const exportButton = screen.getByRole("button", {
+      name: /export to spotify/i,
+    });
+    expect(exportButton).toHaveClass("disabled");
   });
 
   it("shows exportPlaylistToSpotify button if playlist permissions are present", () => {
@@ -69,11 +77,141 @@ describe("PlaylistPage", () => {
     renderWithProviders(
       <RouterProvider router={router} />,
       alternativeContextMock,
-      {
-        wrapper: ReactQueryWrapper,
-      },
+      { wrapper: ReactQueryWrapper },
       false
     );
     screen.getByText("Export to Spotify", { exact: false });
+  });
+
+  it("sorts playlist tracks in the UI", async () => {
+    const makeTrack = (
+      id: string,
+      title: string,
+      creator: string,
+      addedAt: string
+    ): JSPFTrack => ({
+      id,
+      identifier: `https://musicbrainz.org/recording/${id}`,
+      title,
+      creator,
+      extension: {
+        "https://musicbrainz.org/doc/jspf#track": {
+          added_by: "tester",
+          added_at: addedAt,
+        },
+      },
+    });
+  
+    const playlistForSortTest: JSPFObject = {
+      playlist: {
+        creator: "tester",
+        identifier:
+          "https://listenbrainz.org/playlist/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        date: "2026-01-01T00:00:00Z",
+        title: "Sort test playlist",
+        track: [
+          makeTrack(
+            "11111111-1111-1111-1111-111111111111",
+            "Zoo",
+            "Bravo",
+            "2026-01-01T00:00:00Z"
+          ),
+          makeTrack(
+            "22222222-2222-2222-2222-222222222222",
+            "Alpha",
+            "Charlie",
+            "2026-03-02T00:00:00Z"
+          ),
+          makeTrack(
+            "33333333-3333-3333-3333-333333333333",
+            "Mango",
+            "Able",
+            "2026-04-03T00:00:00Z"
+          ),
+        ],
+        extension: {
+          [MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION]: {
+            public: true,
+            collaborators: [],
+          },
+        },
+      },
+    };
+  
+    const sortRouter = createMemoryRouter(
+      [
+        {
+          path: "/playlist/:playlistID/",
+          element: <PlaylistPage />,
+          loader: () => ({
+            playlist: playlistForSortTest,
+            coverArtGridOptions: [],
+            coverArt: null,
+          }),
+        },
+      ],
+      {
+        initialEntries: ["/playlist/sort-test/"],
+      }
+    );
+  
+    renderWithProviders(
+      <RouterProvider router={sortRouter} />,
+      {},
+      { wrapper: ReactQueryWrapper },
+      false
+    );
+  
+    await screen.findByTestId("playlist");
+  
+    const knownTitles = ["Zoo", "Alpha", "Mango"];
+  
+    const getRenderedTitles = async () => {
+      const listens = await screen.findAllByTestId("listen");
+  
+      return listens.map((listen) => {
+        return (
+          knownTitles.find((title) =>
+            within(listen).queryByText(title)
+          ) ?? null
+        );
+      });
+    };
+  
+    const user = userEvent.setup();
+    const sortSelect = screen.getByRole("combobox");
+  
+    const expectSortedOrder = async (
+      option: string,
+      expectedTitles: string[]
+    ) => {
+      await user.selectOptions(sortSelect, option);
+      expect(await getRenderedTitles()).toEqual(expectedTitles);
+    };
+  
+    // Default order
+    expect(await getRenderedTitles()).toEqual([
+      "Zoo",
+      "Alpha",
+      "Mango",
+    ]);
+  
+    await expectSortedOrder("Title (A-Z)", [
+      "Alpha",
+      "Mango",
+      "Zoo",
+    ]);
+  
+    await expectSortedOrder("Artist (A-Z)", [
+      "Mango",
+      "Zoo",
+      "Alpha",
+    ]);
+  
+    await expectSortedOrder("Recently Added", [
+      "Mango",
+      "Alpha",
+      "Zoo",
+    ]);
   });
 });

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, render_template, jsonify
+from flask import Blueprint, current_app, render_template, jsonify, request
 from flask_login import current_user
 
 from listenbrainz.webserver import ts_conn, db_conn
@@ -107,7 +107,17 @@ def load_playlist(playlist_mbid: str):
     if playlist is None or not playlist.is_visible_by(current_user_id):
         return jsonify({"error": "Cannot find playlist: %s" % playlist_mbid}), 404
 
-    fetch_playlist_recording_metadata(playlist)
+    # MB metadata lookup is optional in dev environments where MB db isn't configured.
+    # Mirror the behaviour of the API endpoint GET /1/playlist/<mbid>?fetch_metadata=false
+    # so the playlist page can still render (and allow client-side sorting) without MB data.
+    fetch_metadata = request.args.get("fetch_metadata", "true").lower() != "false"
+    if fetch_metadata:
+        try:
+            fetch_playlist_recording_metadata(playlist)
+        except Exception:
+            current_app.logger.error(
+                "Error while fetching metadata for a playlist:", exc_info=True
+            )
 
     images = get_cover_art_options(playlist)
     

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, render_template, jsonify, request
+from flask import Blueprint, current_app, render_template, jsonify
 from flask_login import current_user
 
 from listenbrainz.webserver import ts_conn, db_conn

--- a/listenbrainz/webserver/views/playlist.py
+++ b/listenbrainz/webserver/views/playlist.py
@@ -107,17 +107,7 @@ def load_playlist(playlist_mbid: str):
     if playlist is None or not playlist.is_visible_by(current_user_id):
         return jsonify({"error": "Cannot find playlist: %s" % playlist_mbid}), 404
 
-    # MB metadata lookup is optional in dev environments where MB db isn't configured.
-    # Mirror the behaviour of the API endpoint GET /1/playlist/<mbid>?fetch_metadata=false
-    # so the playlist page can still render (and allow client-side sorting) without MB data.
-    fetch_metadata = request.args.get("fetch_metadata", "true").lower() != "false"
-    if fetch_metadata:
-        try:
-            fetch_playlist_recording_metadata(playlist)
-        except Exception:
-            current_app.logger.error(
-                "Error while fetching metadata for a playlist:", exc_info=True
-            )
+    fetch_playlist_recording_metadata(playlist)
 
     images = get_cover_art_options(playlist)
     


### PR DESCRIPTION
# PR Description

[LB-1374](https://tickets.metabrainz.org/browse/LB-1374)

Added a Sort By dropdown on the individual playlist page so users can reorder how tracks are displayed without changing the playlist's saved order.

Sorting is frontend-only. Drag-to-reorder is available in Default Mode only; all other sort modes are temporary views.

## What changed

### UI

Added a Sort By `<select>` in the playlist tracks header, next to **Play all**.

**Sort options:**

- Default — original playlist order (same as stored on the server)
- Recently Added — newest `added_at` first (from JSPF track extension)
- Title (A–Z) — case-insensitive
- Artist (A–Z) — case-insensitive
- Shuffle — random permutation (same approach used on the main playlists page)

A `useEffect` re-applies the active sort when tracks change, so the view stays consistent.

When `dragEnabled` is disabled, the drag handle is dimmed and the cursor becomes `not-allowed`.

## Testing

### Manual testing

For local verification, I used one cached test playlist in my dev environment instead of creating new playlists each time.

That playlist had multiple tracks with distinct titles, artists, and `added_at` values in the JSPF track extension.

### Tests (`Playlist.test.tsx`)

Added a new test, **"sorts playlist tracks in the UI"**, which verifies Default, Title, Artist, and Recently Added ordering using mocked JSPF tracks.

<img width="500" height="300" alt="Screenshot 2026-06-13 054114" src="https://github.com/user-attachments/assets/99afe3c8-e0e5-469a-ad5a-5c3422111129" />
