### PR TITLE
docs: clarify when imported/backdated listens appear in statistics

### DIFF
--- a/docs/general/data-update-intervals.rst
+++ b/docs/general/data-update-intervals.rst
@@ -9,6 +9,7 @@ System                                          Update schedule
 Receiving listens, updating listen counts		Immediate [#f1]_
 Deleting listens					                  Removed at the top of the next hour (UTC)
 Updating statistics for new listens			    Daily [#f2]_
+Updating statistics for older listens/imports   1st and 15th of each month
 Artist/album stats				                  Daily
 Removing deleted listens from stats			    On the 2nd and 16th of each month
 Full dumps						                      1st and 15th of each month
@@ -28,7 +29,7 @@ This complicated schedule is caused by ListenBrainz having a lot of interconnect
 different scales. For more details, read on!
 
 .. [#f1] Listens via a connected Spotify account may not be submitted immediately, causing a short delay
-.. [#f2] "New listens" means listens played recently. Imported or backdated listens only appear in statistics after the next full dump (1st or 15th); see `User Statistics`_.
+.. [#f2] Statistics may take longer on the 1st and 15th of each month
 .. [#f3] To generate daily playlists, follow `troi-bot <https://listenbrainz.org/user/troi-bot/>`_.
 
 Listens and Listen Counts

--- a/docs/general/data-update-intervals.rst
+++ b/docs/general/data-update-intervals.rst
@@ -28,7 +28,7 @@ This complicated schedule is caused by ListenBrainz having a lot of interconnect
 different scales. For more details, read on!
 
 .. [#f1] Listens via a connected Spotify account may not be submitted immediately, causing a short delay
-.. [#f2] Statistics may take longer on the 1st and 15th of each month
+.. [#f2] "New listens" means listens played recently. Imported or backdated listens only appear in statistics after the next full dump (1st or 15th); see `User Statistics`_.
 .. [#f3] To generate daily playlists, follow `troi-bot <https://listenbrainz.org/user/troi-bot/>`_.
 
 Listens and Listen Counts
@@ -64,6 +64,11 @@ import a new full data dump on the 2nd and 16th day of the month.
 
 For example: If you delete a listen on the 5th day of the month, you can expect that the statistics generated
 on the 17th will reflect the current stats of your listens as of the end of the 14th day of the month.
+
+Imported and backdated listens are a special case. The daily update only recalculates statistics for listens
+played recently, so an imported history — whose listens are dated months or years ago — is skipped until the next
+full dump rebuilds all statistics from scratch. After a large import, allow up to two weeks for it to appear in
+your statistics; your listen counts update immediately.
 
 We recognize that this is less than ideal – we’re considering how to improve this and to make the ingestion
 of listens and the deletion of listens both happen in real time.

--- a/frontend/js/src/settings/import/ImportListens.tsx
+++ b/frontend/js/src/settings/import/ImportListens.tsx
@@ -212,6 +212,18 @@ function renderImport(
             import
           </b>
         </p>
+        <p>
+          Your listen counts update right away, but imported listens can take up
+          to two weeks to appear in your{" "}
+          <a
+            href="https://listenbrainz.readthedocs.io/en/latest/general/data-update-intervals.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            statistics
+          </a>
+          .
+        </p>
         {extraInfo}
       </div>
     );


### PR DESCRIPTION
## Problem

The [Data Update Intervals](https://listenbrainz.readthedocs.io/en/latest/general/data-update-intervals.html) table lists **"Updating statistics for new listens → Daily"**. A user who imports a large historical archive (e.g. a Spotify *extended streaming history* spanning years) reasonably reads this as "my stats will update tomorrow" — but they don't, and the page never explains why. The only relevant line is **"Full dumps → 1st and 15th"**, which reads like it's about the downloadable database dumps rather than a stats rebuild.

This came up in the community Discord: a new user imported ~10 years of Spotify history, saw listen counts update but stats stay flat, and dug through the wiki without finding an answer. A maintainer confirmed the relevant behaviour is the full dump on the 1st/15th, and that the wording could be clearer.

## Why it happens

"New listens" silently means *recently played* listens. The daily incremental stats job filters listens by `listened_at` against the window each statistic covers (this week/month/year), so imported listens — which carry old `listened_at` timestamps even though they were just submitted — are skipped daily. They only enter statistics when the full-dump rebuild on the 1st/15th recalculates everything from the complete history.

## Changes (docs + one UI note)

- **`docs/general/data-update-intervals.rst`**
  - Expand footnote `[#f2]` to spell out that "new listens" = recently played, and that imported/backdated listens land at the next full dump.
  - Add a note to the *User Statistics* section covering import behaviour, the ~2-week expectation, and clarifying that "full dump" is the same process behind the downloadable data dumps.
- **`frontend/js/src/settings/import/ImportListens.tsx`**
  - Add a short note to the *Import completed!* message linking to the intervals docs, so the expectation is set right where people import.

No behavioural/code-logic changes — wording only.

Opening as a draft for maintainer review of the wording; happy to adjust tone, trim, or split the UI note into a separate PR if preferred.
