### PR TITLE
Fix incorrect parameter documentation in db helpers

### DIFF
--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -274,7 +274,7 @@ def update_comment(db_conn, row_id: int, blurb_content: str) -> bool:
 
         Args:
             db_conn: Database connection
-            user_id: The user for which the comment of pinned record has to be updated
+            row_id: The row ID of the pinned recording whose comment is to be updated
             blurb_content: The new comment of the user
         Returns:
             True if the update was successful, False otherwise

--- a/listenbrainz/db/user.py
+++ b/listenbrainz/db/user.py
@@ -108,7 +108,7 @@ def get_by_login_id(db_conn, login_id):
 
     Args:
         db_conn: database connection
-        id (UUID): login ID of a user.
+        login_id (UUID): login ID of a user.
 
     Returns:
         Dictionary with the following structure:

--- a/listenbrainz/domain/apple.py
+++ b/listenbrainz/domain/apple.py
@@ -47,7 +47,6 @@ class AppleService(ExternalService):
 
         Args:
             user_id: A flask auth `current_user.id`
-            token: A dict containing jwt encoded token and its expiry time
         """
         token = self.fetch_access_token()
         access_token = token["access_token"]

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -693,7 +693,6 @@ class TimescaleListenStore:
         Note: this method tries to delete the user 5 times before giving up.
 
         Args:
-            musicbrainz_id: the MusicBrainz ID of the user
             user_id: the listenbrainz row id of the user
             created: delete listens created before this timestamp
 


### PR DESCRIPTION
### Problem

Four docstrings in the `listenbrainz` package document parameters that do not match their function signatures:

- `db.user.get_by_login_id` documents `id` instead of its actual `login_id` parameter.
- `domain.apple.AppleService.add_new_user` documents a `token` parameter it does not take (the token is fetched internally via `fetch_access_token`).
- `listenstore.timescale_listenstore.TimescaleListenStore.delete` documents a `musicbrainz_id` parameter it does not take (it takes `user_id`).
- `db.pinned_recording.update_comment` documents `user_id` instead of its actual `row_id` parameter.

### Solution

Corrects the documented parameter names/entries to match each signature. Documentation-only change; no behaviour is affected.
