### PR TITLE
Allow pausing/unpausing users from reported_users admin view

### DIFF
--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 import listenbrainz.db.user as db_user
 import listenbrainz.db.external_service_oauth as db_oauth
@@ -113,6 +114,23 @@ class UserTestCase(DatabaseTestCase):
         db_user.pause(self.db_conn, user_id)
         user = db_user.get(self.db_conn, user_id)
         self.assertEqual(user['is_paused'], True)
+
+    def test_pause_multiple_users(self):
+        """ Tests that pauses multiple users and notifies each updated user """
+
+        user_id_1 = db_user.create(self.db_conn, 40, 'anne')
+        user_id_2 = db_user.create(self.db_conn, 41, 'rob')
+
+        with mock.patch("listenbrainz.db.user._notify_user_paused") as notify_user_paused:
+            users = db_user.pause(self.db_conn, [user_id_1, user_id_2])
+
+        self.assertCountEqual(users, ['anne', 'rob'])
+        self.assertEqual(db_user.get(self.db_conn, user_id_1)['is_paused'], True)
+        self.assertEqual(db_user.get(self.db_conn, user_id_2)['is_paused'], True)
+        notify_user_paused.assert_has_calls([
+            mock.call(self.db_conn, user_id_1, True),
+            mock.call(self.db_conn, user_id_2, True),
+        ], any_order=True)
         
     def test_unpause(self):
         """ Tests that pauses the given user """

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -152,6 +152,37 @@ class UserTestCase(DatabaseTestCase):
         self.assertEqual(db_user.get(self.db_conn, user_id_2)['is_paused'], True)
         self.assertCountEqual(notified_user_ids, [user_id_1, user_id_2])
 
+    def test_set_reported_users_paused(self):
+        """ Tests that pauses reported users selected by report id """
+
+        reporter_id = db_user.create(self.db_conn, 44, 'reporter')
+        reported_user_id_1 = db_user.create(self.db_conn, 45, 'anne')
+        reported_user_id_2 = db_user.create(self.db_conn, 46, 'rob')
+
+        db_user.report_user(self.db_conn, reporter_id, reported_user_id_1)
+        db_user.report_user(self.db_conn, reporter_id, reported_user_id_2)
+        result = self.db_conn.execute(sqlalchemy.text("""
+            SELECT id
+              FROM reported_users
+             WHERE reporter_user_id = :reporter_id
+          ORDER BY id
+        """), {
+            "reporter_id": reporter_id,
+        })
+        report_ids = [row.id for row in result.fetchall()]
+
+        with mock.patch("listenbrainz.db.user._notify_user_paused") as notify_user_paused:
+            users = db_user.set_reported_users_paused(self.db_conn, report_ids, True)
+
+        self.assertCountEqual(users, ['anne', 'rob'])
+        self.assertEqual(db_user.get(self.db_conn, reporter_id)['is_paused'], False)
+        self.assertEqual(db_user.get(self.db_conn, reported_user_id_1)['is_paused'], True)
+        self.assertEqual(db_user.get(self.db_conn, reported_user_id_2)['is_paused'], True)
+        notify_user_paused.assert_has_calls([
+            mock.call(self.db_conn, reported_user_id_1, True),
+            mock.call(self.db_conn, reported_user_id_2, True),
+        ], any_order=True)
+
     def test_unpause(self):
         """ Tests that pauses the given user """
 

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -122,9 +122,10 @@ class UserTestCase(DatabaseTestCase):
         user_id_2 = db_user.create(self.db_conn, 41, 'rob')
 
         with mock.patch("listenbrainz.db.user._notify_user_paused") as notify_user_paused:
-            users = db_user.pause(self.db_conn, [user_id_1, user_id_2])
+            users, notification_failed_users = db_user.pause(self.db_conn, [user_id_1, user_id_2])
 
         self.assertCountEqual(users, ['anne', 'rob'])
+        self.assertEqual(notification_failed_users, [])
         self.assertEqual(db_user.get(self.db_conn, user_id_1)['is_paused'], True)
         self.assertEqual(db_user.get(self.db_conn, user_id_2)['is_paused'], True)
         notify_user_paused.assert_has_calls([
@@ -145,9 +146,10 @@ class UserTestCase(DatabaseTestCase):
                 raise Exception("Failed to send email")
 
         with mock.patch("listenbrainz.db.user._notify_user_paused", side_effect=notify_user_paused):
-            users = db_user.pause(self.db_conn, [user_id_1, user_id_2])
+            users, notification_failed_users = db_user.pause(self.db_conn, [user_id_1, user_id_2])
 
         self.assertCountEqual(users, ['anne', 'rob'])
+        self.assertEqual(notification_failed_users, ['anne'])
         self.assertEqual(db_user.get(self.db_conn, user_id_1)['is_paused'], True)
         self.assertEqual(db_user.get(self.db_conn, user_id_2)['is_paused'], True)
         self.assertCountEqual(notified_user_ids, [user_id_1, user_id_2])
@@ -172,9 +174,10 @@ class UserTestCase(DatabaseTestCase):
         report_ids = [row.id for row in result.fetchall()]
 
         with mock.patch("listenbrainz.db.user._notify_user_paused") as notify_user_paused:
-            users = db_user.set_reported_users_paused(self.db_conn, report_ids, True)
+            users, notification_failed_users = db_user.set_reported_users_paused(self.db_conn, report_ids, True)
 
         self.assertCountEqual(users, ['anne', 'rob'])
+        self.assertEqual(notification_failed_users, [])
         self.assertEqual(db_user.get(self.db_conn, reporter_id)['is_paused'], False)
         self.assertEqual(db_user.get(self.db_conn, reported_user_id_1)['is_paused'], True)
         self.assertEqual(db_user.get(self.db_conn, reported_user_id_2)['is_paused'], True)

--- a/listenbrainz/db/tests/test_user.py
+++ b/listenbrainz/db/tests/test_user.py
@@ -131,7 +131,27 @@ class UserTestCase(DatabaseTestCase):
             mock.call(self.db_conn, user_id_1, True),
             mock.call(self.db_conn, user_id_2, True),
         ], any_order=True)
-        
+
+    def test_pause_multiple_users_continues_after_notification_failure(self):
+        """ Tests that notification failures do not stop later notifications """
+
+        user_id_1 = db_user.create(self.db_conn, 42, 'anne')
+        user_id_2 = db_user.create(self.db_conn, 43, 'rob')
+        notified_user_ids = []
+
+        def notify_user_paused(db_conn, user_id, paused):
+            notified_user_ids.append(user_id)
+            if user_id == user_id_1:
+                raise Exception("Failed to send email")
+
+        with mock.patch("listenbrainz.db.user._notify_user_paused", side_effect=notify_user_paused):
+            users = db_user.pause(self.db_conn, [user_id_1, user_id_2])
+
+        self.assertCountEqual(users, ['anne', 'rob'])
+        self.assertEqual(db_user.get(self.db_conn, user_id_1)['is_paused'], True)
+        self.assertEqual(db_user.get(self.db_conn, user_id_2)['is_paused'], True)
+        self.assertCountEqual(notified_user_ids, [user_id_1, user_id_2])
+
     def test_unpause(self):
         """ Tests that pauses the given user """
 

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -593,55 +593,80 @@ def get_all_usernames():
     return user_id_map
 
 
-def pause(db_conn,id):
-    """ Sets the user's is_paused flag to true
-    with specified row ID from the database.
-    
+def pause(db_conn, user_ids):
+    """ Sets the user's is_paused flag to true with specified row ID(s) from the database.
+
     Args:
         db_conn: database connection
-        id (int): the row ID of the listenbrainz user
+        user_ids (int or list): row ID(s) of the listenbrainz user(s)
     """
+    return set_users_paused(db_conn, _normalize_user_ids(user_ids), True)
+
+
+def unpause(db_conn, user_ids):
+    """ Sets the user's is_paused flag to false with specified row ID(s) from the database.
+
+    Args:
+        db_conn: database connection
+        user_ids (int or list): row ID(s) of the listenbrainz user(s)
+    """
+    return set_users_paused(db_conn, _normalize_user_ids(user_ids), False)
+
+
+def _normalize_user_ids(user_ids):
+    if isinstance(user_ids, (str, int)):
+        return [user_ids]
+    return user_ids
+
+
+def set_users_paused(db_conn, user_ids, is_paused):
+    user_ids = [int(user_id) for user_id in user_ids]
+    return _set_users_paused(db_conn, ":user_ids", {"user_ids": tuple(user_ids)}, is_paused)
+
+
+def set_reported_users_paused(db_conn, report_ids, is_paused):
+    report_ids = [int(report_id) for report_id in report_ids]
+    return _set_users_paused(
+        db_conn,
+        """
+            (SELECT DISTINCT reported_user_id
+               FROM reported_users
+              WHERE id IN :report_ids)
+        """,
+        {"report_ids": tuple(report_ids)},
+        is_paused,
+    )
+
+
+def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
+    if not any(params.values()):
+        return []
+
     try:
-        db_conn.execute(sqlalchemy.text("""
+        result = db_conn.execute(sqlalchemy.text(f"""
             UPDATE "user"
-               SET is_paused = true
-             WHERE id = :id
-            """), {
-            'id': id,
+               SET is_paused = :is_paused
+             WHERE "user".id IN {user_ids_expression}
+         RETURNING "user".id, "user".musicbrainz_id
+        """), {
+            **params,
+            "is_paused": is_paused,
         })
+        users = result.mappings().all()
         db_conn.commit()
-        _notify_user_paused(db_conn,id,True)
+
+        for user in users:
+            _notify_user_paused(db_conn, user["id"], is_paused)
+
+        return [user["musicbrainz_id"] for user in users]
 
     except sqlalchemy.exc.ProgrammingError as err:
         logger.error(err)
-        raise DatabaseException("Couldn't pause user: %s" % str(err))
+        action = "pause" if is_paused else "unpause"
+        raise DatabaseException("Couldn't %s user: %s" % (action, str(err)))
 
 
-def unpause(db_conn,id):
-    """ Sets the user's is_paused flag to false
-    with specified row ID from the database.
-    
-    Args:
-        db_conn: database connection
-        id (int): the row ID of the listenbrainz user
-    """
-    try:
-        db_conn.execute(sqlalchemy.text("""
-            UPDATE "user"
-               SET is_paused = false
-             WHERE id = :id
-            """), {
-            'id': id,
-        })
-        db_conn.commit()
-        _notify_user_paused(db_conn,id,False)
-
-    except sqlalchemy.exc.ProgrammingError as err:
-        logger.error(err)
-        raise DatabaseException("Couldn't unpause user: %s" % str(err))
-
-
-def _notify_user_paused(db_conn, user_id,paused):
+def _notify_user_paused(db_conn, user_id, paused):
     user = get(db_conn, user_id, fetch_email=True)
     if user["email"] is None:
         logger.error("%s's email not found" % user["musicbrainz_id"])

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -655,15 +655,24 @@ def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
         users = result.mappings().all()
         db_conn.commit()
 
-        for user in users:
-            _notify_user_paused(db_conn, user["id"], is_paused)
-
-        return [user["musicbrainz_id"] for user in users]
-
     except sqlalchemy.exc.ProgrammingError as err:
         logger.error(err)
         action = "pause" if is_paused else "unpause"
         raise DatabaseException("Couldn't %s user: %s" % (action, str(err)))
+
+    for user in users:
+        try:
+            _notify_user_paused(db_conn, user["id"], is_paused)
+        except Exception as err:
+            logger.error(
+                "Failed to notify user %s after setting is_paused=%s: %s",
+                user["musicbrainz_id"],
+                is_paused,
+                err,
+                exc_info=True,
+            )
+
+    return [user["musicbrainz_id"] for user in users]
 
 
 def _notify_user_paused(db_conn, user_id, paused):

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -640,7 +640,7 @@ def set_reported_users_paused(db_conn, report_ids, is_paused):
 
 def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
     if not any(params.values()):
-        return []
+        return [], []
 
     try:
         result = db_conn.execute(sqlalchemy.text(f"""
@@ -660,10 +660,14 @@ def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
         action = "pause" if is_paused else "unpause"
         raise DatabaseException("Couldn't %s user: %s" % (action, str(err)))
 
+    musicbrainz_ids = [user["musicbrainz_id"] for user in users]
+    notification_failed_musicbrainz_ids = []
+
     for user in users:
         try:
             _notify_user_paused(db_conn, user["id"], is_paused)
         except Exception as err:
+            notification_failed_musicbrainz_ids.append(user["musicbrainz_id"])
             logger.error(
                 "Failed to notify user %s after setting is_paused=%s: %s",
                 user["musicbrainz_id"],
@@ -672,7 +676,7 @@ def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
                 exc_info=True,
             )
 
-    return [user["musicbrainz_id"] for user in users]
+    return musicbrainz_ids, notification_failed_musicbrainz_ids
 
 
 def _notify_user_paused(db_conn, user_id, paused):

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -1,6 +1,10 @@
 from listenbrainz.model import db
+from listenbrainz.db import user as db_user
 from listenbrainz.model.utils import generate_username_link
+from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.admin import AdminModelView
+from flask_admin.model import action
+from flask import  flash, redirect
 
 
 class ReportedUsers(db.Model):
@@ -13,6 +17,7 @@ class ReportedUsers(db.Model):
     reason = db.Column(db.String)
     reporter = db.relationship('User', foreign_keys=[reporter_user_id])
     reported = db.relationship('User', foreign_keys=[reported_user_id])
+    is_paused = db.Column(db.Boolean, nullable=False)
 
 
 class ReportedUserAdminView(AdminModelView):
@@ -21,10 +26,55 @@ class ReportedUserAdminView(AdminModelView):
         'reporter.musicbrainz_id',
         'reported.musicbrainz_id',
         'reason',
-        'reported_at'
+        'reported_at',
+        'is_paused',
     ]
 
     column_formatters = {
         "reporter.musicbrainz_id": lambda view, context, model, name: generate_username_link(model.reporter.musicbrainz_id),
         "reported.musicbrainz_id": lambda view, context, model, name: generate_username_link(model.reported.musicbrainz_id)
     }
+
+    # With select action to pause users.
+    @action(
+        name="pause_users",  # Unique name for the action
+        text="Pause",
+        confirmation="Pause selected users?",
+    )
+    def pause_users(self, ids):
+        for user_id in ids:
+            # making sure user_id is valid
+            user = ReportedUsers.query.get(user_id)
+            if user:
+                try:
+                    db_user.pause(db_conn, user.id)
+                    db_conn.commit()
+                    flash(f"{user.musicbrainz_id} paused", "success")
+                except Exception as e:
+                    flash(
+                        f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
+            else:
+                flash(f"{user_id} not found!", "error")
+        return redirect('/admin/reported_users_model/')
+
+    # With select action to unpause users.
+    @action(
+        name="unpause_users",
+        text="Unpause",
+        confirmation="Unpause selected users?",
+    )
+    def unpause_users(self, ids):
+        for user_id in ids:
+            # making sure user_id is valid
+            user = ReportedUsers.query.get(user_id)
+            if user:
+                try:
+                    db_user.unpause(db_conn, user.id)
+                    db_conn.commit()
+                    flash(f"{user.musicbrainz_id} unpaused", "success")
+                except Exception as e:
+                    flash(
+                        f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
+            else:
+                flash(f"{user_id} not found!", "error")
+        return redirect('/admin/reported_users_model/')

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -41,19 +41,18 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        for user_id in ids:
-            # making sure user_id is valid
-            user = ReportedUsers.query.get(user_id)
-            if user:
+        for report_id in ids:
+            report = ReportedUsers.query.get(report_id)
+            if report:
                 try:
-                    db_user.pause(db_conn, user.id)
+                    db_user.pause(db_conn, report.reported_user_id)
                     db_conn.commit()
-                    flash(f"{user.musicbrainz_id} paused", "success")
+                    flash(f"{report.reported.musicbrainz_id} paused", "success")
                 except Exception as e:
                     flash(
-                        f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
+                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
             else:
-                flash(f"{user_id} not found!", "error")
+                flash(f"{report_id} not found!", "error")
         return redirect('/admin/reported_users_model/')
 
     # With select action to unpause users.
@@ -63,17 +62,16 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        for user_id in ids:
-            # making sure user_id is valid
-            user = ReportedUsers.query.get(user_id)
-            if user:
+        for report_id in ids:
+            report = ReportedUsers.query.get(report_id)
+            if report:
                 try:
-                    db_user.unpause(db_conn, user.id)
+                    db_user.unpause(db_conn, report.reported_user_id)
                     db_conn.commit()
-                    flash(f"{user.musicbrainz_id} unpaused", "success")
+                    flash(f"{report.reported.musicbrainz_id} unpaused", "success")
                 except Exception as e:
                     flash(
-                        f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
+                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
             else:
-                flash(f"{user_id} not found!", "error")
+                flash(f"{report_id} not found!", "error")
         return redirect('/admin/reported_users_model/')

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -1,6 +1,5 @@
 from listenbrainz.model import db
-from listenbrainz.db import user as db_user
-from listenbrainz.model.utils import generate_username_link
+from listenbrainz.model.utils import generate_username_link, set_reported_users_paused
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.admin import AdminModelView
 from flask_admin.model import action
@@ -41,18 +40,11 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        for report_id in ids:
-            report = ReportedUsers.query.get(report_id)
-            if report:
-                try:
-                    db_user.pause(db_conn, report.reported_user_id)
-                    db_conn.commit()
-                    flash(f"{report.reported.musicbrainz_id} paused", "success")
-                except Exception as e:
-                    flash(
-                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{report_id} not found!", "error")
+        try:
+            users = set_reported_users_paused(db_conn, ids, True)
+            flash(f"Paused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to pause users: {str(e)}", "error")
         return redirect('/admin/reported_users_model/')
 
     # With select action to unpause users.
@@ -62,16 +54,9 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        for report_id in ids:
-            report = ReportedUsers.query.get(report_id)
-            if report:
-                try:
-                    db_user.unpause(db_conn, report.reported_user_id)
-                    db_conn.commit()
-                    flash(f"{report.reported.musicbrainz_id} unpaused", "success")
-                except Exception as e:
-                    flash(
-                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{report_id} not found!", "error")
+        try:
+            users = set_reported_users_paused(db_conn, ids, False)
+            flash(f"Unpaused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to unpause users: {str(e)}", "error")
         return redirect('/admin/reported_users_model/')

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -17,7 +17,6 @@ class ReportedUsers(db.Model):
     reason = db.Column(db.String)
     reporter = db.relationship('User', foreign_keys=[reporter_user_id])
     reported = db.relationship('User', foreign_keys=[reported_user_id])
-    is_paused = db.Column(db.Boolean, nullable=False)
 
 
 class ReportedUserAdminView(AdminModelView):
@@ -27,7 +26,7 @@ class ReportedUserAdminView(AdminModelView):
         'reported.musicbrainz_id',
         'reason',
         'reported_at',
-        'is_paused',
+        'reported.is_paused',
     ]
 
     column_formatters = {

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -1,5 +1,6 @@
 from listenbrainz.model import db
-from listenbrainz.model.utils import generate_username_link, set_reported_users_paused
+from listenbrainz.db import user as db_user
+from listenbrainz.model.utils import generate_username_link
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.admin import AdminModelView
 from flask_admin.model import action
@@ -40,11 +41,18 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        try:
-            users = set_reported_users_paused(db_conn, ids, True)
-            flash(f"Paused {len(users)} users", "success")
-        except Exception as e:
-            flash(f"Failed to pause users: {str(e)}", "error")
+        for report_id in ids:
+            report = ReportedUsers.query.get(report_id)
+            if report:
+                try:
+                    db_user.pause(db_conn, report.reported_user_id)
+                    db_conn.commit()
+                    flash(f"{report.reported.musicbrainz_id} paused", "success")
+                except Exception as e:
+                    flash(
+                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
+            else:
+                flash(f"{report_id} not found!", "error")
         return redirect('/admin/reported_users_model/')
 
     # With select action to unpause users.
@@ -54,9 +62,16 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        try:
-            users = set_reported_users_paused(db_conn, ids, False)
-            flash(f"Unpaused {len(users)} users", "success")
-        except Exception as e:
-            flash(f"Failed to unpause users: {str(e)}", "error")
+        for report_id in ids:
+            report = ReportedUsers.query.get(report_id)
+            if report:
+                try:
+                    db_user.unpause(db_conn, report.reported_user_id)
+                    db_conn.commit()
+                    flash(f"{report.reported.musicbrainz_id} unpaused", "success")
+                except Exception as e:
+                    flash(
+                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
+            else:
+                flash(f"{report_id} not found!", "error")
         return redirect('/admin/reported_users_model/')

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -1,6 +1,6 @@
 from listenbrainz.model import db
-from listenbrainz.db import user as db_user
 from listenbrainz.model.utils import generate_username_link
+from listenbrainz.db import user as db_user
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.admin import AdminModelView
 from flask_admin.model import action
@@ -41,18 +41,11 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        for report_id in ids:
-            report = ReportedUsers.query.get(report_id)
-            if report:
-                try:
-                    db_user.pause(db_conn, report.reported_user_id)
-                    db_conn.commit()
-                    flash(f"{report.reported.musicbrainz_id} paused", "success")
-                except Exception as e:
-                    flash(
-                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{report_id} not found!", "error")
+        try:
+            users = db_user.set_reported_users_paused(db_conn, ids, True)
+            flash(f"Paused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to pause users: {str(e)}", "error")
         return redirect('/admin/reported_users_model/')
 
     # With select action to unpause users.
@@ -62,16 +55,9 @@ class ReportedUserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        for report_id in ids:
-            report = ReportedUsers.query.get(report_id)
-            if report:
-                try:
-                    db_user.unpause(db_conn, report.reported_user_id)
-                    db_conn.commit()
-                    flash(f"{report.reported.musicbrainz_id} unpaused", "success")
-                except Exception as e:
-                    flash(
-                        f"Failed for {report.reported.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{report_id} not found!", "error")
+        try:
+            users = db_user.set_reported_users_paused(db_conn, ids, False)
+            flash(f"Unpaused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to unpause users: {str(e)}", "error")
         return redirect('/admin/reported_users_model/')

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -42,8 +42,17 @@ class ReportedUserAdminView(AdminModelView):
     )
     def pause_users(self, ids):
         try:
-            users = db_user.set_reported_users_paused(db_conn, ids, True)
+            users, notification_failed_users = db_user.set_reported_users_paused(db_conn, ids, True)
             flash(f"Paused {len(users)} users", "success")
+            if notification_failed_users:
+                flash(
+                    "Sent %d notifications. Failed to notify %d users: %s" % (
+                        len(users) - len(notification_failed_users),
+                        len(notification_failed_users),
+                        ", ".join(notification_failed_users),
+                    ),
+                    "warning",
+                )
         except Exception as e:
             flash(f"Failed to pause users: {str(e)}", "error")
         return redirect('/admin/reported_users_model/')
@@ -56,8 +65,17 @@ class ReportedUserAdminView(AdminModelView):
     )
     def unpause_users(self, ids):
         try:
-            users = db_user.set_reported_users_paused(db_conn, ids, False)
+            users, notification_failed_users = db_user.set_reported_users_paused(db_conn, ids, False)
             flash(f"Unpaused {len(users)} users", "success")
+            if notification_failed_users:
+                flash(
+                    "Sent %d notifications. Failed to notify %d users: %s" % (
+                        len(users) - len(notification_failed_users),
+                        len(notification_failed_users),
+                        ", ".join(notification_failed_users),
+                    ),
+                    "warning",
+                )
         except Exception as e:
             flash(f"Failed to unpause users: {str(e)}", "error")
         return redirect('/admin/reported_users_model/')

--- a/listenbrainz/model/reported_users.py
+++ b/listenbrainz/model/reported_users.py
@@ -4,7 +4,7 @@ from listenbrainz.db import user as db_user
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.admin import AdminModelView
 from flask_admin.model import action
-from flask import  flash, redirect
+from flask import flash, redirect
 
 
 class ReportedUsers(db.Model):

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -4,9 +4,10 @@ from flask import current_app,flash,redirect
 from flask_admin.model import action
 from psycopg2 import OperationalError, DatabaseError
 from listenbrainz.model import db
-from listenbrainz.model.utils import generate_username_link, set_users_paused
+from listenbrainz.model.utils import generate_username_link
 from listenbrainz.webserver.admin import AdminModelView
 from listenbrainz.background.background_tasks import add_task
+from listenbrainz.db import user as db_user
 from listenbrainz.webserver import create_app, db_conn, ts_conn
 
 
@@ -79,11 +80,18 @@ class UserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        try:
-            users = set_users_paused(db_conn, ids, True)
-            flash(f"Paused {len(users)} users", "success")
-        except Exception as e:
-            flash(f"Failed to pause users: {str(e)}", "error")
+        for user_id in ids:
+            # making sure user_id is valid
+            user = User.query.get(user_id)
+            if user:
+                try:
+                    db_user.pause(db_conn,user.id)
+                    db_conn.commit()
+                    flash(f"{user.musicbrainz_id} paused", "success")
+                except Exception as e:
+                    flash(f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
+            else:
+                flash(f"{user_id} not found!", "error")
         return redirect('/admin/user_model/')
 
 
@@ -94,9 +102,16 @@ class UserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        try:
-            users = set_users_paused(db_conn, ids, False)
-            flash(f"Unpaused {len(users)} users", "success")
-        except Exception as e:
-            flash(f"Failed to unpause users: {str(e)}", "error")
+        for user_id in ids:
+            # making sure user_id is valid
+            user = User.query.get(user_id)
+            if user:
+                try:
+                    db_user.unpause(db_conn,user.id)
+                    db_conn.commit()
+                    flash(f"{user.musicbrainz_id} unpaused", "success")
+                except Exception as e:
+                    flash(f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
+            else:
+                flash(f"{user_id} not found!", "error")
         return redirect('/admin/user_model/')

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -4,10 +4,9 @@ from flask import current_app,flash,redirect
 from flask_admin.model import action
 from psycopg2 import OperationalError, DatabaseError
 from listenbrainz.model import db
-from listenbrainz.model.utils import generate_username_link
+from listenbrainz.model.utils import generate_username_link, set_users_paused
 from listenbrainz.webserver.admin import AdminModelView
 from listenbrainz.background.background_tasks import add_task
-from listenbrainz.db import user as db_user
 from listenbrainz.webserver import create_app, db_conn, ts_conn
 
 
@@ -80,18 +79,11 @@ class UserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        for user_id in ids:
-            # making sure user_id is valid
-            user = User.query.get(user_id)
-            if user:
-                try:
-                    db_user.pause(db_conn,user.id)
-                    db_conn.commit()
-                    flash(f"{user.musicbrainz_id} paused", "success")
-                except Exception as e:
-                    flash(f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{user_id} not found!", "error")
+        try:
+            users = set_users_paused(db_conn, ids, True)
+            flash(f"Paused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to pause users: {str(e)}", "error")
         return redirect('/admin/user_model/')
 
 
@@ -102,16 +94,9 @@ class UserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        for user_id in ids:
-            # making sure user_id is valid
-            user = User.query.get(user_id)
-            if user:
-                try:
-                    db_user.unpause(db_conn,user.id)
-                    db_conn.commit()
-                    flash(f"{user.musicbrainz_id} unpaused", "success")
-                except Exception as e:
-                    flash(f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{user_id} not found!", "error")
+        try:
+            users = set_users_paused(db_conn, ids, False)
+            flash(f"Unpaused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to unpause users: {str(e)}", "error")
         return redirect('/admin/user_model/')

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -80,18 +80,11 @@ class UserAdminView(AdminModelView):
         confirmation="Pause selected users?",
     )
     def pause_users(self, ids):
-        for user_id in ids:
-            # making sure user_id is valid
-            user = User.query.get(user_id)
-            if user:
-                try:
-                    db_user.pause(db_conn,user.id)
-                    db_conn.commit()
-                    flash(f"{user.musicbrainz_id} paused", "success")
-                except Exception as e:
-                    flash(f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{user_id} not found!", "error")
+        try:
+            users = db_user.pause(db_conn, ids)
+            flash(f"Paused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to pause users: {str(e)}", "error")
         return redirect('/admin/user_model/')
 
 
@@ -102,16 +95,9 @@ class UserAdminView(AdminModelView):
         confirmation="Unpause selected users?",
     )
     def unpause_users(self, ids):
-        for user_id in ids:
-            # making sure user_id is valid
-            user = User.query.get(user_id)
-            if user:
-                try:
-                    db_user.unpause(db_conn,user.id)
-                    db_conn.commit()
-                    flash(f"{user.musicbrainz_id} unpaused", "success")
-                except Exception as e:
-                    flash(f"Failed for {user.musicbrainz_id}: {str(e)}", "error")
-            else:
-                flash(f"{user_id} not found!", "error")
+        try:
+            users = db_user.unpause(db_conn, ids)
+            flash(f"Unpaused {len(users)} users", "success")
+        except Exception as e:
+            flash(f"Failed to unpause users: {str(e)}", "error")
         return redirect('/admin/user_model/')

--- a/listenbrainz/model/user.py
+++ b/listenbrainz/model/user.py
@@ -81,8 +81,17 @@ class UserAdminView(AdminModelView):
     )
     def pause_users(self, ids):
         try:
-            users = db_user.pause(db_conn, ids)
+            users, notification_failed_users = db_user.pause(db_conn, ids)
             flash(f"Paused {len(users)} users", "success")
+            if notification_failed_users:
+                flash(
+                    "Sent %d notifications. Failed to notify %d users: %s" % (
+                        len(users) - len(notification_failed_users),
+                        len(notification_failed_users),
+                        ", ".join(notification_failed_users),
+                    ),
+                    "warning",
+                )
         except Exception as e:
             flash(f"Failed to pause users: {str(e)}", "error")
         return redirect('/admin/user_model/')
@@ -96,8 +105,17 @@ class UserAdminView(AdminModelView):
     )
     def unpause_users(self, ids):
         try:
-            users = db_user.unpause(db_conn, ids)
+            users, notification_failed_users = db_user.unpause(db_conn, ids)
             flash(f"Unpaused {len(users)} users", "success")
+            if notification_failed_users:
+                flash(
+                    "Sent %d notifications. Failed to notify %d users: %s" % (
+                        len(users) - len(notification_failed_users),
+                        len(notification_failed_users),
+                        ", ".join(notification_failed_users),
+                    ),
+                    "warning",
+                )
         except Exception as e:
             flash(f"Failed to unpause users: {str(e)}", "error")
         return redirect('/admin/user_model/')

--- a/listenbrainz/model/utils.py
+++ b/listenbrainz/model/utils.py
@@ -1,44 +1,5 @@
 from markupsafe import Markup
-import sqlalchemy
 
 
 def generate_username_link(user_name):
     return Markup(f"""<a href="https://listenbrainz.org/user/{user_name}">{user_name}</a>""")
-
-
-def set_users_paused(db_conn, user_ids, is_paused):
-    user_ids = [int(user_id) for user_id in user_ids]
-    return _set_users_paused(db_conn, ":user_ids", {"user_ids": tuple(user_ids)}, is_paused)
-
-
-def set_reported_users_paused(db_conn, report_ids, is_paused):
-    report_ids = [int(report_id) for report_id in report_ids]
-    return _set_users_paused(
-        db_conn,
-        """
-            (SELECT DISTINCT reported_user_id
-               FROM reported_users
-              WHERE id IN :report_ids)
-        """,
-        {"report_ids": tuple(report_ids)},
-        is_paused,
-    )
-
-
-def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
-    if not any(params.values()):
-        return []
-
-    query = sqlalchemy.text(f"""
-        UPDATE "user"
-           SET is_paused = :is_paused
-         WHERE "user".id IN {user_ids_expression}
-     RETURNING "user".musicbrainz_id
-    """)
-    result = db_conn.execute(query, {
-        **params,
-        "is_paused": is_paused,
-    })
-    users = [row.musicbrainz_id for row in result.fetchall()]
-    db_conn.commit()
-    return users

--- a/listenbrainz/model/utils.py
+++ b/listenbrainz/model/utils.py
@@ -1,5 +1,44 @@
 from markupsafe import Markup
+import sqlalchemy
 
 
 def generate_username_link(user_name):
     return Markup(f"""<a href="https://listenbrainz.org/user/{user_name}">{user_name}</a>""")
+
+
+def set_users_paused(db_conn, user_ids, is_paused):
+    user_ids = [int(user_id) for user_id in user_ids]
+    return _set_users_paused(db_conn, ":user_ids", {"user_ids": tuple(user_ids)}, is_paused)
+
+
+def set_reported_users_paused(db_conn, report_ids, is_paused):
+    report_ids = [int(report_id) for report_id in report_ids]
+    return _set_users_paused(
+        db_conn,
+        """
+            (SELECT DISTINCT reported_user_id
+               FROM reported_users
+              WHERE id IN :report_ids)
+        """,
+        {"report_ids": tuple(report_ids)},
+        is_paused,
+    )
+
+
+def _set_users_paused(db_conn, user_ids_expression, params, is_paused):
+    if not any(params.values()):
+        return []
+
+    query = sqlalchemy.text(f"""
+        UPDATE "user"
+           SET is_paused = :is_paused
+         WHERE "user".id IN {user_ids_expression}
+     RETURNING "user".musicbrainz_id
+    """)
+    result = db_conn.execute(query, {
+        **params,
+        "is_paused": is_paused,
+    })
+    users = [row.musicbrainz_id for row in result.fetchall()]
+    db_conn.commit()
+    return users

--- a/listenbrainz/webserver/templates/emails/id_paused.txt
+++ b/listenbrainz/webserver/templates/emails/id_paused.txt
@@ -1,8 +1,8 @@
 Hi {{ username }}!
 
 We have paused your ListenBrainz account {{ username }} because of a problem with your account.
-Our community manager will reach out to you with the details as to why we took this step.
-Feel free to contact Us {{ url }} if you have any questions about this.
+This could be an issue with your submitter/scrobbler, or that you triggered an anti-bot protection.
+Please contact us {{ url }} if you have any questions about this.
 
 Best,
 The ListenBrainz Team


### PR DESCRIPTION
Copying code from listenbrainz/model/users.py to allow easily pausing reported users (previously only available from the users admin view, which does not have the reported status).

Used Codex to refactor the code in commit 471fd23
