### PR TITLE
LB-1584: Limit time and number of passes for timescale queries

### DIFF
--- a/docs/users/api_usage_examples/get_listens.py
+++ b/docs/users/api_usage_examples/get_listens.py
@@ -24,9 +24,25 @@ def get_listens(username, min_ts=None, max_ts=None, count=None):
                 DO NOT USE WITH min_ts.
         count: How many listens to return. If not specified,
                uses a default from the server.
+               This does not guarantee all requested listens will be returned.
+
 
     Returns:
         A list of listen info dictionaries if there's an OK status.
+        The response will contain a count and a search_status which indicates
+        whether the database search ended before all requested listens were returned.
+        This object has the following shape:
+
+        .. code-block:: text
+
+            {
+                "partial": <boolean>,
+                "continue_max_ts": <unix timestamp, optional>,
+                "continue_min_ts": <unix timestamp, optional>
+            }
+
+        ``partial`` is always present. When true, either ``continue_max_ts`` and ``continue_min_ts``
+        will be present to continue the search.
 
     Raises:
         An HTTPError if there's a failure.

--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -127,7 +127,10 @@ The JSON documents returned from our API look like the following:
         "user_id": "-- the MusicBrainz ID of the user --",
         "listens": [
           "-- listen data here ---"
-        ]
+        ],
+        "search_status": {
+          "partial": false
+        }
       }
     }
 
@@ -135,6 +138,10 @@ The number of listens in the document are returned by the top-level ``count``
 element. The ``user_id`` element contains the MusicBrainz ID of the user whose listens are
 being returned. The other element is the ``listens`` element. This is a list which contains
 the listen JSON elements (described above).
+
+When there is a large time gap between listens, we may return fewer than the requested ``count``.
+The ``search_status`` element contains a ``partial`` boolean which will indicate a partial result set. 
+If ``partial`` is true, a ``continue_max_ts`` or ``continue_min_ts`` timestamp can be used to continue the search.
 
 The JSON document returned by the API endpoint for getting tracks being played right now
 is the same as above, except that it also contains the ``payload/playing_now`` element as a

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -483,9 +483,7 @@ export default function Listen() {
   const isNewerButtonDisabled =
     !previousListenTs || previousListenTs >= latestListenTs;
   const isOlderButtonDisabled = !nextListenTs || nextListenTs <= oldestListenTs;
-  const isOnLastPage =
-    listens.length > 0 &&
-    listens[listens.length - 1]?.listened_at <= oldestListenTs;
+  const isOnLastPage = listens.length > 0 && nextListenTs <= oldestListenTs;
   const isUserLoggedIn = !isNil(currentUser) && !isEmpty(currentUser);
   const isCurrentUsersPage = currentUser?.name === user?.name;
   const isNavigatingListens =
@@ -708,35 +706,32 @@ export default function Listen() {
               >
                 {listens.map(getListenCard)}
               </div>
-              {(searchStatus.partial ||
-                (listens.length < expectedListensPerPage &&
-                  isOnFirstPage &&
-                  !isOnLastPage)) && (
-                <div className="text-center mt-5">
-                  <hr />
-                  <h4>
-                    No {listens.length > 0 ? "more" : ""} listens for that
-                    month.
-                  </h4>
-                  {continuationSearchUrl && (
-                    <Link
-                      to={continuationSearchUrl}
-                      className="btn btn-outline-info"
-                    >
-                      {continuationSearchLabel}
-                    </Link>
-                  )}
-                </div>
-              )}
-              {!searchStatus.partial &&
-                isOnLastPage &&
-                listens.length < expectedListensPerPage && (
+              {!isOnLastPage &&
+                (Boolean(searchStatus.partial) ||
+                  listens.length < expectedListensPerPage) && (
                   <div className="text-center mt-5">
                     <hr />
-                    <h4>End of the line!</h4>
-                    <h5>No more listens to show</h5>
+                    <h4>
+                      No {listens.length > 0 ? "more" : ""} listens for that
+                      month.
+                    </h4>
+                    {continuationSearchUrl && (
+                      <Link
+                        to={continuationSearchUrl}
+                        className="btn btn-outline-info"
+                      >
+                        {continuationSearchLabel}
+                      </Link>
+                    )}
                   </div>
                 )}
+              {isOnLastPage && (
+                <div className="text-center mt-5">
+                  <hr />
+                  <h4>End of the line!</h4>
+                  <h5>No more listens to show</h5>
+                </div>
+              )}
               <ul className="pagination" id="navigation">
                 <li className={`page-item ${isOnFirstPage ? "disabled" : ""}`}>
                   <Link

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -709,7 +709,9 @@ export default function Listen() {
                 {listens.map(getListenCard)}
               </div>
               {(searchStatus.partial ||
-                (listens.length < expectedListensPerPage && isOnFirstPage)) && (
+                (listens.length < expectedListensPerPage &&
+                  isOnFirstPage &&
+                  !isOnLastPage)) && (
                 <div className="text-center">
                   <h4>
                     No {listens.length > 0 ? "more" : ""} listens for that
@@ -726,7 +728,7 @@ export default function Listen() {
                 </div>
               )}
               {!searchStatus.partial &&
-                !isOnFirstPage &&
+                isOnLastPage &&
                 listens.length < expectedListensPerPage && (
                   <div className="text-center mt-5">
                     <hr />

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -12,11 +12,17 @@ import {
   faRss,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { cloneDeep, get, isEmpty, isEqual, isNil } from "lodash";
+import { cloneDeep, get, isEmpty, isEqual, isNil, isNumber } from "lodash";
 import DateTimePicker from "react-datetime-picker/dist/entry.nostyle";
 import { toast } from "react-toastify";
 import { io } from "socket.io-client";
-import { Link, useLocation, useParams, useSearchParams } from "react-router";
+import {
+  Link,
+  useLocation,
+  useNavigation,
+  useParams,
+  useSearchParams,
+} from "react-router";
 import { Helmet } from "react-helmet";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
@@ -29,6 +35,7 @@ import ListenControl from "../common/listens/ListenControl";
 import ListenCountCard from "../common/listens/ListenCountCard";
 import { ToastMsg } from "../notifications/Notifications";
 import PinnedRecordingCard from "./components/PinnedRecordingCard";
+import Loader from "../components/Loader";
 import {
   formatWSMessageToListen,
   getBaseUrl,
@@ -47,6 +54,11 @@ export type ListensProps = {
   latestListenTs: number;
   listens?: Array<Listen>;
   oldestListenTs: number;
+  searchStatus?: {
+    partial: boolean;
+    continueMaxTs?: number;
+    continueMinTs?: number;
+  };
   user: ListenBrainzUser;
   userPinnedRecording?: PinnedRecording;
   playingNow?: Listen;
@@ -57,6 +69,7 @@ type ListenLoaderData = ListensProps;
 
 export default function Listen() {
   const location = useLocation();
+  const navigation = useNavigation();
   const params = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParamsObject = getObjectForURLSearchParams(searchParams);
@@ -68,7 +81,7 @@ export default function Listen() {
     location.pathname
   );
 
-  const { data, refetch } = useQuery<ListenLoaderData>({
+  const { data, refetch, isFetching } = useQuery<ListenLoaderData>({
     queryKey,
     queryFn,
     staleTime: isTimeNavigation ? 1000 * 60 * 5 : 0,
@@ -81,11 +94,26 @@ export default function Listen() {
     playingNow = undefined,
     latestListenTs = 0,
     oldestListenTs = 0,
+    searchStatus = { partial: false },
     already_reported_user = false,
   } = data || {};
 
-  const previousListenTs = listens[0]?.listened_at;
-  const nextListenTs = listens[listens.length - 1]?.listened_at;
+  let previousListenTs = listens[0]?.listened_at;
+  let nextListenTs = listens[listens.length - 1]?.listened_at;
+  let continuationSearchUrl: string | undefined;
+  let continuationSearchLabel: string | undefined;
+  if (searchStatus.partial) {
+    if (searchStatus.continueMinTs) {
+      previousListenTs = searchStatus.continueMinTs;
+      continuationSearchUrl = `?min_ts=${searchStatus.continueMinTs}`;
+      continuationSearchLabel = "Continue searching newer listens";
+    }
+    if (searchStatus.continueMaxTs) {
+      nextListenTs = searchStatus.continueMaxTs;
+      continuationSearchUrl = `?max_ts=${searchStatus.continueMaxTs}`;
+      continuationSearchLabel = "Continue searching older listens";
+    }
+  }
 
   const { currentUser, websocketsUrl, APIService } = React.useContext(
     GlobalAppContext
@@ -451,15 +479,19 @@ export default function Listen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allListenables]);
 
-  const isNewestButtonDisabled = listens[0]?.listened_at >= latestListenTs;
+  const isOnFirstPage = listens[0]?.listened_at >= latestListenTs;
   const isNewerButtonDisabled =
     !previousListenTs || previousListenTs >= latestListenTs;
   const isOlderButtonDisabled = !nextListenTs || nextListenTs <= oldestListenTs;
-  const isOldestButtonDisabled =
+  const isOnLastPage =
     listens.length > 0 &&
     listens[listens.length - 1]?.listened_at <= oldestListenTs;
   const isUserLoggedIn = !isNil(currentUser) && !isEmpty(currentUser);
   const isCurrentUsersPage = currentUser?.name === user?.name;
+  const isNavigatingListens =
+    navigation.state === "loading" &&
+    navigation.location?.pathname === location.pathname;
+  const isLoadingListens = isFetching || isNavigatingListens;
 
   return (
     <div role="main" id="dashboard">
@@ -512,7 +544,7 @@ export default function Listen() {
           {user && <UserSocialNetwork user={user} />}
         </div>
         <div className="col-lg-8 order-lg-1">
-          {!listens.length && (
+          {!listens.length && isNumber(listenCount) && listenCount === 0 && (
             <div className="empty-listens">
               <FontAwesomeIcon icon={faCompactDisc as IconProp} size="10x" />
               {isCurrentUsersPage ? (
@@ -522,12 +554,11 @@ export default function Listen() {
                   {user?.name} hasn&apos;t listened to any songs yet.
                 </div>
               )}
-
               {isCurrentUsersPage && (
                 <div className="empty-action">
                   Import{" "}
                   <Link to="/settings/import/">your listening history</Link>{" "}
-                  from last.fm/libre.fm and track your listens by{" "}
+                  from Spotify or last.fm/libre.fm and track your listens by{" "}
                   <Link to="/settings/music-services/details/">
                     connecting to a music streaming service
                   </Link>
@@ -559,7 +590,7 @@ export default function Listen() {
             </div>
           )}
           <div className="listen-header">
-            {listens.length === 0 ? (
+            {listens.length === 0 && !searchStatus.partial ? (
               <div id="spacer" />
             ) : (
               <h3 className="header-with-line">Recent listens</h3>
@@ -666,8 +697,8 @@ export default function Listen() {
               <FontAwesomeIcon icon={faRss} size="sm" />
             </button>
           </div>
-
-          {listens.length > 0 && (
+          <Loader isLoading={isLoadingListens} />
+          {(listens.length > 0 || searchStatus.partial) && (
             <div>
               <div
                 id="listens"
@@ -677,20 +708,39 @@ export default function Listen() {
               >
                 {listens.map(getListenCard)}
               </div>
-              {listens.length < expectedListensPerPage && (
-                <h5 className="text-center">No more listens to show</h5>
+              {(searchStatus.partial ||
+                (listens.length < expectedListensPerPage && isOnFirstPage)) && (
+                <div className="text-center">
+                  <h4>
+                    No {listens.length > 0 ? "more" : ""} listens for that
+                    month.
+                  </h4>
+                  {continuationSearchUrl && (
+                    <Link
+                      to={continuationSearchUrl}
+                      className="btn btn-outline-info"
+                    >
+                      {continuationSearchLabel}
+                    </Link>
+                  )}
+                </div>
               )}
+              {!searchStatus.partial &&
+                !isOnFirstPage &&
+                listens.length < expectedListensPerPage && (
+                  <div className="text-center mt-5">
+                    <hr />
+                    <h4>End of the line!</h4>
+                    <h5>No more listens to show</h5>
+                  </div>
+                )}
               <ul className="pagination" id="navigation">
-                <li
-                  className={`page-item ${
-                    isNewestButtonDisabled ? "disabled" : ""
-                  }`}
-                >
+                <li className={`page-item ${isOnFirstPage ? "disabled" : ""}`}>
                   <Link
                     role="button"
                     aria-label="Navigate to most recent listens"
                     tabIndex={0}
-                    aria-disabled={isNewestButtonDisabled}
+                    aria-disabled={isOnFirstPage}
                     to={location.pathname}
                     className="page-link"
                   >
@@ -749,15 +799,13 @@ export default function Listen() {
                   </Link>
                 </li>
                 <li
-                  className={`page-item next ${
-                    isOldestButtonDisabled ? "disabled" : ""
-                  }`}
+                  className={`page-item next ${isOnLastPage ? "disabled" : ""}`}
                 >
                   <Link
                     aria-label="Navigate to oldest listens"
                     role="button"
                     tabIndex={0}
-                    aria-disabled={isOldestButtonDisabled}
+                    aria-disabled={isOnLastPage}
                     to={`?min_ts=${oldestListenTs - 1}`}
                     className="page-link"
                   >

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -712,7 +712,8 @@ export default function Listen() {
                 (listens.length < expectedListensPerPage &&
                   isOnFirstPage &&
                   !isOnLastPage)) && (
-                <div className="text-center">
+                <div className="text-center mt-5">
+                  <hr />
                   <h4>
                     No {listens.length > 0 ? "more" : ""} listens for that
                     month.

--- a/frontend/js/tests/user/Dashboard.test.tsx
+++ b/frontend/js/tests/user/Dashboard.test.tsx
@@ -529,6 +529,86 @@ describe("Dashboard page", () => {
     });
 
     describe("handleClickOlder", () => {
+      it("shows a continue search link when the older search is partial", async () => {
+        server.use(
+          http.post("/", async (path) => {
+            return HttpResponse.json({
+              ...props,
+              listens: listens.slice(0, 3),
+              searchStatus: {
+                partial: true,
+                continueMaxTs: 1520941000,
+              },
+            });
+          })
+        );
+
+        renderWithProviders(
+          <Listens />,
+          {
+            currentUser,
+          },
+          {
+            wrapper: reactQueryWrapper,
+          }
+        );
+
+        await waitFor(() => {
+          const state = queryClient.getQueryState(queryKey);
+          expect(state?.status === "success").toBeTruthy();
+        });
+
+        const continueSearchLink = await screen.findByRole("link", {
+          name: "Continue searching older listens",
+        });
+        expect(continueSearchLink).toHaveAttribute(
+          "href",
+          "/?max_ts=1520941000"
+        );
+        expect(screen.queryByText("No more listens to show")).toBeNull();
+      });
+
+      it("shows a continue search link for an empty partial range", async () => {
+        server.use(
+          http.post("/", async (path) => {
+            return HttpResponse.json({
+              ...props,
+              listens: [],
+              searchStatus: {
+                partial: true,
+                continueMaxTs: 1520941000,
+              },
+            });
+          })
+        );
+
+        renderWithProviders(
+          <Listens />,
+          {
+            currentUser,
+          },
+          {
+            wrapper: reactQueryWrapper,
+          }
+        );
+
+        await waitFor(() => {
+          const state = queryClient.getQueryState(queryKey);
+          expect(state?.status === "success").toBeTruthy();
+        });
+
+        expect(
+          screen.getByText("No listens found in this range.")
+        ).toBeInTheDocument();
+        const continueSearchLink = await screen.findByRole("link", {
+          name: "Continue searching older listens",
+        });
+        expect(continueSearchLink).toHaveAttribute(
+          "href",
+          "/?max_ts=1520941000"
+        );
+      });
+
       it("older button should be disabled if there is no older listens timestamp", async () => {
         server.use(
           http.post("/", async (path) => {

--- a/frontend/js/tests/user/Dashboard.test.tsx
+++ b/frontend/js/tests/user/Dashboard.test.tsx
@@ -68,6 +68,10 @@ const currentUser = { id: 1, name: "iliekcomputers", auth_token: "fnord" };
 let mockSearchParam = {};
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
+  useNavigation: () => ({
+    state: "idle",
+    location: undefined,
+  }),
   useSearchParams: () => {
     const [params, setParams] = React.useState(
       new URLSearchParams(mockSearchParam)
@@ -82,12 +86,19 @@ jest.mock("react-router", () => ({
   },
 }));
 
-jest.mock("react-datetime-picker/dist/entry.nostyle", () => (props: any) => (
-  <input
-    data-testid="mock-date-picker"
-    onChange={(e) => props.onChange(new Date(e.target.value))}
-  />
-));
+jest.mock(
+  "react-datetime-picker/dist/entry.nostyle",
+  () =>
+    function (datePickerProps: any) {
+      const { onChange } = datePickerProps;
+      return (
+        <input
+          data-testid="mock-date-picker"
+          onChange={(e) => onChange(new Date(e.target.value))}
+        />
+      );
+    }
+);
 
 describe("Dashboard page", () => {
   jest.setTimeout(10000);
@@ -102,7 +113,7 @@ describe("Dashboard page", () => {
         HttpResponse.json({ followers: [] })
       ),
       http.get("/1/user/*/similar-users", async (path) => {
-        HttpResponse.json({ payload: [] });
+        return HttpResponse.json({ payload: [] });
       }),
       http.get("/1/user/*/listen-count", async (path) =>
         HttpResponse.json({ payload: { count: 42 } })
@@ -162,7 +173,7 @@ describe("Dashboard page", () => {
       const state = queryClient.getQueryState(queryKey);
       expect(state?.status === "success").toBeTruthy();
     });
-    
+
     // Ensure we show a listen count card component, but don't test the contents
     // Tests for it are in ListenCountCard.test.tsx
     screen.getByTestId("listen-count-card");
@@ -530,6 +541,7 @@ describe("Dashboard page", () => {
 
     describe("handleClickOlder", () => {
       it("shows a continue search link when the older search is partial", async () => {
+        const continueMaxTs = oldestListenTs + 1;
         server.use(
           http.post("/", async (path) => {
             return HttpResponse.json({
@@ -537,7 +549,7 @@ describe("Dashboard page", () => {
               listens: listens.slice(0, 3),
               searchStatus: {
                 partial: true,
-                continueMaxTs: 1520941000,
+                continueMaxTs: oldestListenTs + 1,
               },
             });
           })
@@ -563,12 +575,13 @@ describe("Dashboard page", () => {
         });
         expect(continueSearchLink).toHaveAttribute(
           "href",
-          "/?max_ts=1520941000"
+          `/?max_ts=${continueMaxTs}`
         );
         expect(screen.queryByText("No more listens to show")).toBeNull();
       });
 
       it("shows a continue search link for an empty partial range", async () => {
+        const continueMaxTs = oldestListenTs + 1;
         server.use(
           http.post("/", async (path) => {
             return HttpResponse.json({
@@ -576,7 +589,7 @@ describe("Dashboard page", () => {
               listens: [],
               searchStatus: {
                 partial: true,
-                continueMaxTs: 1520941000,
+                continueMaxTs,
               },
             });
           })
@@ -598,14 +611,14 @@ describe("Dashboard page", () => {
         });
 
         expect(
-          screen.getByText("No listens found in this range.")
+          screen.getByText("No listens for that month.")
         ).toBeInTheDocument();
         const continueSearchLink = await screen.findByRole("link", {
           name: "Continue searching older listens",
         });
         expect(continueSearchLink).toHaveAttribute(
           "href",
-          "/?max_ts=1520941000"
+          `/?max_ts=${continueMaxTs}`
         );
       });
 

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -125,6 +125,9 @@ STATS_CALCULATION_INTERVAL = 7 # stats are calculated every 7 days
 # Max time in seconds after which the playing_now stream will expire.
 PLAYING_NOW_MAX_DURATION = 10 * 60
 
+# None to disable (i.e. for local dev)
+FETCH_LISTENS_SOFT_TIME_LIMIT_MS = None
+
 # LOGGING
 
 # Uncomment any of the following logging stubs if you want to enable logging

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from unittest import mock
 from datetime import datetime, timedelta, timezone
 from time import time
 
@@ -12,7 +13,7 @@ from listenbrainz.db import timescale as ts, timescale
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
 from listenbrainz.listenstore.tests.util import create_test_data_for_timescalelistenstore
 from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT, \
-    TimescaleListenStore, REDIS_TOTAL_LISTEN_COUNT
+    TimescaleListenStore, REDIS_TOTAL_LISTEN_COUNT, MAX_FETCH_PASSES
 from listenbrainz.listenstore.timescale_utils import delete_listens_and_update_user_listen_data,\
     recalculate_all_user_data, add_missing_to_listen_users_metadata, update_user_listen_data
 from listenbrainz.webserver import create_app
@@ -175,6 +176,27 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(listens[1].ts_since_epoch, 1420000000)
         self.assertEqual(listens[2].ts_since_epoch, 1400000050)
         self.assertEqual(listens[3].ts_since_epoch, 1400000000)
+
+    def test_fetch_listens_soft_time_limit(self):
+        self._create_test_data(self.testuser_name, self.testuser_id,
+                               test_data_file_name='timescale_listenstore_test_listens_over_greater_time_range.json')
+
+        from_ts = datetime.fromtimestamp(1399999999, timezone.utc)
+        with mock.patch(
+            "listenbrainz.listenstore.timescale_listenstore.time.monotonic",
+            side_effect=[0, 2, 2, 2],
+        ):
+            listens, min_ts, max_ts, search_status = self.logstore.fetch_listens(
+                user=self.testuser,
+                from_ts=from_ts,
+                max_passes=MAX_FETCH_PASSES,
+                soft_time_limit_ms=1,
+                return_search_status=True,
+            )
+
+        self.assertEqual(len(listens), 2)
+        self.assertTrue(search_status["partial"])
+        self.assertIn("continue_min_ts", search_status)
 
     def test_fetch_listens_with_mapping(self):
         """ Test that the recording mbid submitted by the user is preferred over the mapping created by LB """

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -37,6 +37,7 @@ DEFAULT_FETCH_WINDOW = timedelta(days=30)  # 30 days
 
 # When expanding the search, how fast should the bounds be moved out
 WINDOW_SIZE_MULTIPLIER = 3
+MAX_FETCH_PASSES = 3  # maximum number of times to expand the search window when fetching listens
 
 LISTEN_COUNT_BUCKET_WIDTH = 2592000
 
@@ -201,7 +202,15 @@ class TimescaleListenStore:
 
         return inserted_rows
 
-    def fetch_listens(self, user: Dict, from_ts: datetime = None, to_ts: datetime = None, limit: int = DEFAULT_LISTENS_PER_FETCH):
+    def fetch_listens(
+        self,
+        user: Dict,
+        from_ts: datetime = None,
+        to_ts: datetime = None,
+        limit: int = DEFAULT_LISTENS_PER_FETCH,
+        max_passes: int = 1,
+        return_search_status: bool = False,
+    ):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
             the value they are converted to the local server's timezone. So to compare
             datetime object we need to create a object in the same timezone as the server.
@@ -213,7 +222,16 @@ class TimescaleListenStore:
                 listens will be returned in descending order
             to_ts: seconds since epoch, in float
             limit: the maximum number of items to return
+            max_passes: the maximum number of time windows to search
+            return_search_status: if True, return metadata describing a partial search
         """
+        if max_passes < 1:
+            raise ValueError("max_passes should be at least 1")
+        if max_passes > MAX_FETCH_PASSES:
+            raise ValueError("max_passes should be at most %d" % MAX_FETCH_PASSES)
+
+        search_status = {"partial": False}
+
         if from_ts and to_ts and from_ts >= to_ts:
             raise ValueError("from_ts should be less than to_ts")
         if from_ts:
@@ -224,6 +242,8 @@ class TimescaleListenStore:
         min_user_ts, max_user_ts = self.get_timestamps_for_user(user["id"])
 
         if min_user_ts == EPOCH and max_user_ts == EPOCH:
+            if return_search_status:
+                return [], min_user_ts, max_user_ts, search_status
             return [], min_user_ts, max_user_ts
 
         if to_ts is None and from_ts is None:
@@ -305,13 +325,9 @@ class TimescaleListenStore:
         t0 = time.monotonic()
 
         passes = 0
+        stopped_early = False
         while True:
             passes += 1
-
-            # Oh shit valve. I'm keeping it here for the time being. :)
-            if passes == 10:
-                done = True
-                break
 
             curs = ts_conn.execute(
                 sqlalchemy.text(query),
@@ -329,6 +345,11 @@ class TimescaleListenStore:
                         break
 
                     if to_ts > datetime.now(tz=timezone.utc) + MAX_FUTURE_SECONDS:
+                        done = True
+                        break
+
+                    if passes >= max_passes:
+                        stopped_early = True
                         done = True
                         break
 
@@ -374,8 +395,24 @@ class TimescaleListenStore:
         if order == ORDER_ASC:
             listens.reverse()
 
-        self.log.info("fetch listens %s %.2fs (%d passes)" % (user["musicbrainz_id"], fetch_listens_time, passes))
+        if stopped_early:
+            search_status["partial"] = True
+            if from_dynamic:
+                search_status["continue_max_ts"] = int(from_ts.timestamp())
+            elif to_dynamic:
+                search_status["continue_min_ts"] = int(to_ts.timestamp())
 
+        self.log.info(
+            "fetch listens %s %.2fs (%d passes%s)" % (
+                user["musicbrainz_id"],
+                fetch_listens_time,
+                passes,
+                ", partial" if search_status["partial"] else "",
+            )
+        )
+
+        if return_search_status:
+            return listens, min_user_ts, max_user_ts, search_status
         return listens, min_user_ts, max_user_ts
 
     def fetch_recent_listens_for_users(self, users, min_ts: datetime = None, max_ts: datetime = None, per_user_limit=2, limit=10):
@@ -657,7 +694,8 @@ class TimescaleListenStore:
 
     def fetch_listens_with_cache(
         self, user: dict, from_ts: datetime = None,
-        to_ts: datetime = None, limit: int = DEFAULT_LISTENS_PER_FETCH
+        to_ts: datetime = None, limit: int = DEFAULT_LISTENS_PER_FETCH,
+        max_passes: int = 1
     ):
         """ Fetch listens for a user, using a cache to avoid unnecessary queries. If a database query is necessary,
             the result is cached.
@@ -666,13 +704,21 @@ class TimescaleListenStore:
             "user_id": user["id"],
             "min_ts": int(from_ts.timestamp()) if from_ts else None,
             "max_ts": int(to_ts.timestamp()) if to_ts else None,
-            "count": limit
+            "count": limit,
+            "max_passes": max_passes,
         }
         cached_data = get_listens_from_cache(**key_parts)
         if cached_data is not None:
             return cached_data
 
-        listens, min_ts_per_user, max_ts_per_user = self.fetch_listens(user, from_ts, to_ts, limit)
+        listens, min_ts_per_user, max_ts_per_user, search_status = self.fetch_listens(
+            user,
+            from_ts,
+            to_ts,
+            limit,
+            max_passes=max_passes,
+            return_search_status=True,
+        )
         listen_data = []
         for listen in listens:
             listen_data.append(listen.to_api())
@@ -681,6 +727,7 @@ class TimescaleListenStore:
             "listens": listen_data,
             "latest_listen_ts": int(max_ts_per_user.timestamp()),
             "oldest_listen_ts": int(min_ts_per_user.timestamp()),
+            "search_status": search_status,
         }
 
         set_listens_in_cache(data, **key_parts)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -9,6 +9,7 @@ import psycopg2
 import psycopg2.sql
 import sqlalchemy
 from brainzutils import cache
+from flask import current_app, has_app_context
 from psycopg2.errors import UntranslatableCharacter
 from psycopg2.extras import execute_values
 from sqlalchemy import text
@@ -208,7 +209,8 @@ class TimescaleListenStore:
         from_ts: datetime = None,
         to_ts: datetime = None,
         limit: int = DEFAULT_LISTENS_PER_FETCH,
-        max_passes: int = 1,
+        max_passes: int = MAX_FETCH_PASSES,
+        soft_time_limit_ms: int = None,
         return_search_status: bool = False,
     ):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
@@ -223,12 +225,18 @@ class TimescaleListenStore:
             to_ts: seconds since epoch, in float
             limit: the maximum number of items to return
             max_passes: the maximum number of time windows to search
+            soft_time_limit_ms: elapsed time after which no more search windows will be attempted. None disables it.
             return_search_status: if True, return metadata describing a partial search
         """
+        max_passes = int(max_passes)
         if max_passes < 1:
             raise ValueError("max_passes should be at least 1")
         if max_passes > MAX_FETCH_PASSES:
             raise ValueError("max_passes should be at most %d" % MAX_FETCH_PASSES)
+        if soft_time_limit_ms is not None:
+            soft_time_limit_ms = int(soft_time_limit_ms)
+        if soft_time_limit_ms is not None and soft_time_limit_ms < 0:
+            raise ValueError("soft_time_limit_ms should be at least 0, or None to disable")
 
         search_status = {"partial": False}
 
@@ -348,7 +356,12 @@ class TimescaleListenStore:
                         done = True
                         break
 
-                    if passes >= max_passes:
+                    # If we've reached the maximum number of passes or the query is running long,
+                    # #stop searching and return what we have.
+                    elapsed_ms = (time.monotonic() - t0) * 1000
+                    if passes >= max_passes or (
+                        soft_time_limit_ms is not None and elapsed_ms >= soft_time_limit_ms
+                    ):
                         stopped_early = True
                         done = True
                         break
@@ -695,17 +708,26 @@ class TimescaleListenStore:
     def fetch_listens_with_cache(
         self, user: dict, from_ts: datetime = None,
         to_ts: datetime = None, limit: int = DEFAULT_LISTENS_PER_FETCH,
-        max_passes: int = 1
+        max_passes: int = None,
+        soft_time_limit_ms: int = None
     ):
         """ Fetch listens for a user, using a cache to avoid unnecessary queries. If a database query is necessary,
             the result is cached.
         """
+        max_passes = int(
+            max_passes if max_passes is not None else MAX_FETCH_PASSES
+        )
+        if soft_time_limit_ms is None and has_app_context():
+            soft_time_limit_ms = current_app.config.get("FETCH_LISTENS_SOFT_TIME_LIMIT_MS")
+        if soft_time_limit_ms is not None:
+            soft_time_limit_ms = int(soft_time_limit_ms)
         key_parts = {
             "user_id": user["id"],
             "min_ts": int(from_ts.timestamp()) if from_ts else None,
             "max_ts": int(to_ts.timestamp()) if to_ts else None,
             "count": limit,
             "max_passes": max_passes,
+            "soft_time_limit_ms": soft_time_limit_ms,
         }
         cached_data = get_listens_from_cache(**key_parts)
         if cached_data is not None:
@@ -717,6 +739,7 @@ class TimescaleListenStore:
             to_ts,
             limit,
             max_passes=max_passes,
+            soft_time_limit_ms=soft_time_limit_ms,
             return_search_status=True,
         )
         listen_data = []

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -9,9 +9,11 @@ from psycopg2.extras import execute_values
 import requests_mock
 from sqlalchemy import text
 
+from listenbrainz import config
 import listenbrainz.db.user as db_user
 import listenbrainz.db.user_relationship as db_user_relationship
 from data.model.external_service import ExternalServiceType
+from listenbrainz.listenstore.timescale_listenstore import MAX_FETCH_PASSES
 from listenbrainz.listenstore.timescale_utils import delete_listens
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.webserver import timescale_connection
@@ -1479,11 +1481,22 @@ class ListenAPICachingTestCase(ListenAPIIntegrationTestCase):
         self.mock_fetch_listens.assert_called_once()
 
         user_cache_key = f"user_listens_cache:{self.user['id']}"
-        listens_key = _get_listens_cache_key(self.user["id"], count=DEFAULT_ITEMS_PER_GET)
+        listens_key = _get_listens_cache_key(
+            self.user["id"],
+            count=DEFAULT_ITEMS_PER_GET,
+            max_passes=MAX_FETCH_PASSES,
+            soft_time_limit_ms=config.FETCH_LISTENS_SOFT_TIME_LIMIT_MS,
+        )
         self.assertEqual(cache.smembers(user_cache_key), {listens_key})
         self.assertEqual(
             json.loads(cache.get(listens_key)),
-            {"count": 0, "listens": [], "latest_listen_ts": 0, "oldest_listen_ts": 0}
+            {
+                "count": 0,
+                "listens": [],
+                "latest_listen_ts": 0,
+                "oldest_listen_ts": 0,
+                "search_status": {"partial": False},
+            }
         )
 
         self.mock_fetch_listens.reset_mock()
@@ -1553,7 +1566,12 @@ class ListenAPICachingTestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
 
         user_cache_key = f"user_listens_cache:{self.user['id']}"
-        listens_key = _get_listens_cache_key(self.user["id"], count=DEFAULT_ITEMS_PER_GET)
+        listens_key = _get_listens_cache_key(
+            self.user["id"],
+            count=DEFAULT_ITEMS_PER_GET,
+            max_passes=MAX_FETCH_PASSES,
+            soft_time_limit_ms=config.FETCH_LISTENS_SOFT_TIME_LIMIT_MS,
+        )
         self.assertEqual(cache.smembers(user_cache_key), {listens_key})
 
         listen = response.json['payload']['listens'][0]
@@ -1590,7 +1608,12 @@ class ListenAPICachingTestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
 
         user_cache_key = f"user_listens_cache:{self.user['id']}"
-        listens_key = _get_listens_cache_key(self.user["id"], count=DEFAULT_ITEMS_PER_GET)
+        listens_key = _get_listens_cache_key(
+            self.user["id"],
+            count=DEFAULT_ITEMS_PER_GET,
+            max_passes=MAX_FETCH_PASSES,
+            soft_time_limit_ms=config.FETCH_LISTENS_SOFT_TIME_LIMIT_MS,
+        )
         self.assertEqual(cache.smembers(user_cache_key), {listens_key})
 
         recording_mbid = str(uuid.uuid4())

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -1,3 +1,4 @@
+import csv
 import io
 import json
 import os.path
@@ -401,11 +402,22 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
 
     def test_import_spotify(self):
         self.insert_sample_spotify_data()
+        from_date = datetime(2015, 1, 1)
+        to_date = datetime(2024, 1, 1)
+        from_ts = from_date.replace(tzinfo=timezone.utc)
+        to_ts = to_date.replace(tzinfo=timezone.utc)
+        fixture_timestamps = []
+        for filename in ("spotify_streaming_2023.json", "spotify_streaming_endsong_0.json"):
+            with open(self.path_to_data_file(filename), "r") as f:
+                for item in json.load(f):
+                    listened_at = datetime.fromisoformat(item["ts"].replace("Z", "+00:00"))
+                    if from_ts <= listened_at < to_ts:
+                        fixture_timestamps.append(int(listened_at.timestamp()))
         data = {
             "service": "spotify",
             "file": self.create_spotify_zip(),
-            "from_date": datetime(2015, 1, 1).isoformat(),
-            "to_date": datetime(2024, 1, 1).isoformat(),
+            "from_date": from_date.isoformat(),
+            "to_date": to_date.isoformat(),
         }
         response = self.client.post(
             self.custom_url_for("import_listens_api_v1.create_import_task"),
@@ -418,7 +430,15 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
 
         url = self.custom_url_for("api_v1.get_listens", user_name=self.user["musicbrainz_id"])
         # Some tracks will be skipped,only expecting 6 tracks 
-        response = self.wait_for_query_to_have_items(url, num_items=6, attempts=20)
+        response = self.wait_for_query_to_have_items(
+            url,
+            num_items=6,
+            attempts=20,
+            query_string={
+                "min_ts": min(fixture_timestamps) - 1,
+                "max_ts": max(fixture_timestamps) + 1,
+            },
+        )
         listens = response.json["payload"]["listens"]
         self.assertEqual(len(listens), 6)
 
@@ -577,6 +597,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(metadata["success_count"], 3)
 
     def test_import_librefm_without_album_column(self):
+        expected_timestamps = [1762874400, 1609459200]
         data = {
             "service": "librefm",
             "file": open(self.path_to_data_file("librefm_no_album_column.csv"), "rb"),
@@ -591,12 +612,20 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         import_id = response.json["import_id"]
 
         url = self.custom_url_for("api_v1.get_listens", user_name=self.user["musicbrainz_id"])
-        response = self.wait_for_query_to_have_items(url, num_items=2, attempts=20)
+        response = self.wait_for_query_to_have_items(
+            url,
+            num_items=2,
+            attempts=20,
+            query_string={
+                "min_ts": min(expected_timestamps) - 1,
+                "max_ts": max(expected_timestamps) + 1,
+            },
+        )
         listens = response.json["payload"]["listens"]
         self.assertEqual(len(listens), 2)
 
         first_listen = listens[0]
-        self.assertEqual(first_listen["listened_at"], 1762874400)
+        self.assertEqual(first_listen["listened_at"], expected_timestamps[0])
         track_metadata = first_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "Rick Astley")
         self.assertEqual(track_metadata["track_name"], "Never Gonna Give You Up")
@@ -604,7 +633,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(track_metadata["additional_info"]["submission_client"], "ListenBrainz Archive Importer")
 
         second_listen = listens[1]
-        self.assertEqual(second_listen["listened_at"], 1609459200)
+        self.assertEqual(second_listen["listened_at"], expected_timestamps[1])
         track_metadata = second_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "Nina Simone")
         self.assertEqual(track_metadata["track_name"], "Feeling Good")
@@ -669,6 +698,8 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(metadata["success_count"], 2)
 
     def test_import_librefm_via_maloja(self):
+        with open(self.path_to_data_file("librefm_via_maloja.csv"), "r") as f:
+            fixture_timestamps = sorted((int(row["Time"]) for row in csv.DictReader(f)), reverse=True)
         data = {
             "service": "librefm",
             "file": open(self.path_to_data_file("librefm_via_maloja.csv"), "rb")
@@ -683,12 +714,20 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         import_id = response.json["import_id"]
 
         url = self.custom_url_for("api_v1.get_listens", user_name=self.user["musicbrainz_id"])
-        response = self.wait_for_query_to_have_items(url, num_items=3, attempts=20)
+        response = self.wait_for_query_to_have_items(
+            url,
+            num_items=3,
+            attempts=20,
+            query_string={
+                "min_ts": min(fixture_timestamps) - 1,
+                "max_ts": max(fixture_timestamps) + 1,
+            },
+        )
         listens = response.json["payload"]["listens"]
         self.assertEqual(len(listens), 3)
 
         first_listen = listens[0]
-        self.assertEqual(first_listen["listened_at"], 1760532855)
+        self.assertEqual(first_listen["listened_at"], fixture_timestamps[0])
         track_metadata = first_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "Vega Trails")
         self.assertEqual(track_metadata["track_name"], "Old Friend; The Sea")
@@ -697,7 +736,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(additional_info["submission_client"], "ListenBrainz Archive Importer")
 
         second_listen = listens[1]
-        self.assertEqual(second_listen["listened_at"], 1690348225)
+        self.assertEqual(second_listen["listened_at"], fixture_timestamps[1])
         track_metadata = second_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "Sweet Garden")
         self.assertEqual(track_metadata["track_name"], "Altered State")
@@ -706,7 +745,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(additional_info["submission_client"], "ListenBrainz Archive Importer")
 
         third_listen = listens[2]
-        self.assertEqual(third_listen["listened_at"], 1690347960)
+        self.assertEqual(third_listen["listened_at"], fixture_timestamps[2])
         track_metadata = third_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "The Horrors")
         self.assertEqual(track_metadata["track_name"], "New Ice Age")
@@ -753,6 +792,11 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual("Unable to locate Libre.fm header row in import file.", metadata["progress"])
 
     def test_import_librefm_with_comments(self):
+        with open(self.path_to_data_file("librefm_with_comments.csv"), "r") as f:
+            fixture_timestamps = sorted(
+                (int(row["time"]) for row in csv.DictReader(row for row in f if not row.startswith("#"))),
+                reverse=True,
+            )
         data = {
             "service": "librefm",
             "file": open(self.path_to_data_file("librefm_with_comments.csv"), "rb")
@@ -767,12 +811,20 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         import_id = response.json["import_id"]
 
         url = self.custom_url_for("api_v1.get_listens", user_name=self.user["musicbrainz_id"])
-        response = self.wait_for_query_to_have_items(url, num_items=3, attempts=20)
+        response = self.wait_for_query_to_have_items(
+            url,
+            num_items=3,
+            attempts=20,
+            query_string={
+                "min_ts": min(fixture_timestamps) - 1,
+                "max_ts": max(fixture_timestamps) + 1,
+            },
+        )
         listens = response.json["payload"]["listens"]
         self.assertEqual(len(listens), 3)
 
         first_listen = listens[0]
-        self.assertEqual(first_listen["listened_at"], 1760532855)
+        self.assertEqual(first_listen["listened_at"], fixture_timestamps[0])
         track_metadata = first_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "Vega Trails")
         self.assertEqual(track_metadata["track_name"], "Old Friend; The Sea")
@@ -781,7 +833,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(additional_info["submission_client"], "ListenBrainz Archive Importer")
 
         second_listen = listens[1]
-        self.assertEqual(second_listen["listened_at"], 1690348225)
+        self.assertEqual(second_listen["listened_at"], fixture_timestamps[1])
         track_metadata = second_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "Sweet Garden")
         self.assertEqual(track_metadata["track_name"], "Altered State")
@@ -790,7 +842,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(additional_info["submission_client"], "ListenBrainz Archive Importer")
 
         third_listen = listens[2]
-        self.assertEqual(third_listen["listened_at"], 1690347960)
+        self.assertEqual(third_listen["listened_at"], fixture_timestamps[2])
         track_metadata = third_listen["track_metadata"]
         self.assertEqual(track_metadata["artist_name"], "The Horrors")
         self.assertEqual(track_metadata["track_name"], "New Ice Age")

--- a/listenbrainz/tests/integration/test_timescale_writer.py
+++ b/listenbrainz/tests/integration/test_timescale_writer.py
@@ -18,6 +18,7 @@ from listenbrainz.webserver import redis_connection, timescale_connection
 
 
 class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
+    FIXTURE_TO_TS = datetime.fromtimestamp(1486466947, timezone.utc)
 
     def setUp(self):
         super(TimescaleWriterTestCase, self).setUp()
@@ -46,8 +47,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
 
-        to_ts = datetime.now(timezone.utc)
-        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=self.FIXTURE_TO_TS)
         self.assertEqual(len(listens), 1)
 
         recent = self.rs.get_recent_listens(4)
@@ -79,8 +79,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         self.assert200(r)
         r = self.send_listen(user, 'valid_single.json')
         self.assert200(r)
-        to_ts = datetime.now(timezone.utc)
-        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=self.FIXTURE_TO_TS)
         self.assertEqual(len(listens), 1)
 
     def test_dedup_same_batch(self):
@@ -89,8 +88,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'same_batch_duplicates.json')
         self.assert200(r)
 
-        to_ts = datetime.now(timezone.utc)
-        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=self.FIXTURE_TO_TS)
         self.assertEqual(len(listens), 1)
 
     def test_dedup_different_users(self):
@@ -107,11 +105,10 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user2, 'valid_single.json')
         self.assert200(r)
 
-        to_ts = datetime.now(timezone.utc)
-        listens, _, _ = self.ls.fetch_listens(user1, to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user1, to_ts=self.FIXTURE_TO_TS)
         self.assertEqual(len(listens), 1)
 
-        listens, _, _ = self.ls.fetch_listens(user2, to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user2, to_ts=self.FIXTURE_TO_TS)
         self.assertEqual(len(listens), 1)
 
     def test_dedup_same_timestamp_different_tracks(self):
@@ -134,8 +131,7 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
         r = self.send_listen(user, 'same_timestamp_diff_track_valid_single_3.json')
         self.assert200(r)
 
-        to_ts = datetime.now(timezone.utc)
-        listens, _, _ = self.ls.fetch_listens(user, to_ts=to_ts)
+        listens, _, _ = self.ls.fetch_listens(user, to_ts=self.FIXTURE_TO_TS)
         self.assertEqual(len(listens), 4)
 
     def test_rejection_queue_on_error(self):
@@ -191,5 +187,5 @@ class TimescaleWriterTestCase(NonAPIIntegrationTestCase):
             # test timescale writer is still working and processing listens
             r = self.send_listen(user, "valid_single.json")
             self.assert200(r)
-            listens, _, _ = self.ls.fetch_listens(user, to_ts=datetime.now(timezone.utc))
+            listens, _, _ = self.ls.fetch_listens(user, to_ts=self.FIXTURE_TO_TS)
             self.assertEqual(len(listens), 1)

--- a/listenbrainz/webserver/listens_cache.py
+++ b/listenbrainz/webserver/listens_cache.py
@@ -10,7 +10,8 @@ def _get_listens_cache_key(
     min_ts: Optional[int] = None,
     max_ts: Optional[int] = None,
     count: Optional[int] = None,
-    max_passes: Optional[int] = None
+    max_passes: Optional[int] = None,
+    soft_time_limit_ms: Optional[int] = None
 ) -> str:
     """Generate a cache key for the get_listens endpoint.
     
@@ -32,6 +33,8 @@ def _get_listens_cache_key(
         key_parts.append(f"count_{count}")
     if max_passes is not None:
         key_parts.append(f"passes_{max_passes}")
+    if soft_time_limit_ms is not None:
+        key_parts.append(f"soft_ms_{soft_time_limit_ms}")
     return ":".join(key_parts)
 
 
@@ -40,7 +43,8 @@ def get_listens_from_cache(
     min_ts: Optional[float] = None,
     max_ts: Optional[float] = None,
     count: Optional[int] = None,
-    max_passes: Optional[int] = None
+    max_passes: Optional[int] = None,
+    soft_time_limit_ms: Optional[int] = None
 ) -> Optional[dict[str, Any]]:
     """Get listens from cache if available.
     
@@ -53,7 +57,7 @@ def get_listens_from_cache(
     Returns:
         Cached data if found, None otherwise
     """
-    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count, max_passes)
+    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count, max_passes, soft_time_limit_ms)
     cached = cache.get(cache_key)
     if cached:
         return json.loads(cached)
@@ -67,6 +71,7 @@ def set_listens_in_cache(
     max_ts: Optional[float] = None, 
     count: Optional[int] = None,
     max_passes: Optional[int] = None,
+    soft_time_limit_ms: Optional[int] = None,
     expire_time: int = 3600
 ) -> None:
     """Store listens data in cache.
@@ -79,7 +84,7 @@ def set_listens_in_cache(
         count: Optional number of items
         expire_time: Time in seconds until the cache expires.
     """
-    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count, max_passes)
+    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count, max_passes, soft_time_limit_ms)
     cache.sadd(f"user_listens_cache:{user_id}", cache_key, expire_time * 2)
     cache.set(cache_key, json.dumps(data), expire_time)
 

--- a/listenbrainz/webserver/listens_cache.py
+++ b/listenbrainz/webserver/listens_cache.py
@@ -9,7 +9,8 @@ def _get_listens_cache_key(
     user_id: int,
     min_ts: Optional[int] = None,
     max_ts: Optional[int] = None,
-    count: Optional[int] = None
+    count: Optional[int] = None,
+    max_passes: Optional[int] = None
 ) -> str:
     """Generate a cache key for the get_listens endpoint.
     
@@ -29,6 +30,8 @@ def _get_listens_cache_key(
         key_parts.append(f"max_{max_ts}")
     if count is not None:
         key_parts.append(f"count_{count}")
+    if max_passes is not None:
+        key_parts.append(f"passes_{max_passes}")
     return ":".join(key_parts)
 
 
@@ -36,7 +39,8 @@ def get_listens_from_cache(
     user_id: int,
     min_ts: Optional[float] = None,
     max_ts: Optional[float] = None,
-    count: Optional[int] = None
+    count: Optional[int] = None,
+    max_passes: Optional[int] = None
 ) -> Optional[dict[str, Any]]:
     """Get listens from cache if available.
     
@@ -49,7 +53,7 @@ def get_listens_from_cache(
     Returns:
         Cached data if found, None otherwise
     """
-    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count)
+    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count, max_passes)
     cached = cache.get(cache_key)
     if cached:
         return json.loads(cached)
@@ -62,6 +66,7 @@ def set_listens_in_cache(
     min_ts: Optional[float] = None,
     max_ts: Optional[float] = None, 
     count: Optional[int] = None,
+    max_passes: Optional[int] = None,
     expire_time: int = 3600
 ) -> None:
     """Store listens data in cache.
@@ -74,7 +79,7 @@ def set_listens_in_cache(
         count: Optional number of items
         expire_time: Time in seconds until the cache expires.
     """
-    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count)
+    cache_key = _get_listens_cache_key(user_id, min_ts, max_ts, count, max_passes)
     cache.sadd(f"user_listens_cache:{user_id}", cache_key, expire_time * 2)
     cache.set(cache_key, json.dumps(data), expire_time)
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -178,9 +178,20 @@ def get_listens(user_name):
 
     :param max_ts: If you specify a ``max_ts`` timestamp, listens with listened_at less than (but not including) this value will be returned.
     :param min_ts: If you specify a ``min_ts`` timestamp, listens with listened_at greater than (but not including) this value will be returned.
-    :param count: Optional, number of listens to return. Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET` . Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
-    :returns search_status: Indicates whether the search ended before all matching time windows were scanned and
-        includes a continuation timestamp when another request can continue the search.
+    :param count: Optional, number of listens to return. This does not guarantee all requested listens will be returned. Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET` . Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
+    :returns search_status: Indicates whether the database search ended before all requested listens were returned.
+        This object has the following shape:
+
+        .. code-block:: text
+
+            {
+                "partial": <boolean>,
+                "continue_max_ts": <unix timestamp, optional>,
+                "continue_min_ts": <unix timestamp, optional>
+            }
+
+        ``partial`` is always present. ``continue_max_ts`` and ``continue_min_ts`` are optional
+        continuation timestamps included only when partial is true. At most one continuation timestamp is returned.
     :statuscode 200: Yay, you have data!
     :statuscode 404: The requested user was not found.
     :resheader Content-Type: *application/json*

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -179,6 +179,8 @@ def get_listens(user_name):
     :param max_ts: If you specify a ``max_ts`` timestamp, listens with listened_at less than (but not including) this value will be returned.
     :param min_ts: If you specify a ``min_ts`` timestamp, listens with listened_at greater than (but not including) this value will be returned.
     :param count: Optional, number of listens to return. Default: :data:`~webserver.views.api.DEFAULT_ITEMS_PER_GET` . Max: :data:`~webserver.views.api.MAX_ITEMS_PER_GET`
+    :returns search_status: Indicates whether the search ended before all matching time windows were scanned and
+        includes a continuation timestamp when another request can continue the search.
     :statuscode 200: Yay, you have data!
     :statuscode 404: The requested user was not found.
     :resheader Content-Type: *application/json*

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -178,7 +178,7 @@ class UserViewsTestCase(IntegrationTestCase):
         timescale.return_value = ([], EPOCH, EPOCH, {"partial": False})
 
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'))
-        req_call = mock.call(user, None, None, 25, max_passes=1, return_search_status=True)
+        req_call = mock.call(user, None, None, 25, max_passes=3, soft_time_limit_ms=None, return_search_status=True)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
@@ -190,7 +190,8 @@ class UserViewsTestCase(IntegrationTestCase):
             None,
             datetime.fromtimestamp(1520946000, timezone.utc),
             25,
-            max_passes=1,
+            max_passes=3,
+            soft_time_limit_ms=None,
             return_search_status=True,
         )
         timescale.assert_has_calls([req_call])
@@ -204,7 +205,8 @@ class UserViewsTestCase(IntegrationTestCase):
             datetime.fromtimestamp(1520941000, timezone.utc),
             None,
             25,
-            max_passes=1,
+            max_passes=3,
+            soft_time_limit_ms=None,
             return_search_status=True,
         )
         timescale.assert_has_calls([req_call])
@@ -220,7 +222,8 @@ class UserViewsTestCase(IntegrationTestCase):
             None,
             datetime.fromtimestamp(1520946000, timezone.utc),
             25,
-            max_passes=1,
+            max_passes=3,
+            soft_time_limit_ms=None,
             return_search_status=True,
         )
         timescale.assert_has_calls([req_call])

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -175,24 +175,38 @@ class UserViewsTestCase(IntegrationTestCase):
     def test_ts_filters(self, timescale):
         """Check that max_ts and min_ts are passed to timescale """
         user = self.user.to_dict()
-        timescale.return_value = ([], EPOCH, EPOCH)
+        timescale.return_value = ([], EPOCH, EPOCH, {"partial": False})
 
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'))
-        req_call = mock.call(user, None, None, 25)
+        req_call = mock.call(user, None, None, 25, max_passes=1, return_search_status=True)
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # max_ts query param -> to_ts timescale param
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'max_ts': 1520946000})
-        req_call = mock.call(user, None, datetime.fromtimestamp(1520946000, timezone.utc), 25)
+        req_call = mock.call(
+            user,
+            None,
+            datetime.fromtimestamp(1520946000, timezone.utc),
+            25,
+            max_passes=1,
+            return_search_status=True,
+        )
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
         # min_ts query param -> from_ts timescale param
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000})
-        req_call = mock.call(user, datetime.fromtimestamp(1520941000, timezone.utc), None, 25)
+        req_call = mock.call(
+            user,
+            datetime.fromtimestamp(1520941000, timezone.utc),
+            None,
+            25,
+            max_passes=1,
+            return_search_status=True,
+        )
         timescale.assert_has_calls([req_call])
         timescale.reset_mock()
 
@@ -201,8 +215,34 @@ class UserViewsTestCase(IntegrationTestCase):
         # If max_ts and min_ts set, only max_ts is used
         self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'),
                         query_string={'min_ts': 1520941000, 'max_ts': 1520946000})
-        req_call = mock.call(user, None, datetime.fromtimestamp(1520946000, timezone.utc), 25)
+        req_call = mock.call(
+            user,
+            None,
+            datetime.fromtimestamp(1520946000, timezone.utc),
+            25,
+            max_passes=1,
+            return_search_status=True,
+        )
         timescale.assert_has_calls([req_call])
+
+    @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')
+    def test_partial_listen_search_status(self, timescale):
+        """Check that partial listen search metadata is exposed to the frontend."""
+        cache._r.flushdb()
+        timescale.return_value = (
+            [],
+            EPOCH,
+            EPOCH,
+            {"partial": True, "continue_max_ts": 1520941000},
+        )
+
+        response = self.client.post(self.custom_url_for('user.profile', user_name='iliekcomputers'))
+        self.assert200(response)
+        parsed_response = orjson.loads(response.data)
+        self.assertDictEqual(parsed_response["searchStatus"], {
+            "partial": True,
+            "continueMaxTs": 1520941000,
+        })
 
     @mock.patch('listenbrainz.webserver.timescale_connection._ts.fetch_listens')
     def test_ts_filters_errors(self, timescale):

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -80,6 +80,15 @@ def profile(user_name):
     if pin:
         pin = fetch_track_metadata_for_items(webserver.ts_conn, [pin])[0].to_api()
 
+    search_status = data.get("search_status", {"partial": False})
+    search_status_payload = {
+        "partial": search_status.get("partial", False),
+    }
+    if "continue_max_ts" in search_status:
+        search_status_payload["continueMaxTs"] = search_status["continue_max_ts"]
+    if "continue_min_ts" in search_status:
+        search_status_payload["continueMinTs"] = search_status["continue_min_ts"]
+
     data = {
         "user": {
             "id": user.id,
@@ -93,6 +102,7 @@ def profile(user_name):
         "playingNow": playing_now,
         "logged_in_user_follows_user": logged_in_user_follows_user(user),
         "already_reported_user": already_reported_user,
+        "searchStatus": search_status_payload,
     }
 
     return jsonify(data)


### PR DESCRIPTION

# Problem
We have had this issue for a very long time. Because of the way we partition timescale listens table by time buckets (per-month), if there is a large gap between a user's listens, the query can take a lot of time (I've seen >690 seconds for API calls!) and causes a timeout on the user side or a completely blank dashboard page while the query runs.
With our current setup the query will run, expanding the scope (adding 3 months each pass) until it has the requested number of listens or it reaches 10 passes (as a safety valve).
See LB-1584

# Solution

Instead of blindly continuing until reaching the requested number of listens, stop early if a certain time threshold is reached, or 3 passes (= 9 months). *We can tweak the max passes, it could be higher I think*
This requires some changes in the API response and in the user dashboard UI.
We now return some additional information in the API response in this format:
```json
"searchStatus": {
  "continueMaxTs": 1780420144,
  "partial": true
},
```
Where `partial: true` indicates we returned early and that the count will be less than requested, and `continueMaxTs`/`continueMinTs` (depending on original search params) gives the user a timestamp from where to continue requesting data.
This is because instead of the usual method of using the first/last listen's timestamp, these partial requests can sometimes return 0 results (say if you did not listen to any listen in over 9 months). The continuation timestamp represents the boundary of the last fetch window (so in drastic cases, requested timestamp minus 9 months).

Not certain about the phrasing of "searchStatus" since this isn't really search? Suggestions welcome.

### Limit query time
The new FETCH_LISTENS_SOFT_TIME_LIMIT_MS config variable is set to None by default (for local dev) but can be tweaked in production to limit maximum query times.
If by the end of the current pass the elapsed time is greater than that value, the query will stop there and return early.

The combination of the max passes and time limit allow for multiple passes to happen (if they are fast enough), while not going over a time budget.

### UI changes
Added some text and a button for easier navigation, when the page is not showing the usual 25 listens:
<img width="1113" height="546" alt="image" src="https://github.com/user-attachments/assets/18fb79cb-f5d6-4c5c-8dc2-9d223860f45e" />

And on the last page:
<img width="947" height="421" alt="image" src="https://github.com/user-attachments/assets/3f8c3b89-5d36-4d48-b110-e936352c1d98" />


* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Used Codex for most of the backend changes and tests (commits df36fe6ac and e4b0e6268), based on an implementation plan I wrote from scratch because I didn't trust codex to generate code if I didn't fully understand the issue and solution.

# Action

Returning fewer than the requested number of listens is an API breaking change. We will need to announce it, perhaps even wait before merging and deploying it.
We could potentially enable this mechanism using query params in such a way that regular API calls are not affected, and only the calls from our front-end are limited (`@user_bp.post("/<mb_username:user_name>/")`). But that kind of defeats the purpose...

Thoroughly test this on test, then beta, before merging.
Only tested in local dev so far.
