### PR TITLE
LB-2012: Update Booming Music app link

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -385,7 +385,7 @@ export default function AddData() {
         </li>
         <li>
           <em>
-            <a href="https://boomingmusic.vercel.app/">Booming Music</a>
+            <a href="https://boomingmusic.org/">Booming Music</a>
           </em>
           , a clean and fast, and Material You music player for Android
         </li>


### PR DESCRIPTION
# Problem

The **Booming Music** Android music player link on the "Submitting data" page (https://listenbrainz.org/add-data/) currently points to a temporary Vercel deployment URL (`https://boomingmusic.vercel.app/`). This link will break soon when the website is migrated to a new host.

JIRA Ticket: [LB-2012](https://tickets.metabrainz.org/browse/LB-2012)

# Solution

We update the domain URL from `https://boomingmusic.vercel.app/` to the new official domain `https://boomingmusic.org/`.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

*Details:* An AI assistant was used to locate the URL reference in `AddData.tsx` and draft the PR description following repository guidelines.
