### PR TITLE
Fix incorrect parameter documentation in db helpers

### DIFF
--- a/listenbrainz/db/missing_musicbrainz_data.py
+++ b/listenbrainz/db/missing_musicbrainz_data.py
@@ -37,7 +37,7 @@ def insert_user_missing_musicbrainz_data(db_conn, user_id: int,
         Args:
             db_conn: database connection
             user_id : row id of the user.
-            data : Data that is submitted to ListenBrainz by the users
+            missing_musicbrainz_data : Data that is submitted to ListenBrainz by the users
                    but is not submitted to MusicBrainz.
             source : Source of generation of missing MusicBrainz data.
     """

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -534,8 +534,6 @@ def search_playlist(db_conn, ts_conn, query: str, count: int = 0, offset: int = 
         db_conn: database connection
         ts_conn: timescale database connection
         query: The search query
-        include_private: If True, include all playlists by a user, including private ones. The count of
-                 playlists returned will include private playlists if True
         count: Return this many playlists. If 0, return all playlists
         offset: if set, get playlists from this offset
 

--- a/listenbrainz/db/stats.py
+++ b/listenbrainz/db/stats.py
@@ -143,7 +143,8 @@ def insert_sitewide_stats(stats_type: str, stats_range: str, from_ts: int, to_ts
     """ Insert sitewide stats in couchdb.
 
         Args:
-            database: the name of the database to insert the stat in
+            stats_type: the type of the stat to insert
+            stats_range: the time range of the stat to insert
             from_ts: the start of the time period for which the stat is
             to_ts: the end of the time period for which the stat is
             data: sitewide stat to insert


### PR DESCRIPTION
A few more `Args:` entries in the db helpers documented parameter names that don't match the actual function signatures:

- `insert_user_missing_musicbrainz_data`: `data` -> `missing_musicbrainz_data`
- `search_playlist`: removed the phantom `include_private` argument (not in the signature)
- `insert_sitewide_stats`: replaced the phantom `database` argument with the actual `stats_type` and `stats_range` parameters

Documentation-only change; no behavior change.