### PR TITLE
GSoC-26 Add Tags To Playlists - Backend

### DIFF
--- a/admin/timescale/create_foreign_keys.sql
+++ b/admin/timescale/create_foreign_keys.sql
@@ -18,4 +18,10 @@ ALTER TABLE playlist.playlist_collaborator
     REFERENCES "playlist".playlist (id)
     ON DELETE CASCADE;
 
+ALTER TABLE playlist.playlist_tag
+    ADD CONSTRAINT playlist_tag_playlist_id_foreign_key
+    FOREIGN KEY (playlist_id)
+    REFERENCES "playlist".playlist (id)
+    ON DELETE CASCADE;
+
 COMMIT;

--- a/admin/timescale/create_primary_keys.sql
+++ b/admin/timescale/create_primary_keys.sql
@@ -2,6 +2,7 @@ BEGIN;
 
 ALTER TABLE playlist.playlist ADD CONSTRAINT playlist_pkey PRIMARY KEY (id);
 ALTER TABLE playlist.playlist_recording ADD CONSTRAINT playlist_recording_pkey PRIMARY KEY (id);
+ALTER TABLE playlist.playlist_tag ADD CONSTRAINT playlist_tag_pkey PRIMARY KEY (id);
 ALTER TABLE mbid_mapping_metadata ADD CONSTRAINT mbid_mapping_metadata_pkey PRIMARY KEY (recording_mbid);
 ALTER TABLE mapping.mb_metadata_cache ADD CONSTRAINT mb_metadata_cache_pkey PRIMARY KEY (recording_mbid);
 ALTER TABLE background_worker_state ADD CONSTRAINT background_worker_state_pkey PRIMARY KEY (key);

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -76,14 +76,6 @@ CREATE TABLE playlist.playlist_tag (
 CREATE INDEX playlist_tag_playlist_id_idx ON playlist.playlist_tag (playlist_id);
 CREATE INDEX playlist_tag_tag_idx ON playlist.playlist_tag (tag);
 
-ALTER TABLE playlist.playlist_tag ADD CONSTRAINT playlist_tag_pkey PRIMARY KEY (id);
-
-ALTER TABLE playlist.playlist_tag
-    ADD CONSTRAINT playlist_tag_playlist_id_foreign_key
-    FOREIGN KEY (playlist_id)
-    REFERENCES "playlist".playlist (id)
-    ON DELETE CASCADE; -- Deleting a playlist will delete all tags associated with it
-
 -- MBID Mapping
 
 CREATE TABLE mbid_manual_mapping(

--- a/admin/timescale/create_tables.sql
+++ b/admin/timescale/create_tables.sql
@@ -65,6 +65,25 @@ CREATE TABLE playlist.playlist_collaborator (
     collaborator_id int not null  -- link to user.id in main database
 );
 
+CREATE TABLE playlist.playlist_tag (
+    id serial,
+    playlist_id int not null,  -- FK playlist.playlist.id
+    tag text not null,
+    created timestamp with time zone default now() not null,
+    UNIQUE (playlist_id, tag)
+);
+
+CREATE INDEX playlist_tag_playlist_id_idx ON playlist.playlist_tag (playlist_id);
+CREATE INDEX playlist_tag_tag_idx ON playlist.playlist_tag (tag);
+
+ALTER TABLE playlist.playlist_tag ADD CONSTRAINT playlist_tag_pkey PRIMARY KEY (id);
+
+ALTER TABLE playlist.playlist_tag
+    ADD CONSTRAINT playlist_tag_playlist_id_foreign_key
+    FOREIGN KEY (playlist_id)
+    REFERENCES "playlist".playlist (id)
+    ON DELETE CASCADE; -- Deleting a playlist will delete all tags associated with it
+
 -- MBID Mapping
 
 CREATE TABLE mbid_manual_mapping(

--- a/admin/timescale/updates/2026-05-04-add-playlist-tags.sql
+++ b/admin/timescale/updates/2026-05-04-add-playlist-tags.sql
@@ -1,0 +1,40 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS playlist.playlist_tag (
+    id SERIAL,
+    playlist_id INT NOT NULL, -- FK playlist.playlist.id
+    tag TEXT NOT NULL,
+    created TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    UNIQUE (playlist_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS playlist_tag_playlist_id_idx
+    ON playlist.playlist_tag (playlist_id);
+
+CREATE INDEX IF NOT EXISTS playlist_tag_tag_idx
+    ON playlist.playlist_tag (tag);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'playlist_tag_pkey'
+    ) THEN
+        ALTER TABLE playlist.playlist_tag ADD CONSTRAINT playlist_tag_pkey PRIMARY KEY (id);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'playlist_tag_playlist_id_foreign_key'
+    ) THEN
+        ALTER TABLE playlist.playlist_tag
+            ADD CONSTRAINT playlist_tag_playlist_id_foreign_key
+            FOREIGN KEY (playlist_id)
+            REFERENCES "playlist".playlist (id)
+            ON DELETE CASCADE;
+    END IF;
+END $$;
+
+COMMIT;
+

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -27,6 +27,7 @@ SEARCH_PLAYLIST_SORTS = {
     "creator": "pl.creator_id ASC",
 }
 MAX_PLAYLIST_TAG_LENGTH = 40
+MAX_TAGS_PER_PLAYLIST = 50
 
 # These are the recommendation troi patches that we showcase on the recommendations page for each user
 RECOMMENDATION_PATCHES = (
@@ -286,7 +287,7 @@ def _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings, incl
     return playlists
 
 
-def _normalize_playlist_tag(tag: str) -> Optional[str]:
+def normalize_playlist_tag(tag: str) -> Optional[str]:
     if tag is None:
         return None
     tag = " ".join(tag.strip().split()).lower()
@@ -302,7 +303,7 @@ def _normalize_playlist_tags(tags: Optional[List[str]]) -> List[str]:
         return []
     normalized = []
     for tag in tags:
-        n = _normalize_playlist_tag(tag)
+        n = normalize_playlist_tag(tag)
         if n:
             normalized.append(n)
     # preserve order but remove duplicates
@@ -340,20 +341,37 @@ def add_tags_to_playlist(ts_conn, playlist_id: int, tags: List[str]) -> int:
     if not normalized:
         return 0
 
+    existing_query = text("""
+        SELECT tag
+          FROM playlist.playlist_tag
+         WHERE playlist_id = :playlist_id
+    """)
+    existing_tags = {
+        row.tag for row in ts_conn.execute(existing_query, {"playlist_id": playlist_id})
+    }
+    new_tags = [tag for tag in normalized if tag not in existing_tags]
+    if not new_tags:
+        return 0
+
+    if len(existing_tags) + len(new_tags) > MAX_TAGS_PER_PLAYLIST:
+        raise ValueError(
+            "Cannot add more than %d tags to a playlist." % MAX_TAGS_PER_PLAYLIST
+        )
+
     query = text("""
         INSERT INTO playlist.playlist_tag (playlist_id, tag)
         SELECT :playlist_id, t.tag
           FROM unnest(:tags) AS t(tag)
         ON CONFLICT DO NOTHING
     """)
-    result = ts_conn.execute(query, {"playlist_id": playlist_id, "tags": normalized})
+    result = ts_conn.execute(query, {"playlist_id": playlist_id, "tags": new_tags})
     ts_conn.commit()
     return result.rowcount or 0
 
 
 def remove_tag_from_playlist(ts_conn, playlist_id: int, tag: str) -> int:
     
-    tag = _normalize_playlist_tag(tag)
+    tag = normalize_playlist_tag(tag)
     if not tag:
         return 0
 

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -338,16 +338,7 @@ def _tag_filter_with_combined_ctes(tag_cte_body: str, rest_after_with: str) -> s
 
 
 def add_tags_to_playlist(ts_conn, playlist_id: int, tags: List[str]) -> int:
-    if not tags:
-        return 0
-
-    normalized = []
-    for tag in tags:
-        n = _normalize_playlist_tag(tag)
-        if n:
-            normalized.append(n)
-    # Uniquify in-process to avoid pointless VALUES rows.
-    normalized = list(dict.fromkeys(normalized))
+    normalized = _normalize_playlist_tags(tags)
     if not normalized:
         return 0
 
@@ -363,10 +354,7 @@ def add_tags_to_playlist(ts_conn, playlist_id: int, tags: List[str]) -> int:
 
 
 def remove_tag_from_playlist(ts_conn, playlist_id: int, tag: str) -> int:
-    """Remove a tag from a playlist.
-
-    Returns number of rows deleted.
-    """
+    
     tag = _normalize_playlist_tag(tag)
     if not tag:
         return 0
@@ -616,6 +604,7 @@ def search_playlists_for_user(
             - ``"collaborative"``: search only playlists the user collaborates on.
         sort: How to order search results. One of ``relevance``, ``dateCreated``,
             ``dateUpdated``, ``title``, or ``creator``. Default: ``relevance``.
+        tags: If set, only return playlists that have all of the given tags .
 
     Returns:
         a tuple (playlists, total_playlists)

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -1,6 +1,6 @@
 import collections
 import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 import sqlalchemy
@@ -26,6 +26,7 @@ SEARCH_PLAYLIST_SORTS = {
     "title": "pl.name ASC",
     "creator": "pl.creator_id ASC",
 }
+MAX_PLAYLIST_TAG_LENGTH = 40
 
 # These are the recommendation troi patches that we showcase on the recommendations page for each user
 RECOMMENDATION_PATCHES = (
@@ -102,11 +103,20 @@ def get_by_mbid(db_conn, ts_conn, playlist_id: str, load_recordings: bool = True
     collaborator_ids_list = playlist_collaborator_ids.get(obj['id'], [])
     obj['collaborator_ids'] = collaborator_ids_list
     obj['collaborators'] = get_collaborators_names_from_ids(db_conn, collaborator_ids_list)
+
+    tags_map = get_tags_for_playlists(ts_conn, [obj['id']])
+    tags = tags_map.get(obj['id'], [])
+    if tags:
+        if obj.get('additional_metadata') is None or not isinstance(obj.get('additional_metadata'), dict):
+            obj['additional_metadata'] = {}
+        obj['additional_metadata']['tags'] = tags
+
     return model_playlist.Playlist.parse_obj(obj)
 
 
 def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool = False,
-                           load_recordings: bool = False, count: int = 0, offset: int = 0):
+                           load_recordings: bool = False, count: int = 0, offset: int = 0,
+                           tags: Optional[List[str]] = None):
     """Get all playlists that a user created
 
     Arguments:
@@ -134,7 +144,9 @@ def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool
     if not include_private:
         where_public = "AND pl.public = :public"
         params["public"] = True
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
+        {_tag_filter_with_prefix(tag_cte_body)}
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -148,6 +160,7 @@ def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool
              , pl.additional_metadata
              , copy.mbid as copied_from_mbid
           FROM playlist.playlist AS pl
+          {tag_join}
      LEFT JOIN playlist.playlist AS copy
             ON pl.copied_from_id = copy.id
          WHERE pl.creator_id = :creator_id
@@ -165,10 +178,15 @@ def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool
     if not include_private:
         where_public = "AND public = :public"
         params["public"] = True
-    query = text(f"""SELECT COUNT(*)
-                       FROM playlist.playlist
-                      WHERE creator_id = :creator_id
-                           {where_public}""")
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
+    query = text(f"""
+        {_tag_filter_with_prefix(tag_cte_body)}
+        SELECT COUNT(*)
+          FROM playlist.playlist pl
+               {tag_join}
+         WHERE pl.creator_id = :creator_id
+               {where_public}
+    """)
     count = ts_conn.execute(query, params).fetchone()[0]
 
     return playlists, count
@@ -254,12 +272,174 @@ def _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings):
         for p in playlists:
             p.collaborator_ids = playlist_collaborator_ids.get(p.id, [])
             p.collaborators = get_collaborators_names_from_ids(db_conn, p.collaborator_ids)
+        playlist_tags = get_tags_for_playlists(ts_conn, playlist_ids)
+        for p in playlists:
+            tags = playlist_tags.get(p.id, [])
+            if tags:
+                if p.additional_metadata is None:
+                    p.additional_metadata = {}
+                p.additional_metadata["tags"] = tags
 
     return playlists
 
 
+def _normalize_playlist_tag(tag: str) -> Optional[str]:
+    if tag is None:
+        return None
+    tag = " ".join(tag.strip().split()).lower()
+    if not tag:
+        return None
+    if len(tag) > MAX_PLAYLIST_TAG_LENGTH:
+        return None
+    return tag
+
+
+def _normalize_playlist_tags(tags: Optional[List[str]]) -> List[str]:
+    if not tags:
+        return []
+    normalized = []
+    for tag in tags:
+        n = _normalize_playlist_tag(tag)
+        if n:
+            normalized.append(n)
+    # preserve order but remove duplicates
+    return list(dict.fromkeys(normalized))
+
+
+def _build_tag_filter(tags: Optional[List[str]], params: dict):
+    normalized = _normalize_playlist_tags(tags)
+    if not normalized:
+        return "", ""
+
+    params["tags"] = tuple(normalized)
+    params["tag_count"] = len(normalized)
+
+    cte_body = """tagged_playlists AS (
+        SELECT playlist_id
+          FROM playlist.playlist_tag
+         WHERE tag IN :tags
+      GROUP BY playlist_id
+        HAVING COUNT(DISTINCT tag) = :tag_count
+    )"""
+    join = "JOIN tagged_playlists tp ON tp.playlist_id = pl.id"
+    return cte_body, join
+
+
+def _tag_filter_with_prefix(tag_cte_body: str) -> str:
+    if not tag_cte_body:
+        return ""
+    return f"WITH {tag_cte_body}\n"
+
+
+def _tag_filter_with_combined_ctes(tag_cte_body: str, rest_after_with: str) -> str:
+    if tag_cte_body:
+        return f"WITH {tag_cte_body},\n{rest_after_with}"
+    return f"WITH {rest_after_with}"
+
+
+def add_tags_to_playlist(ts_conn, playlist_id: int, tags: List[str]) -> int:
+    if not tags:
+        return 0
+
+    normalized = []
+    for tag in tags:
+        n = _normalize_playlist_tag(tag)
+        if n:
+            normalized.append(n)
+    # Uniquify in-process to avoid pointless VALUES rows.
+    normalized = list(dict.fromkeys(normalized))
+    if not normalized:
+        return 0
+
+    query = text("""
+        INSERT INTO playlist.playlist_tag (playlist_id, tag)
+             VALUES (:playlist_id, :tag)
+        ON CONFLICT DO NOTHING
+    """)
+    params = [{"playlist_id": playlist_id, "tag": t} for t in normalized]
+    result = ts_conn.execute(query, params)
+    ts_conn.commit()
+    return result.rowcount or 0
+
+
+def remove_tag_from_playlist(ts_conn, playlist_id: int, tag: str) -> int:
+    """Remove a tag from a playlist.
+
+    Returns number of rows deleted.
+    """
+    tag = _normalize_playlist_tag(tag)
+    if not tag:
+        return 0
+
+    query = text("""
+        DELETE FROM playlist.playlist_tag
+              WHERE playlist_id = :playlist_id
+                AND tag = :tag
+    """)
+    result = ts_conn.execute(query, {"playlist_id": playlist_id, "tag": tag})
+    ts_conn.commit()
+    return result.rowcount or 0
+
+
+def get_tags_for_playlists(ts_conn, playlist_ids: List[int]) -> Dict[int, List[str]]:
+    if not playlist_ids:
+        return {}
+
+    query = text("""
+        SELECT playlist_id
+             , array_agg(tag ORDER BY tag) AS tags
+          FROM playlist.playlist_tag
+         WHERE playlist_id IN :playlist_ids
+      GROUP BY playlist_id
+    """)
+    result = ts_conn.execute(query, {"playlist_ids": tuple(playlist_ids)})
+    ret: Dict[int, List[str]] = {}
+    for row in result.fetchall():
+        ret[row.playlist_id] = row.tags or []
+    return ret
+
+
+def get_tags_for_user(ts_conn, user_id: int, include_private: bool = False,
+                      collaborated_only: bool = False):
+    params = {}
+    where_public = ""
+    if not include_private:
+        where_public = "AND pl.public = true"
+
+    if collaborated_only:
+        params["collaborator_id"] = user_id
+        query = text(f"""
+        SELECT pt.tag
+             , COUNT(DISTINCT pt.playlist_id) AS count
+          FROM playlist.playlist_tag pt
+          JOIN playlist.playlist pl
+            ON pl.id = pt.playlist_id
+          JOIN playlist.playlist_collaborator pc
+            ON pl.id = pc.playlist_id
+         WHERE pc.collaborator_id = :collaborator_id
+               {where_public}
+      GROUP BY pt.tag
+      ORDER BY pt.tag
+    """)
+    else:
+        params["creator_id"] = user_id
+        query = text(f"""
+        SELECT pt.tag
+             , COUNT(DISTINCT pt.playlist_id) AS count
+          FROM playlist.playlist_tag pt
+          JOIN playlist.playlist pl
+            ON pl.id = pt.playlist_id
+         WHERE pl.creator_id = :creator_id
+               {where_public}
+      GROUP BY pt.tag
+      ORDER BY pt.tag
+    """)
+    rows = ts_conn.execute(query, params).mappings().all()
+    return [dict(r) for r in rows]
+
+
 def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordings: bool = False,
-                                   count: int = 0, offset: int = 0):
+                                   count: int = 0, offset: int = 0, tags: Optional[List[str]] = None):
     """Get all playlists that were created for a user by bots
 
     Arguments:
@@ -280,7 +460,9 @@ def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordin
         count = None
 
     params = {"created_for_id": user_id, "count": count, "offset": offset}
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
+        {_tag_filter_with_prefix(tag_cte_body)}
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -294,6 +476,7 @@ def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordin
              , pl.additional_metadata
              , copy.mbid as copied_from_mbid
           FROM playlist.playlist AS pl
+          {tag_join}
      LEFT JOIN playlist.playlist AS copy
             ON pl.copied_from_id = copy.id
          WHERE pl.created_for_id = :created_for_id
@@ -306,16 +489,22 @@ def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordin
 
     # Fetch the total count of playlists
     params = {"created_for_id": user_id}
-    query = text(f"""SELECT COUNT(*)
-                       FROM playlist.playlist
-                      WHERE created_for_id = :created_for_id""")
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
+    query = text(f"""
+        {_tag_filter_with_prefix(tag_cte_body)}
+        SELECT COUNT(*)
+          FROM playlist.playlist pl
+               {tag_join}
+         WHERE pl.created_for_id = :created_for_id
+    """)
     count = ts_conn.execute(query, params).fetchone()[0]
 
     return playlists, count
 
 
 def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_private: bool = False,
-                                  load_recordings: bool = False, count: int = 0, offset: int = 0):
+                                  load_recordings: bool = False, count: int = 0, offset: int = 0,
+                                  tags: Optional[List[str]] = None):
     """Get playlists that this user doesn't own, but is a collaborator on.
     Playlists are ordered by creation date.
 
@@ -340,7 +529,9 @@ def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_privat
     if not include_private:
         where_public = "AND pl.public = :public"
         params["public"] = True
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
+        {_tag_filter_with_prefix(tag_cte_body)}
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -354,6 +545,7 @@ def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_privat
              , pl.additional_metadata
              , copy.mbid as copied_from_mbid
           FROM playlist.playlist AS pl
+          {tag_join}
      LEFT JOIN playlist.playlist AS copy
             ON pl.copied_from_id = copy.id
      LEFT JOIN playlist.playlist_collaborator
@@ -373,9 +565,12 @@ def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_privat
     if not include_private:
         where_public = "AND playlist.public = :public"
         params["public"] = True
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = sqlalchemy.text(f"""
+        {_tag_filter_with_prefix(tag_cte_body)}
         SELECT COUNT(*)
           FROM playlist.playlist
+          {tag_join.replace('pl.id', 'playlist.playlist.id')}
      LEFT JOIN playlist.playlist_collaborator
             ON playlist.playlist.id = playlist_collaborator.playlist_id
          WHERE playlist.playlist_collaborator.collaborator_id = :collaborator_id
@@ -397,6 +592,7 @@ def search_playlists_for_user(
     include_global: bool = False,
     playlist_type: Optional[str] = None,
     sort: str = "relevance",
+    tags: Optional[List[str]] = None,
 ):
     """
     Search for playlists associated with a user by name or description.
@@ -436,6 +632,7 @@ def search_playlists_for_user(
         "user_id": user_id,
         "viewer_id": viewer_id,
     }
+    tag_cte_body, tag_join = _build_tag_filter(tags, params)
 
     # When viewer_id = user_id, visibility is automatically satisfied for associated playlists
     # (if user is creator/collaborator/created_for, they can see it)
@@ -488,12 +685,12 @@ def search_playlists_for_user(
             )
         """
 
-    query = text(f"""
-    WITH candidate_playlists AS (
+    candidate_ctes = f"""candidate_playlists AS (
         SELECT pl.id
              , similarity(pl.name, :query) AS name_similarity
              , similarity(COALESCE(pl.description, ''), :query) AS description_similarity
           FROM playlist.playlist AS pl
+          {tag_join}
          WHERE {association_condition}
            AND {visibility_condition}
     ),
@@ -502,7 +699,10 @@ def search_playlists_for_user(
           FROM candidate_playlists
          WHERE name_similarity > 0.1
             OR description_similarity > 0.1
-    )
+    )"""
+
+    query = text(f"""
+    {_tag_filter_with_combined_ctes(tag_cte_body, candidate_ctes)}
     SELECT pl.id
          , pl.mbid
          , pl.creator_id
@@ -533,12 +733,12 @@ def search_playlists_for_user(
     # Fetch the total count of playlists
     # Reuse the same visibility condition logic
     total_count = 0
-    query = text(f"""
-    WITH candidate_playlists AS (
+    candidate_count_cte = f"""candidate_playlists AS (
         SELECT pl.id
              , similarity(pl.name, :query) AS name_similarity
              , similarity(COALESCE(pl.description, ''), :query) AS description_similarity
           FROM playlist.playlist AS pl
+          {tag_join}
          WHERE {association_condition}
            AND {visibility_condition}
     )
@@ -546,7 +746,8 @@ def search_playlists_for_user(
       FROM candidate_playlists
      WHERE name_similarity > 0.1
         OR description_similarity > 0.1
-    """)
+    """
+    query = text(_tag_filter_with_combined_ctes(tag_cte_body, candidate_count_cte))
     result = ts_conn.execute(query, params)
     row = result.fetchone()
     if row:

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -116,7 +116,7 @@ def get_by_mbid(db_conn, ts_conn, playlist_id: str, load_recordings: bool = True
 
 def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool = False,
                            load_recordings: bool = False, count: int = 0, offset: int = 0,
-                           tags: Optional[List[str]] = None):
+                           tags: Optional[List[str]] = None, include_tags: bool = False):
     """Get all playlists that a user created
 
     Arguments:
@@ -146,7 +146,7 @@ def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool
         params["public"] = True
     tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
-        {_tag_filter_with_prefix(tag_cte_body)}
+        {_assemble_with_clause(tag_cte_body)}
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -170,7 +170,9 @@ def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool
         OFFSET :offset""")
 
     result = ts_conn.execute(query, params)
-    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings)
+    playlists = _playlist_resultset_to_model(
+        db_conn, ts_conn, result, load_recordings, include_tags=include_tags
+    )
 
     # Now fetch the count of playlists
     params = {"creator_id": user_id}
@@ -180,7 +182,7 @@ def get_playlists_for_user(db_conn, ts_conn, user_id: int, include_private: bool
         params["public"] = True
     tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
-        {_tag_filter_with_prefix(tag_cte_body)}
+        {_assemble_with_clause(tag_cte_body)}
         SELECT COUNT(*)
           FROM playlist.playlist pl
                {tag_join}
@@ -231,7 +233,7 @@ def get_recommendation_playlists_for_user(db_conn, ts_conn, user_id: int):
     return playlists
 
 
-def _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings):
+def _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings, include_tags: bool = False):
     """Parse the result of an sql query to get playlists
 
     Fill in related data (username, created_for username) and collaborators
@@ -272,13 +274,14 @@ def _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings):
         for p in playlists:
             p.collaborator_ids = playlist_collaborator_ids.get(p.id, [])
             p.collaborators = get_collaborators_names_from_ids(db_conn, p.collaborator_ids)
-        playlist_tags = get_tags_for_playlists(ts_conn, playlist_ids)
-        for p in playlists:
-            tags = playlist_tags.get(p.id, [])
-            if tags:
-                if p.additional_metadata is None:
-                    p.additional_metadata = {}
-                p.additional_metadata["tags"] = tags
+        if include_tags:
+            playlist_tags = get_tags_for_playlists(ts_conn, playlist_ids)
+            for p in playlists:
+                tags = playlist_tags.get(p.id, [])
+                if tags:
+                    if p.additional_metadata is None:
+                        p.additional_metadata = {}
+                    p.additional_metadata["tags"] = tags
 
     return playlists
 
@@ -325,16 +328,11 @@ def _build_tag_filter(tags: Optional[List[str]], params: dict):
     return cte_body, join
 
 
-def _tag_filter_with_prefix(tag_cte_body: str) -> str:
-    if not tag_cte_body:
+def _assemble_with_clause(tag_cte_body: str = "", rest: Optional[str] = None) -> str:
+    parts = [p for p in (tag_cte_body, rest) if p]
+    if not parts:
         return ""
-    return f"WITH {tag_cte_body}\n"
-
-
-def _tag_filter_with_combined_ctes(tag_cte_body: str, rest_after_with: str) -> str:
-    if tag_cte_body:
-        return f"WITH {tag_cte_body},\n{rest_after_with}"
-    return f"WITH {rest_after_with}"
+    return f"WITH {',\n'.join(parts)}\n"
 
 
 def add_tags_to_playlist(ts_conn, playlist_id: int, tags: List[str]) -> int:
@@ -344,11 +342,11 @@ def add_tags_to_playlist(ts_conn, playlist_id: int, tags: List[str]) -> int:
 
     query = text("""
         INSERT INTO playlist.playlist_tag (playlist_id, tag)
-             VALUES (:playlist_id, :tag)
+        SELECT :playlist_id, t.tag
+          FROM unnest(:tags) AS t(tag)
         ON CONFLICT DO NOTHING
     """)
-    params = [{"playlist_id": playlist_id, "tag": t} for t in normalized]
-    result = ts_conn.execute(query, params)
+    result = ts_conn.execute(query, {"playlist_id": playlist_id, "tags": normalized})
     ts_conn.commit()
     return result.rowcount or 0
 
@@ -427,7 +425,8 @@ def get_tags_for_user(ts_conn, user_id: int, include_private: bool = False,
 
 
 def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordings: bool = False,
-                                   count: int = 0, offset: int = 0, tags: Optional[List[str]] = None):
+                                   count: int = 0, offset: int = 0, tags: Optional[List[str]] = None,
+                                   include_tags: bool = False):
     """Get all playlists that were created for a user by bots
 
     Arguments:
@@ -450,7 +449,7 @@ def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordin
     params = {"created_for_id": user_id, "count": count, "offset": offset}
     tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
-        {_tag_filter_with_prefix(tag_cte_body)}
+        {_assemble_with_clause(tag_cte_body)}
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -473,13 +472,15 @@ def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordin
         OFFSET :offset""")
 
     result = ts_conn.execute(query, params)
-    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings)
+    playlists = _playlist_resultset_to_model(
+        db_conn, ts_conn, result, load_recordings, include_tags=include_tags
+    )
 
     # Fetch the total count of playlists
     params = {"created_for_id": user_id}
     tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
-        {_tag_filter_with_prefix(tag_cte_body)}
+        {_assemble_with_clause(tag_cte_body)}
         SELECT COUNT(*)
           FROM playlist.playlist pl
                {tag_join}
@@ -492,7 +493,7 @@ def get_playlists_created_for_user(db_conn, ts_conn, user_id: int, load_recordin
 
 def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_private: bool = False,
                                   load_recordings: bool = False, count: int = 0, offset: int = 0,
-                                  tags: Optional[List[str]] = None):
+                                  tags: Optional[List[str]] = None, include_tags: bool = False):
     """Get playlists that this user doesn't own, but is a collaborator on.
     Playlists are ordered by creation date.
 
@@ -519,7 +520,7 @@ def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_privat
         params["public"] = True
     tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = text(f"""
-        {_tag_filter_with_prefix(tag_cte_body)}
+        {_assemble_with_clause(tag_cte_body)}
         SELECT pl.id
              , pl.mbid
              , pl.creator_id
@@ -545,7 +546,9 @@ def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_privat
         OFFSET :offset""")
 
     result = ts_conn.execute(query, params)
-    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, load_recordings)
+    playlists = _playlist_resultset_to_model(
+        db_conn, ts_conn, result, load_recordings, include_tags=include_tags
+    )
 
     # Fetch the total count of playlists
     params = {"collaborator_id": user_id}
@@ -555,7 +558,7 @@ def get_playlists_collaborated_on(db_conn, ts_conn, user_id: int, include_privat
         params["public"] = True
     tag_cte_body, tag_join = _build_tag_filter(tags, params)
     query = sqlalchemy.text(f"""
-        {_tag_filter_with_prefix(tag_cte_body)}
+        {_assemble_with_clause(tag_cte_body)}
         SELECT COUNT(*)
           FROM playlist.playlist
           {tag_join.replace('pl.id', 'playlist.playlist.id')}
@@ -581,6 +584,7 @@ def search_playlists_for_user(
     playlist_type: Optional[str] = None,
     sort: str = "relevance",
     tags: Optional[List[str]] = None,
+    include_tags: bool = False,
 ):
     """
     Search for playlists associated with a user by name or description.
@@ -691,7 +695,7 @@ def search_playlists_for_user(
     )"""
 
     query = text(f"""
-    {_tag_filter_with_combined_ctes(tag_cte_body, candidate_ctes)}
+    {_assemble_with_clause(tag_cte_body, candidate_ctes)}
     SELECT pl.id
          , pl.mbid
          , pl.creator_id
@@ -717,7 +721,9 @@ def search_playlists_for_user(
     """)
 
     result = ts_conn.execute(query, params)
-    playlists = _playlist_resultset_to_model(db_conn, ts_conn, result, False)
+    playlists = _playlist_resultset_to_model(
+        db_conn, ts_conn, result, False, include_tags=include_tags
+    )
 
     # Fetch the total count of playlists
     # Reuse the same visibility condition logic
@@ -736,7 +742,7 @@ def search_playlists_for_user(
      WHERE name_similarity > 0.1
         OR description_similarity > 0.1
     """
-    query = text(_tag_filter_with_combined_ctes(tag_cte_body, candidate_count_cte))
+    query = text(_assemble_with_clause(tag_cte_body, candidate_count_cte))
     result = ts_conn.execute(query, params)
     row = result.fetchone()
     if row:

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -1077,6 +1077,39 @@ class PlaylistAPITestCase(IntegrationTestCase):
         md = response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI].get("additional_metadata", {})
         self.assertListEqual(md.get("tags", []), ["hip-hop"])
 
+    def test_playlist_tags_per_playlist_limit(self):
+        """A playlist cannot have more than MAX_TAGS_PER_PLAYLIST tags in total."""
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=get_test_data(),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        playlist_mbid = response.json["playlist_mbid"]
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["tag-%d" % i for i in range(25)]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["added"], 25)
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["tag-%d" % i for i in range(25, 50)]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["added"], 25)
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["tag-50"]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert400(response)
+
     def test_playlist_tags_sidebar_endpoint_and_filtering(self):
         """Tags list endpoint returns tags; tag filter works for get playlists and search."""
         response = self.client.post(

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -1062,7 +1062,6 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
     def test_playlist_tags_sidebar_endpoint_and_filtering(self):
         """Tags list endpoint returns tags; tag filter works for get playlists and search."""
-        # Create two playlists, tag only one
         response = self.client.post(
             self.custom_url_for("playlist_api_v1.create_playlist"),
             json=get_test_data(),
@@ -1129,7 +1128,6 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assert200(response)
         self.assertEqual(response.json["playlist_count"], 1)
 
-        # Tag + search compose (query must be >=3 chars)
         response = self.client.get(
             self.custom_url_for("api_v1.search_user_playlist", playlist_user_name=self.user["musicbrainz_id"], query="198", tag="rock"),
             headers={"Authorization": "Token {}".format(self.user["auth_token"])},

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -1027,6 +1027,23 @@ class PlaylistAPITestCase(IntegrationTestCase):
             headers={"Authorization": "Token {}".format(self.user["auth_token"])}
         )
         self.assert200(response)
+        self.assertEqual(response.json["added"], 2)
+
+        # Empty or whitespace-only tags are rejected
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["   "]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert400(response)
+
+        # Too many tags in one request is rejected
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["tag-%d" % i for i in range(26)]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert400(response)
 
         # Collaborator can view tags on playlist fetch
         response = self.client.get(

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -997,6 +997,229 @@ class PlaylistAPITestCase(IntegrationTestCase):
         self.assertEqual(response.json["count"], 1)
         self.assertEqual(response.json["offset"], 1)
 
+    def test_playlist_tags_owner_only(self):
+        """Only playlist owner can add/remove tags; collaborators can view."""
+        playlist = get_test_data()
+        # Private with a collaborator
+        playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["public"] = False
+        playlist["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["collaborators"] = [self.user2["musicbrainz_id"]]
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=playlist,
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        playlist_mbid = response.json["playlist_mbid"]
+
+        # Collaborator cannot add tags
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["gym", "Hip-Hop"]},
+            headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
+        )
+        self.assert403(response)
+
+        # Owner can add tags
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=playlist_mbid),
+            json={"tags": ["gym", "Hip-Hop", "  gym  "]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+
+        # Collaborator can view tags on playlist fetch
+        response = self.client.get(
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
+        )
+        self.assert200(response)
+        md = response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI].get("additional_metadata", {})
+        self.assertIn("tags", md)
+        self.assertListEqual(sorted(md["tags"]), ["gym", "hip-hop"])
+
+        # Collaborator cannot remove tags
+        response = self.client.delete(
+            self.custom_url_for("playlist_api_v1.delete_playlist_tag", playlist_mbid=playlist_mbid, tag="gym"),
+            headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
+        )
+        self.assert403(response)
+
+        # Owner can remove tags
+        response = self.client.delete(
+            self.custom_url_for("playlist_api_v1.delete_playlist_tag", playlist_mbid=playlist_mbid, tag="gym"),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+
+        response = self.client.get(
+            self.custom_url_for("playlist_api_v1.get_playlist", playlist_mbid=playlist_mbid, fetch_metadata="false"),
+            headers={"Authorization": "Token {}".format(self.user2["auth_token"])}
+        )
+        self.assert200(response)
+        md = response.json["playlist"]["extension"][PLAYLIST_EXTENSION_URI].get("additional_metadata", {})
+        self.assertListEqual(md.get("tags", []), ["hip-hop"])
+
+    def test_playlist_tags_sidebar_endpoint_and_filtering(self):
+        """Tags list endpoint returns tags; tag filter works for get playlists and search."""
+        # Create two playlists, tag only one
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=get_test_data(),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        p1 = response.json["playlist_mbid"]
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=get_test_data(),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        p2 = response.json["playlist_mbid"]
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=p1),
+            json={"tags": ["rock"]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+
+        # Sidebar endpoint
+        response = self.client.get(
+            self.custom_url_for("api_v1.get_playlist_tags_for_user", playlist_user_name=self.user["musicbrainz_id"]),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["tags"][0]["tag"], "rock")
+        self.assertEqual(response.json["tags"][0]["count"], 1)
+
+        # Tag filtering for list endpoint
+        response = self.client.get(
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user["musicbrainz_id"], tag="rock"),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["playlist_count"], 1)
+        self.assertEqual(response.json["playlists"][0]["playlist"]["identifier"], PLAYLIST_URI_PREFIX + p1)
+
+        # Add a second tag to p1 and verify AND semantics
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=p1),
+            json={"tags": ["gym"]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+
+        # p1 has both rock and gym; p2 has none
+        response = self.client.get(
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user["musicbrainz_id"], tag="rock,gym"),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["playlist_count"], 1)
+        self.assertEqual(response.json["playlists"][0]["playlist"]["identifier"], PLAYLIST_URI_PREFIX + p1)
+
+        # If we filter by gym alone, we should still only get p1
+        response = self.client.get(
+            self.custom_url_for("api_v1.get_playlists_for_user", playlist_user_name=self.user["musicbrainz_id"], tag="gym"),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["playlist_count"], 1)
+
+        # Tag + search compose (query must be >=3 chars)
+        response = self.client.get(
+            self.custom_url_for("api_v1.search_user_playlist", playlist_user_name=self.user["musicbrainz_id"], query="198", tag="rock"),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["playlist_count"], 1)
+        self.assertEqual(response.json["playlists"][0]["playlist"]["identifier"], PLAYLIST_URI_PREFIX + p1)
+
+    def test_playlist_tags_sidebar_by_section(self):
+        """Tags sidebar lists tags from owned playlists or collaborated playlists only."""
+        owned = get_test_data()
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=owned,
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        owned_mbid = response.json["playlist_mbid"]
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=owned_mbid),
+            json={"tags": ["owned-tag"]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+
+        collab = get_test_data()
+        collab["playlist"]["extension"][PLAYLIST_EXTENSION_URI]["collaborators"] = [
+            self.user2["musicbrainz_id"]
+        ]
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=collab,
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+        collab_mbid = response.json["playlist_mbid"]
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.add_playlist_tags", playlist_mbid=collab_mbid),
+            json={"tags": ["collab-tag"]},
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert200(response)
+
+        response = self.client.get(
+            self.custom_url_for(
+                "api_v1.get_playlist_tags_for_user",
+                playlist_user_name=self.user2["musicbrainz_id"],
+            ),
+            headers={"Authorization": "Token {}".format(self.user2["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["tags"], [])
+
+        response = self.client.get(
+            self.custom_url_for(
+                "api_v1.get_playlist_tags_for_user",
+                playlist_user_name=self.user2["musicbrainz_id"],
+                collaborator=True,
+            ),
+            headers={"Authorization": "Token {}".format(self.user2["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(len(response.json["tags"]), 1)
+        self.assertEqual(response.json["tags"][0]["tag"], "collab-tag")
+        self.assertEqual(response.json["tags"][0]["count"], 1)
+
+        response = self.client.get(
+            self.custom_url_for(
+                "api_v1.get_playlist_tags_for_user",
+                playlist_user_name=self.user["musicbrainz_id"],
+            ),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        owned_tags = {t["tag"] for t in response.json["tags"]}
+        self.assertEqual(owned_tags, {"owned-tag", "collab-tag"})
+
+        response = self.client.get(
+            self.custom_url_for(
+                "api_v1.get_playlist_tags_for_user",
+                playlist_user_name=self.user["musicbrainz_id"],
+                collaborator=True,
+            ),
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])},
+        )
+        self.assert200(response)
+        self.assertEqual(response.json["tags"], [])
+
     def test_playlist_unauthorized_access(self):
         """ Test for checking that unauthorized access return 401 """
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -647,7 +647,7 @@ def get_playlists_for_user(playlist_user_name):
     playlists, playlist_count = db_playlist.get_playlists_for_user(db_conn, ts_conn, playlist_user["id"],
                                                                    include_private=include_private,
                                                                    load_recordings=False, count=count, offset=offset,
-                                                                   tags=tags)
+                                                                   tags=tags, include_tags=True)
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
 
@@ -679,7 +679,8 @@ def get_playlists_created_for_user(playlist_user_name):
 
     playlists, playlist_count = db_playlist.get_playlists_created_for_user(
         db_conn, ts_conn, playlist_user["id"], load_recordings=False, count=count, offset=offset,
-        tags=request.args.get("tag").split(",") if request.args.get("tag") else None
+        tags=request.args.get("tag").split(",") if request.args.get("tag") else None,
+        include_tags=True,
     )
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
@@ -720,7 +721,8 @@ def get_playlists_collaborated_on_for_user(playlist_user_name):
                                                                           load_recordings=False,
                                                                           count=count,
                                                                           offset=offset,
-                                                                          tags=request.args.get("tag").split(",") if request.args.get("tag") else None)
+                                                                          tags=request.args.get("tag").split(",") if request.args.get("tag") else None,
+                                                                          include_tags=True)
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
 
@@ -801,6 +803,7 @@ def search_user_playlist(playlist_user_name):
         db_conn, ts_conn, playlist_user["id"], query, count, offset,
         viewer_id=viewer_id, include_global=include_global,
         playlist_type=playlist_type, tags=tags,
+        include_tags=True,
     )
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -642,9 +642,12 @@ def get_playlists_for_user(playlist_user_name):
         raise APINotFound("Cannot find user: %s" % playlist_user_name)
 
     include_private = True if user and user["id"] == playlist_user["id"] else False
+    tag_param = request.args.get("tag")
+    tags = tag_param.split(",") if tag_param else None
     playlists, playlist_count = db_playlist.get_playlists_for_user(db_conn, ts_conn, playlist_user["id"],
                                                                    include_private=include_private,
-                                                                   load_recordings=False, count=count, offset=offset)
+                                                                   load_recordings=False, count=count, offset=offset,
+                                                                   tags=tags)
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
 
@@ -675,7 +678,8 @@ def get_playlists_created_for_user(playlist_user_name):
         raise APINotFound("Cannot find user: %s" % playlist_user_name)
 
     playlists, playlist_count = db_playlist.get_playlists_created_for_user(
-        db_conn, ts_conn, playlist_user["id"], load_recordings=False, count=count, offset=offset
+        db_conn, ts_conn, playlist_user["id"], load_recordings=False, count=count, offset=offset,
+        tags=request.args.get("tag").split(",") if request.args.get("tag") else None
     )
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
@@ -715,7 +719,8 @@ def get_playlists_collaborated_on_for_user(playlist_user_name):
                                                                           include_private=include_private,
                                                                           load_recordings=False,
                                                                           count=count,
-                                                                          offset=offset)
+                                                                          offset=offset,
+                                                                          tags=request.args.get("tag").split(",") if request.args.get("tag") else None)
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
 
@@ -788,13 +793,37 @@ def search_user_playlist(playlist_user_name):
     if not query or len(query) < 3:
         log_raise_400("Query string must be at least 3 characters long.")
 
+    tag_param = request.args.get("tag")
+    tags = tag_param.split(",") if tag_param else None
+
     viewer_id = user["id"] if user else None
     playlists, playlist_count = db_playlist.search_playlists_for_user(
         db_conn, ts_conn, playlist_user["id"], query, count, offset,
-        viewer_id=viewer_id, include_global=include_global, playlist_type=playlist_type
+        viewer_id=viewer_id, include_global=include_global,
+        playlist_type=playlist_type, tags=tags,
     )
 
     return jsonify(serialize_playlists(playlists, playlist_count, count, offset))
+
+
+@api_bp.get("/user/<playlist_user_name>/playlists/tags")
+@crossdomain
+@ratelimit()
+def get_playlist_tags_for_user(playlist_user_name):
+    user = validate_auth_header(optional=True)
+    playlist_user = db_user.get_by_mb_id(db_conn, playlist_user_name)
+    if playlist_user is None:
+        raise APINotFound("Cannot find user: %s" % playlist_user_name)
+
+    include_private = True if user and user["id"] == playlist_user["id"] else False
+    collaborated_only = parse_boolean_arg("collaborator", False)
+    tags = db_playlist.get_tags_for_user(
+        ts_conn,
+        playlist_user["id"],
+        include_private=include_private,
+        collaborated_only=collaborated_only,
+    )
+    return jsonify({"tags": tags})
 
 
 @api_bp.get("/user/<mb_username:user_name>/services")

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -810,6 +810,19 @@ def search_user_playlist(playlist_user_name):
 @crossdomain
 @ratelimit()
 def get_playlist_tags_for_user(playlist_user_name):
+    """
+    Fetch tag names and playlist counts for a user's playlists.
+
+    Used by the playlist tags sidebar. Tags are listed with the number of playlists
+    that use each tag.
+
+    :param playlist_user_name: the MusicBrainz ID of the user whose playlist tags are requested.
+    :queryparam collaborator: if true, return tags from playlists the user collaborates on
+        rather than playlists they created. Default: false.
+    :statuscode 200: success
+    :statuscode 404: user not found
+    :resheader Content-Type: *application/json*
+    """
     user = validate_auth_header(optional=True)
     playlist_user = db_user.get_by_mb_id(db_conn, playlist_user_name)
     if playlist_user is None:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -33,6 +33,7 @@ playlist_api_bp = Blueprint('playlist_api_v1', __name__)
 
 MAX_RECORDINGS_PER_ADD = 100
 DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL = 25
+MAX_TAGS_PER_PLAYLIST_REQUEST = 25
 
 
 def _validate_tags_payload(data):
@@ -43,10 +44,29 @@ def _validate_tags_payload(data):
         log_raise_400("Missing 'tags' in request body.")
     if type(tags) not in (list, tuple):
         log_raise_400("'tags' must be a list.")
+    if len(tags) > MAX_TAGS_PER_PLAYLIST_REQUEST:
+        log_raise_400(
+            "Cannot add more than %d tags in a single request." % MAX_TAGS_PER_PLAYLIST_REQUEST
+        )
+    normalized = []
     for tag in tags:
         if type(tag) != str:
             log_raise_400("Tag values must be strings.")
-    return tags
+        n = db_playlist._normalize_playlist_tag(tag)
+        if n is None:
+            collapsed = " ".join(tag.strip().split())
+            if not collapsed:
+                log_raise_400("Tag values cannot be empty.")
+            log_raise_400(
+                "Please keep tag length to %d characters or less."
+                % db_playlist.MAX_PLAYLIST_TAG_LENGTH
+            )
+        normalized.append(n)
+
+    normalized = list(dict.fromkeys(normalized))
+    if not normalized:
+        log_raise_400("No valid tags submitted.")
+    return normalized
 
 supported_services = {
     "spotify": SpotifyService,
@@ -895,12 +915,12 @@ def add_playlist_tags(playlist_mbid):
 
     tags = _validate_tags_payload(request.json)
     try:
-        db_playlist.add_tags_to_playlist(ts_conn, playlist.id, tags)
+        added = db_playlist.add_tags_to_playlist(ts_conn, playlist.id, tags)
     except Exception:
         current_app.logger.error("Error while adding tags to playlist: ", exc_info=True)
         raise APIInternalServerError("Failed to add tags to the playlist. Please try again.")
 
-    return jsonify({"status": "ok"})
+    return jsonify({"status": "ok", "added": added})
 
 
 @playlist_api_bp.delete("/<playlist_mbid>/tags/<path:tag>")

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -34,6 +34,20 @@ playlist_api_bp = Blueprint('playlist_api_v1', __name__)
 MAX_RECORDINGS_PER_ADD = 100
 DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL = 25
 
+
+def _validate_tags_payload(data):
+    if not isinstance(data, dict):
+        log_raise_400("Invalid JSON document submitted.")
+    tags = data.get("tags")
+    if tags is None:
+        log_raise_400("Missing 'tags' in request body.")
+    if type(tags) not in (list, tuple):
+        log_raise_400("'tags' must be a list.")
+    for tag in tags:
+        if type(tag) != str:
+            log_raise_400("Tag values must be strings.")
+    return tags
+
 supported_services = {
     "spotify": SpotifyService,
     "apple_music": AppleService,
@@ -856,6 +870,64 @@ def copy_playlist(playlist_mbid):
         raise APIInternalServerError("Failed to copy the playlist. Please try again.")
 
     return jsonify({'status': 'ok', 'playlist_mbid': new_playlist.mbid})
+
+
+@playlist_api_bp.post("/<playlist_mbid>/tags")
+@crossdomain
+@ratelimit()
+@api_listenstore_needed
+def add_playlist_tags(playlist_mbid):
+    """Add one or more tags to a playlist.
+
+    Only the playlist owner can edit tags. Collaborators can view tags but cannot modify them.
+    """
+    user = validate_auth_header()
+
+    if not is_valid_uuid(playlist_mbid):
+        log_raise_400("Provided playlist ID is invalid.")
+
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, False)
+    if playlist is None or not playlist.is_visible_by(user["id"]):
+        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
+
+    if playlist.creator_id != user["id"]:
+        raise APIForbidden("You are not allowed to edit tags on this playlist.")
+
+    tags = _validate_tags_payload(request.json)
+    try:
+        db_playlist.add_tags_to_playlist(ts_conn, playlist.id, tags)
+    except Exception:
+        current_app.logger.error("Error while adding tags to playlist: ", exc_info=True)
+        raise APIInternalServerError("Failed to add tags to the playlist. Please try again.")
+
+    return jsonify({"status": "ok"})
+
+
+@playlist_api_bp.delete("/<playlist_mbid>/tags/<path:tag>")
+@crossdomain
+@ratelimit()
+@api_listenstore_needed
+def delete_playlist_tag(playlist_mbid, tag):
+    """Remove a tag from a playlist. Only the playlist owner can edit tags."""
+    user = validate_auth_header()
+
+    if not is_valid_uuid(playlist_mbid):
+        log_raise_400("Provided playlist ID is invalid.")
+
+    playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, False)
+    if playlist is None or not playlist.is_visible_by(user["id"]):
+        raise APINotFound("Cannot find playlist: %s" % playlist_mbid)
+
+    if playlist.creator_id != user["id"]:
+        raise APIForbidden("You are not allowed to edit tags on this playlist.")
+
+    try:
+        db_playlist.remove_tag_from_playlist(ts_conn, playlist.id, tag)
+    except Exception:
+        current_app.logger.error("Error while removing tag from playlist: ", exc_info=True)
+        raise APIInternalServerError("Failed to remove the tag from the playlist. Please try again.")
+
+    return jsonify({"status": "ok"})
 
 
 @playlist_api_bp.route("/<playlist_mbid>/export/<service>", methods=["POST", "OPTIONS"])

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -52,7 +52,7 @@ def _validate_tags_payload(data):
     for tag in tags:
         if type(tag) != str:
             log_raise_400("Tag values must be strings.")
-        n = db_playlist._normalize_playlist_tag(tag)
+        n = db_playlist.normalize_playlist_tag(tag)
         if n is None:
             collapsed = " ".join(tag.strip().split())
             if not collapsed:
@@ -916,6 +916,8 @@ def add_playlist_tags(playlist_mbid):
     tags = _validate_tags_payload(request.json)
     try:
         added = db_playlist.add_tags_to_playlist(ts_conn, playlist.id, tags)
+    except ValueError as e:
+        log_raise_400(str(e))
     except Exception:
         current_app.logger.error("Error while adding tags to playlist: ", exc_info=True)
         raise APIInternalServerError("Failed to add tags to the playlist. Please try again.")

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -193,18 +193,19 @@ def playlists(user_name: str):
             playlist_type=playlist_type,
             sort=sort,
             tags=tags,
+            include_tags=True,
         )
     elif type == "collaborative":
         user_playlists, playlist_count = get_playlists_collaborated_on(
             db_conn, ts_conn, user.id, include_private=include_private,
             load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset,
-            tags=tags
+            tags=tags, include_tags=True,
         )
     else:
         user_playlists, playlist_count = get_playlists_for_user(
             db_conn, ts_conn, user.id, include_private=include_private,
             load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset,
-            tags=tags
+            tags=tags, include_tags=True,
         )
 
     playlists = []

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -155,6 +155,8 @@ def playlists(user_name: str):
     type = request.args.get("type", "")
     search_query = (request.args.get("search") or "").strip()
     sort = request.args.get("sort", "relevance")
+    tag_param = request.args.get("tag")
+    tags = tag_param.split(",") if tag_param else None
 
     user = _get_user(user_name)
     if not user:
@@ -190,16 +192,19 @@ def playlists(user_name: str):
             viewer_id=viewer_id,
             playlist_type=playlist_type,
             sort=sort,
+            tags=tags,
         )
     elif type == "collaborative":
         user_playlists, playlist_count = get_playlists_collaborated_on(
             db_conn, ts_conn, user.id, include_private=include_private,
-            load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset
+            load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset,
+            tags=tags
         )
     else:
         user_playlists, playlist_count = get_playlists_for_user(
             db_conn, ts_conn, user.id, include_private=include_private,
-            load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset
+            load_recordings=True, count=DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL, offset=offset,
+            tags=tags
         )
 
     playlists = []


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

Ticket : [LB-1302](https://tickets.metabrainz.org/browse/LB-1302)

# Description

Adds backend support for playlist tags , so users can label and filter  playlists by tag.

Tags are stored in TimescaleDB, returned in playlist JSPF metadata, and can be used to filter playlist lists and search results. A new sidebar endpoint returns tags with playlist counts, with separate views for owned vs collaborated playlists.

Only the playlist owner may add or remove tags; collaborators can view them. This PR is backend only.

# Implementation

## Database
New playlist.playlist_tag table 
Schema in admin/timescale/create_tables.sql
Migration: admin/timescale/updates/2026-05-04-add-playlist-tags.sql

## DB layer 

- Tag normalization: lowercase, whitespace collapse, max 40 chars, deduplication via _normalize_playlist_tags
- CRUD: add_tags_to_playlist, remove_tag_from_playlist, get_tags_for_playlists, get_tags_for_user
- GET .../playlists/tags?collaborator=true — tags from collaborated playlists only; default is owned

# Tests 

Three integration tests in `listenbrainz/tests/integration/test_playlist_api.py:`

`test_playlist_tags_owner_only` -  Owner can add/remove; collaborator gets 403; tags visible in playlist fetch

`test_playlist_tags_sidebar_endpoint_and_filtering `- Sidebar endpoint, single/multi-tag AND filter, tag + search

`test_playlist_tags_sidebar_by_section` - Owned vs collaborative tag lists via ?collaborator=true

# AI Usage 

I had used AI for Debugging and understanding existing code. 


