### PR TITLE
Fix test database connection string

### DIFF
--- a/mbid_mapping/docker/consul_config.py.ctmpl
+++ b/mbid_mapping/docker/consul_config.py.ctmpl
@@ -49,9 +49,9 @@ TIMESCALE_ADMIN_LB_URI=""
 
 {{if service "timescale-listenbrainz"}}
 {{with index (service "timescale-listenbrainz") 0}}
-SQLALCHEMY_TIMESCALE_URI = """postgresql://listenbrainz_ts:{{template "KEY" "timescale_lb_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
+SQLALCHEMY_TIMESCALE_URI = """postgresql://{{template "KEY" "timescale_lb_user"}}:{{template "KEY" "timescale_lb_password"}}@{{.Address}}:{{.Port}}/{{template "KEY" "timescale_db_name"}}"""
 TIMESCALE_ADMIN_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/postgres"""
-TIMESCALE_ADMIN_LB_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/listenbrainz_ts"""
+TIMESCALE_ADMIN_LB_URI = """postgresql://postgres:{{template "KEY" "timescale_admin_password"}}@{{.Address}}:{{.Port}}/{{template "KEY" "timescale_db_name"}}"""
 {{end}}
 {{else}}
 SQLALCHEMY_TIMESCALE_URI = "SERVICEDOESNOTEXIST_timescale-listenbrainz"


### PR DESCRIPTION
timescale writer for the test environment is currently failing to insert listens with a connection error, trying (and failing) to connect as user listenbrainz_ts. Looks like some parts of the connection string in consul template were not changed accordingly.
```log
psycopg2.OperationalError connection to server at "10.10.10.31", port 13046 failed:
FATAL:  password authentication failed for user "listenbrainz_ts"
```

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I did not use any AI