### PR TITLE
LB-2011: Add Dopamine to the client list

### DIFF
--- a/frontend/js/src/about/add-data/AddData.tsx
+++ b/frontend/js/src/about/add-data/AddData.tsx
@@ -60,6 +60,12 @@ export default function AddData() {
         </li>
         <li>
           <em>
+            <a href="https://github.com/digimezzo/dopamine">Dopamine</a>
+          </em>
+          , an audio player which tries to make organizing and listening to music as simple and pretty as possible
+        </li>
+        <li>
+          <em>
             <a href="https://www.foobar2000.org/">Foobar2000</a>
           </em>
           , full-fledged music player for Windows:{" "}


### PR DESCRIPTION
# Problem

The Dopamine music player is currently missing from the list of supported client players on the "Submitting data" page (https://listenbrainz.org/add-data/), despite having native support for ListenBrainz scrobbling since version 3.0.7.

JIRA Ticket: [LB-2011](https://tickets.metabrainz.org/browse/LB-2011)

# Solution

Adding Dopamine to the "Music players" list in alphabetical order in `frontend/js/src/about/add-data/AddData.tsx`.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

*Details:* An AI assistant was used to research Dopamine's scrobbling support, locate the file in the repository, and draft the PR description.
