### PR TITLE
Replace react-tooltip with Overlay elements from react-bootstrap

### DIFF
--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -417,19 +417,16 @@ $youtube-expanded-width: 1280px;
     top: -$progress-bar-hover-height;
   }
 
-  .progress-tooltip {
-    background: $primary-color;
-    margin-top: -4px;
-    border-radius: 24px;
-    font-size: 1.2rem;
-    padding: 6px 12px;
-    &::before {
-      display: none;
-    }
-  }
   & > ::after {
     border-color: transparent;
   }
+}
+
+.progress-tooltip .tooltip-inner {
+  background: $primary-color;
+  border-radius: 24px;
+  font-size: 1.2rem;
+  padding: 6px 12px;
 }
 
 .volume {

--- a/frontend/css/sass/brainzplayer.scss
+++ b/frontend/css/sass/brainzplayer.scss
@@ -422,11 +422,14 @@ $youtube-expanded-width: 1280px;
   }
 }
 
-.progress-tooltip .tooltip-inner {
-  background: $primary-color;
-  border-radius: 24px;
-  font-size: 1.2rem;
-  padding: 6px 12px;
+.progress-tooltip {
+  --bs-tooltip-bg: $primary-color;
+  .tooltip-inner {
+    background: $primary-color;
+    border-radius: 24px;
+    font-size: 1.2rem;
+    padding: 6px 12px;
+  }
 }
 
 .volume {

--- a/frontend/css/sass/variables.scss
+++ b/frontend/css/sass/variables.scss
@@ -55,7 +55,7 @@ $font-size-base: 1.4rem;
 
 $body-secondary-bg: $gray-light;
 $body-tertiary-bg: #fafafa;
-$body-emphasis-color: $body-color;
+$body-emphasis-color: darken($body-color, 15%);
 
 $success-text-emphasis: #3c763d;
 $success-bg-subtle: #dff0d8;
@@ -162,3 +162,5 @@ $badge-font-size: 1.2rem;
 $grid-gutter-width: 3rem;
 $base-border-radius: 6px;
 $navbar-toggler-border-radius: $base-border-radius;
+
+$tooltip-max-width: 400px;

--- a/frontend/css/sass/variables.scss
+++ b/frontend/css/sass/variables.scss
@@ -55,7 +55,7 @@ $font-size-base: 1.4rem;
 
 $body-secondary-bg: $gray-light;
 $body-tertiary-bg: #fafafa;
-$body-emphasis-color: darken($body-color, 15%);
+$body-emphasis-color: color.adjust($body-color, $lightness: -15%);
 
 $success-text-emphasis: #3c763d;
 $success-bg-subtle: #dff0d8;

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -2,20 +2,33 @@ import { faCheck, faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
 import { Link } from "react-router";
-import ReactTooltip from "react-tooltip";
 import { COLOR_LB_GREEN } from "../../utils/constants";
 import Blob from "../../home/Blob";
 import GlobalAppContext from "../../utils/GlobalAppContext";
+import Tooltip from "../../components/Tooltip";
 
 export default function Donate() {
   const { currentUser } = React.useContext(GlobalAppContext);
   const flairQuestionMarkIcon = (
-    <FontAwesomeIcon
-      icon={faQuestionCircle}
-      data-tip
-      data-for="flair-tooltip"
-      size="sm"
-    />
+    <Tooltip
+      id="flair-tooltip"
+      placement="bottom"
+      tooltip={
+        <>
+          Every $5 donation unlocks flairs for 1 month,
+          <br />
+          with larger donations extending the duration.
+          <br />
+          Donations stack up, adding more months
+          <br />
+          of unlocked flairs with each contribution.
+        </>
+      }
+    >
+      <span>
+        <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+      </span>
+    </Tooltip>
   );
   return (
     <div id="donations-page">
@@ -45,15 +58,6 @@ export default function Donate() {
               </b>
             </div>
           </div>
-          <ReactTooltip id="flair-tooltip" place="bottom" multiline>
-            Every $5 donation unlocks flairs for 1 month,
-            <br />
-            with larger donations extending the duration.
-            <br />
-            Donations stack up, adding more months
-            <br />
-            of unlocked flairs with each contribution.
-          </ReactTooltip>
           <div className="tier card">
             <div className="tier-heading">
               <h2>

--- a/frontend/js/src/about/donations/Donate.tsx
+++ b/frontend/js/src/about/donations/Donate.tsx
@@ -15,13 +15,11 @@ export default function Donate() {
       placement="bottom"
       tooltip={
         <>
-          Every $5 donation unlocks flairs for 1 month,
+          Every $5 donation unlocks flairs for 1 month, with larger donations
+          extending the duration.
           <br />
-          with larger donations extending the duration.
-          <br />
-          Donations stack up, adding more months
-          <br />
-          of unlocked flairs with each contribution.
+          Donations stack up, adding more months of unlocked flairs with each
+          contribution.
         </>
       }
     >

--- a/frontend/js/src/cb-review/CBReviewModal.tsx
+++ b/frontend/js/src/cb-review/CBReviewModal.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
 
-import ReactTooltip from "react-tooltip";
 import { toast } from "react-toastify";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import NiceModal, { useModal, bootstrapDialog } from "@ebay/nice-modal-react";
-import { Modal } from "react-bootstrap";
+import { Modal, OverlayTrigger, Popover } from "react-bootstrap";
 import { Link, useNavigate } from "react-router";
 import GlobalAppContext from "../utils/GlobalAppContext";
 
@@ -346,36 +344,44 @@ export default NiceModal.create((props: CBReviewModalProps) => {
       APIService,
       listen,
       modal,
+      onReviewSubmitted,
       refreshCritiquebrainzToken,
       handleError,
     ]
   );
   const CBInfoButton = React.useMemo(() => {
     return (
-      <span>
-        <span
+      <OverlayTrigger
+        placement="bottom"
+        trigger={["click", "focus"]}
+        rootClose
+        overlay={
+          <Popover id="critiquebrainz-info-popover">
+            <Popover.Body>
+              CritiqueBrainz is a{" "}
+              <a href={`${MBBaseUrl}/projects`}>MetaBrainz project</a> aimed at
+              providing an open platform for music critics and hosting Creative
+              Commons licensed music reviews.
+              <br />
+              <br />
+              Your reviews will be independently visible on CritiqueBrainz and
+              appear publicly on your CritiqueBrainz profile. To view or delete
+              your reviews, visit your <a href={CBBaseUrl}>
+                CritiqueBrainz
+              </a>{" "}
+              profile.
+            </Popover.Body>
+          </Popover>
+        }
+      >
+        <button
           className="CBInfoButton"
-          data-tip={`CritiqueBrainz is a <a href='${MBBaseUrl}/projects'>
-          MetaBrainz project</a> aimed at providing an open platform </br>for music critics
-          and hosting Creative Commons licensed music reviews. </br></br>
-          Your reviews will be independently visible on CritiqueBrainz and appear publicly</br>
-          on your CritiqueBrainz profile. To view or delete your reviews, visit your
-          <a href='${CBBaseUrl}'>CritiqueBrainz</a>  profile.`}
-          data-event="click focus"
+          type="button"
+          style={{ background: "none", border: 0, padding: 0 }}
         >
-          <FontAwesomeIcon
-            icon={faInfoCircle as IconProp}
-            style={{ color: "black" }}
-          />
-        </span>
-        <ReactTooltip
-          place="bottom"
-          globalEventOff="click"
-          clickable
-          html
-          type="light"
-        />
-      </span>
+          <FontAwesomeIcon icon={faInfoCircle} style={{ color: "black" }} />
+        </button>
+      </OverlayTrigger>
     );
   }, []);
 

--- a/frontend/js/src/cb-review/CBReviewModal.tsx
+++ b/frontend/js/src/cb-review/CBReviewModal.tsx
@@ -378,6 +378,7 @@ export default NiceModal.create((props: CBReviewModalProps) => {
           className="CBInfoButton"
           type="button"
           style={{ background: "none", border: 0, padding: 0 }}
+          aria-label="About CritiqueBrainz"
         >
           <FontAwesomeIcon icon={faInfoCircle} style={{ color: "black" }} />
         </button>

--- a/frontend/js/src/common/brainzplayer/ProgressBar.tsx
+++ b/frontend/js/src/common/brainzplayer/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import { throttle } from "lodash";
 import * as React from "react";
-import ReactTooltip from "react-tooltip";
+import { Overlay, Tooltip } from "react-bootstrap";
+import type { OverlayInjectedProps } from "react-bootstrap/Overlay";
 import { useAtomValue } from "jotai";
 import { millisecondsToStr } from "../../playlists/utils";
 import { durationMsAtom, progressMsAtom } from "./BrainzPlayerAtoms";
@@ -16,12 +17,15 @@ const KEYBOARD_BIG_STEP_MS: number = 10000;
 
 const EVENT_KEY_ARROWLEFT: string = "ArrowLeft";
 const EVENT_KEY_ARROWRIGHT: string = "ArrowRight";
-const EVENT_TYPE_CLICK: string = "click";
-const EVENT_TYPE_MOUSEMOVE: string = "mousemove";
 const MOUSE_THROTTLE_DELAY: number = 300;
 
 const TOOLTIP_INITIAL_CONTENT: string = "0:00";
-const TOOLTIP_TOP_OFFSET: number = 39;
+
+type ProgressTooltipProps = {
+  overlayProps: OverlayInjectedProps;
+  tipContent: string;
+  tooltipXPosition: number;
+};
 
 // Originally by ford04 - https://stackoverflow.com/a/62017005
 const useThrottle = (callback: any, delay: number | undefined) => {
@@ -36,44 +40,81 @@ const useThrottle = (callback: any, delay: number | undefined) => {
   );
 };
 
+function ProgressTooltip({
+  overlayProps,
+  tipContent,
+  tooltipXPosition,
+}: ProgressTooltipProps) {
+  React.useEffect(() => {
+    overlayProps.popper?.scheduleUpdate?.();
+  }, [overlayProps.popper, tooltipXPosition]);
+
+  return (
+    <Tooltip
+      id="progress-tooltip"
+      {...overlayProps}
+      className={`progress-tooltip ${overlayProps.className ?? ""}`.trim()}
+    >
+      {tipContent}
+    </Tooltip>
+  );
+}
+
 function ProgressBar(props: ProgressBarProps) {
   const progressMs = useAtomValue(progressMsAtom);
   const durationMs = useAtomValue(durationMsAtom);
 
   const { seekToPositionMs, showNumbers } = props;
   const [tipContent, setTipContent] = React.useState(TOOLTIP_INITIAL_CONTENT);
+  const [showTooltip, setShowTooltip] = React.useState(false);
+  const [tooltipXPosition, setTooltipXPosition] = React.useState(0);
   const progressBarRef = React.useRef<HTMLDivElement>(null);
+  const tooltipTargetRef = React.useRef<HTMLSpanElement>(null);
   const progressPercentage = Number(
     ((progressMs * 100) / durationMs).toFixed()
   );
+  const throttledSetTipContent = useThrottle((positionTime: string): void => {
+    setTipContent(positionTime);
+  }, MOUSE_THROTTLE_DELAY);
 
-  const mouseEventHandler = useThrottle(
-    (event: React.MouseEvent<HTMLInputElement>): void => {
-      const progressBarBoundingRect = event.currentTarget.getBoundingClientRect();
-      const progressBarWidth = progressBarBoundingRect.width;
-      const musicPlayerXOffset = progressBarBoundingRect.x;
-      const absoluteClickXPos = event.clientX;
-      const relativeClickXPos = absoluteClickXPos - musicPlayerXOffset;
-      const percentPos = relativeClickXPos / progressBarWidth;
-      const positionMs = Math.round(durationMs * percentPos);
-      const positionTime = millisecondsToStr(positionMs);
+  const getPositionFromMouseEvent = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    const progressBarBoundingRect = event.currentTarget.getBoundingClientRect();
+    const progressBarWidth = progressBarBoundingRect.width;
+    const musicPlayerXOffset = progressBarBoundingRect.x;
+    const absoluteClickXPos = event.clientX;
+    const relativeClickXPos = absoluteClickXPos - musicPlayerXOffset;
+    const percentPos = relativeClickXPos / progressBarWidth;
+    const positionMs = Math.round(durationMs * percentPos);
 
-      const isMobile = /Mobi/.test(navigator.userAgent);
+    return {
+      positionMs,
+      positionTime: millisecondsToStr(positionMs),
+      tooltipXPosition: absoluteClickXPos,
+    };
+  };
 
-      if (isMobile) {
-        setTipContent(positionTime);
-        seekToPositionMs(positionMs);
-        return;
-      }
+  const onMouseMoveHandler = (
+    event: React.MouseEvent<HTMLDivElement>
+  ): void => {
+    if (/Mobi/.test(navigator.userAgent)) {
+      setShowTooltip(false);
+      return;
+    }
 
-      if (event.type === EVENT_TYPE_MOUSEMOVE) {
-        setTipContent(positionTime);
-      } else if (event.type === EVENT_TYPE_CLICK) {
-        seekToPositionMs(positionMs);
-      }
-    },
-    MOUSE_THROTTLE_DELAY
-  );
+    const mousePosition = getPositionFromMouseEvent(event);
+    throttledSetTipContent(mousePosition.positionTime);
+    setTooltipXPosition(mousePosition.tooltipXPosition);
+    setShowTooltip(true);
+  };
+
+  const onClickHandler = (event: React.MouseEvent<HTMLDivElement>): void => {
+    const mousePosition = getPositionFromMouseEvent(event);
+    setTipContent(mousePosition.positionTime);
+    setShowTooltip(false);
+    seekToPositionMs(mousePosition.positionMs);
+  };
 
   const onKeyPressHandler = (
     event: React.KeyboardEvent<HTMLInputElement>
@@ -117,8 +158,9 @@ function ProgressBar(props: ProgressBarProps) {
     <div className="progress-bar-wrapper">
       <div
         className="progress"
-        onClick={mouseEventHandler}
-        onMouseMove={mouseEventHandler}
+        onClick={onClickHandler}
+        onMouseMove={onMouseMoveHandler}
+        onMouseLeave={() => setShowTooltip(false)}
         onKeyDown={onKeyPressHandler}
         aria-label="Audio progress control"
         role="progressbar"
@@ -126,24 +168,34 @@ function ProgressBar(props: ProgressBarProps) {
         aria-valuemax={100}
         aria-valuenow={progressPercentage || 0}
         tabIndex={0}
-        data-tip={tipContent}
         ref={progressBarRef}
       >
         <div className="progress-bar bg-info" style={progressBarStyle} />
-        <ReactTooltip
-          className="progress-tooltip"
-          arrowColor="inherit"
-          getContent={() => tipContent}
-          globalEventOff="click"
-          overridePosition={({ left, top }) => {
-            const progressBarBoundingRect = progressBarRef.current?.getBoundingClientRect();
-            if (progressBarBoundingRect) {
-              // eslint-disable-next-line no-param-reassign
-              top = progressBarBoundingRect.top - TOOLTIP_TOP_OFFSET;
-            }
-            return { left, top };
+        <span
+          ref={tooltipTargetRef}
+          style={{
+            position: "fixed",
+            left: tooltipXPosition,
+            top: progressBarRef.current?.getBoundingClientRect().top,
+            width: 1,
+            height: 1,
+            pointerEvents: "none",
           }}
         />
+        <Overlay
+          target={tooltipTargetRef.current}
+          show={showTooltip}
+          placement="top"
+          transition={false}
+        >
+          {(overlayProps) => (
+            <ProgressTooltip
+              overlayProps={overlayProps}
+              tipContent={tipContent}
+              tooltipXPosition={tooltipXPosition}
+            />
+          )}
+        </Overlay>
       </div>
       {showNumbers && (
         <div className="progress-numbers">

--- a/frontend/js/src/common/listens/MBIDMappingModal.tsx
+++ b/frontend/js/src/common/listens/MBIDMappingModal.tsx
@@ -9,7 +9,6 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
 import { toast } from "react-toastify";
-import Tooltip from "react-tooltip";
 import { Link } from "react-router";
 import { merge } from "lodash";
 import ListenCard from "./ListenCard";

--- a/frontend/js/src/components/SyndicationFeedModal.tsx
+++ b/frontend/js/src/components/SyndicationFeedModal.tsx
@@ -7,7 +7,7 @@ import {
   faCircleQuestion,
   faRssSquare,
 } from "@fortawesome/free-solid-svg-icons";
-import Tooltip from "react-tooltip";
+import Tooltip from "./Tooltip";
 
 type BaseOptionProps = {
   label: string;
@@ -106,11 +106,15 @@ export default NiceModal.create((props: SyndicationFeedModalProps) => {
               {option.tooltip && (
                 <>
                   &nbsp;
-                  <FontAwesomeIcon
-                    icon={faCircleQuestion}
-                    data-tip={option.tooltip}
-                  />
-                  <Tooltip place="right" type="dark" effect="solid" />
+                  <Tooltip
+                    id={`${option.key}-tooltip`}
+                    placement="right"
+                    tooltip={option.tooltip}
+                  >
+                    <span>
+                      <FontAwesomeIcon icon={faCircleQuestion} />
+                    </span>
+                  </Tooltip>
                 </>
               )}
             </label>

--- a/frontend/js/src/components/Tooltip.tsx
+++ b/frontend/js/src/components/Tooltip.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { OverlayTrigger, Tooltip as BootstrapTooltip } from "react-bootstrap";
+
+type TooltipProps = {
+  children: React.ReactElement;
+  id: string;
+  placement?: "top" | "right" | "bottom" | "left";
+  tooltip: React.ReactNode;
+};
+
+export default function Tooltip({
+  children,
+  id,
+  placement = "top",
+  tooltip,
+}: TooltipProps) {
+  return (
+    <OverlayTrigger
+      placement={placement}
+      trigger={["hover", "focus"]}
+      overlay={<BootstrapTooltip id={id}>{tooltip}</BootstrapTooltip>}
+    >
+      {children}
+    </OverlayTrigger>
+  );
+}

--- a/frontend/js/src/components/Tooltip.tsx
+++ b/frontend/js/src/components/Tooltip.tsx
@@ -1,23 +1,32 @@
 import * as React from "react";
 import { OverlayTrigger, Tooltip as BootstrapTooltip } from "react-bootstrap";
+import type {
+  OverlayDelay,
+  OverlayTriggerType,
+} from "react-bootstrap/OverlayTrigger";
 
 type TooltipProps = {
   children: React.ReactElement;
+  delay?: OverlayDelay;
   id: string;
   placement?: "top" | "right" | "bottom" | "left";
   tooltip: React.ReactNode;
+  trigger?: OverlayTriggerType | OverlayTriggerType[];
 };
 
 export default function Tooltip({
   children,
+  delay,
   id,
   placement = "top",
   tooltip,
+  trigger = ["hover", "focus"],
 }: TooltipProps) {
   return (
     <OverlayTrigger
+      delay={delay}
       placement={placement}
-      trigger={["hover", "focus"]}
+      trigger={trigger}
       overlay={<BootstrapTooltip id={id}>{tooltip}</BootstrapTooltip>}
     >
       {children}

--- a/frontend/js/src/components/Tooltip.tsx
+++ b/frontend/js/src/components/Tooltip.tsx
@@ -9,7 +9,7 @@ type TooltipProps = {
   children: React.ReactElement;
   delay?: OverlayDelay;
   id: string;
-  placement?: "top" | "right" | "bottom" | "left";
+  placement?: "top" | "right" | "bottom" | "left" | "auto";
   tooltip: React.ReactNode;
   trigger?: OverlayTriggerType | OverlayTriggerType[];
 };
@@ -18,7 +18,7 @@ export default function Tooltip({
   children,
   delay,
   id,
-  placement = "top",
+  placement = "auto",
   tooltip,
   trigger = ["hover", "focus"],
 }: TooltipProps) {

--- a/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
+++ b/frontend/js/src/settings/brainzplayer/BrainzPlayerSettings.tsx
@@ -10,16 +10,14 @@ import { Helmet } from "react-helmet";
 import { Link } from "react-router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { toast } from "react-toastify";
-import ReactTooltip from "react-tooltip";
 import { ReactSortable } from "react-sortablejs";
 import { faGripLines } from "@fortawesome/free-solid-svg-icons";
-import { IconDefinition, IconProp } from "@fortawesome/fontawesome-svg-core";
 import Switch from "../../components/Switch";
+import Tooltip from "../../components/Tooltip";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import SpotifyPlayer from "../../common/brainzplayer/SpotifyPlayer";
 import SoundcloudPlayer from "../../common/brainzplayer/SoundcloudPlayer";
 import FunkwhalePlayer from "../../common/brainzplayer/FunkwhalePlayer";
-import { ToastMsg } from "../../notifications/Notifications";
 import AppleMusicPlayer from "../../common/brainzplayer/AppleMusicPlayer";
 import Card from "../../components/Card";
 import faInternetArchive from "../../common/icons/faInternetArchive";
@@ -77,6 +75,10 @@ export const defaultDataSourcesPriority = [
   "youtube",
   "internetArchive",
 ] as DataSourceKey[];
+
+const getLoginFirstTooltipTrigger = (
+  disableTooltip: boolean
+): ("hover" | "focus")[] => (disableTooltip ? [] : ["hover", "focus"]);
 
 function BrainzPlayerSettings() {
   const {
@@ -180,6 +182,12 @@ function BrainzPlayerSettings() {
     },
     [triggerAutoSave]
   );
+  const loginFirstTooltip = (
+    <>
+      You must login to this service in the &quot;Connect services&quot; section
+      before using it.
+    </>
+  );
 
   return (
     <>
@@ -223,252 +231,271 @@ function BrainzPlayerSettings() {
           YouTube is enabled by default. For a better listening experience we
           recommend enabling another service.
         </p>
-        <div
-          className="mb-4"
-          data-tip
-          data-tip-disable={
+        <Tooltip
+          id="login-first"
+          delay={{ show: 0, hide: 500 }}
+          trigger={getLoginFirstTooltipTrigger(
             spotifyEnabled || SpotifyPlayer.hasPermissions(spotifyAuth)
-          }
-          data-for="login-first"
+          )}
+          tooltip={loginFirstTooltip}
         >
-          <Switch
-            id="enable-spotify"
-            disabled={
-              !spotifyEnabled && !SpotifyPlayer.hasPermissions(spotifyAuth)
-            }
-            value="spotify"
-            checked={spotifyEnabled}
-            onChange={() =>
-              updateSettings((prev) => ({
-                ...prev,
-                spotifyEnabled: !prev.spotifyEnabled,
-              }))
-            }
-            switchLabel={
-              <span
-                className={`text-brand ${!spotifyEnabled ? "text-muted" : ""}`}
-              >
-                <span>
-                  <FontAwesomeIcon
-                    icon={faSpotify}
-                    color={spotifyEnabled ? dataSourcesInfo.spotify.color : ""}
-                  />
+          <div className="mb-4">
+            <Switch
+              id="enable-spotify"
+              disabled={
+                !spotifyEnabled && !SpotifyPlayer.hasPermissions(spotifyAuth)
+              }
+              value="spotify"
+              checked={spotifyEnabled}
+              onChange={() =>
+                updateSettings((prev) => ({
+                  ...prev,
+                  spotifyEnabled: !prev.spotifyEnabled,
+                }))
+              }
+              switchLabel={
+                <span
+                  className={`text-brand ${
+                    !spotifyEnabled ? "text-muted" : ""
+                  }`}
+                >
+                  <span>
+                    <FontAwesomeIcon
+                      icon={faSpotify}
+                      color={
+                        spotifyEnabled ? dataSourcesInfo.spotify.color : ""
+                      }
+                    />
+                  </span>
+                  <span>&nbsp;Spotify</span>
                 </span>
-                <span>&nbsp;Spotify</span>
-              </span>
-            }
-          />
-          <br />
-          <small>
-            Spotify requires a premium account.
+              }
+            />
             <br />
-            Sign in on the{" "}
-            <Link to="/settings/music-services/details/">
-              &quot;connect services&quot; page
-            </Link>
-            .
-          </small>
-        </div>
-        <div
-          className="mb-4"
-          data-tip
-          data-tip-disable={
+            <small>
+              Spotify requires a premium account.
+              <br />
+              Sign in on the{" "}
+              <Link to="/settings/music-services/details/">
+                &quot;connect services&quot; page
+              </Link>
+              .
+            </small>
+          </div>
+        </Tooltip>
+        <Tooltip
+          id="login-first"
+          delay={{ show: 0, hide: 500 }}
+          trigger={getLoginFirstTooltipTrigger(
             appleMusicEnabled || AppleMusicPlayer.hasPermissions(appleAuth)
-          }
-          data-for="login-first"
+          )}
+          tooltip={loginFirstTooltip}
         >
-          <Switch
-            id="enable-apple-music"
-            value="apple-music"
-            disabled={
-              !appleMusicEnabled && !AppleMusicPlayer.hasPermissions(appleAuth)
-            }
-            checked={appleMusicEnabled}
-            onChange={() =>
-              updateSettings((prev) => ({
-                ...prev,
-                appleMusicEnabled: !prev.appleMusicEnabled,
-              }))
-            }
-            switchLabel={
-              <span
-                className={`text-brand ${
-                  !appleMusicEnabled ? "text-muted" : ""
-                }`}
-              >
-                <span>
-                  <FontAwesomeIcon
-                    icon={faApple}
-                    color={
-                      appleMusicEnabled ? dataSourcesInfo.appleMusic.color : ""
-                    }
-                  />
+          <div className="mb-4">
+            <Switch
+              id="enable-apple-music"
+              value="apple-music"
+              disabled={
+                !appleMusicEnabled &&
+                !AppleMusicPlayer.hasPermissions(appleAuth)
+              }
+              checked={appleMusicEnabled}
+              onChange={() =>
+                updateSettings((prev) => ({
+                  ...prev,
+                  appleMusicEnabled: !prev.appleMusicEnabled,
+                }))
+              }
+              switchLabel={
+                <span
+                  className={`text-brand ${
+                    !appleMusicEnabled ? "text-muted" : ""
+                  }`}
+                >
+                  <span>
+                    <FontAwesomeIcon
+                      icon={faApple}
+                      color={
+                        appleMusicEnabled
+                          ? dataSourcesInfo.appleMusic.color
+                          : ""
+                      }
+                    />
+                  </span>
+                  <span>&nbsp;Apple Music</span>
                 </span>
-                <span>&nbsp;Apple Music</span>
-              </span>
-            }
-          />
-          <br />
-          <small>
-            Apple Music requires a premium account.
+              }
+            />
             <br />
-            Sign in on the{" "}
-            <Link to="/settings/music-services/details/">
-              &quot;connect services&quot; page
-            </Link>
-            . You will need to sign in every 6 months, as the authorization
-            expires.
-          </small>
-        </div>
-        <div
-          className="mb-4"
-          data-tip
-          data-tip-disable={
+            <small>
+              Apple Music requires a premium account.
+              <br />
+              Sign in on the{" "}
+              <Link to="/settings/music-services/details/">
+                &quot;connect services&quot; page
+              </Link>
+              . You will need to sign in every 6 months, as the authorization
+              expires.
+            </small>
+          </div>
+        </Tooltip>
+        <Tooltip
+          id="login-first"
+          delay={{ show: 0, hide: 500 }}
+          trigger={getLoginFirstTooltipTrigger(
             soundcloudEnabled || SoundcloudPlayer.hasPermissions(soundcloudAuth)
-          }
-          data-for="login-first"
+          )}
+          tooltip={loginFirstTooltip}
         >
-          <Switch
-            id="enable-soundcloud"
-            value="soundcloud"
-            disabled={
-              !soundcloudEnabled &&
-              !SoundcloudPlayer.hasPermissions(soundcloudAuth)
-            }
-            checked={soundcloudEnabled}
-            onChange={() =>
-              updateSettings((prev) => ({
-                ...prev,
-                soundcloudEnabled: !prev.soundcloudEnabled,
-              }))
-            }
-            switchLabel={
-              <span
-                className={`text-brand ${
-                  !soundcloudEnabled ? "text-muted" : ""
-                }`}
-              >
-                <span className={soundcloudEnabled ? "text-success" : ""}>
-                  <FontAwesomeIcon
-                    icon={faSoundcloud}
-                    color={
-                      soundcloudEnabled ? dataSourcesInfo.soundcloud.color : ""
-                    }
-                  />
+          <div className="mb-4">
+            <Switch
+              id="enable-soundcloud"
+              value="soundcloud"
+              disabled={
+                !soundcloudEnabled &&
+                !SoundcloudPlayer.hasPermissions(soundcloudAuth)
+              }
+              checked={soundcloudEnabled}
+              onChange={() =>
+                updateSettings((prev) => ({
+                  ...prev,
+                  soundcloudEnabled: !prev.soundcloudEnabled,
+                }))
+              }
+              switchLabel={
+                <span
+                  className={`text-brand ${
+                    !soundcloudEnabled ? "text-muted" : ""
+                  }`}
+                >
+                  <span className={soundcloudEnabled ? "text-success" : ""}>
+                    <FontAwesomeIcon
+                      icon={faSoundcloud}
+                      color={
+                        soundcloudEnabled
+                          ? dataSourcesInfo.soundcloud.color
+                          : ""
+                      }
+                    />
+                  </span>
+                  <span>&nbsp;SoundCloud</span>
                 </span>
-                <span>&nbsp;SoundCloud</span>
-              </span>
-            }
-          />
-          <br />
-          <small>
-            SoundCloud requires a free account.
+              }
+            />
             <br />
-            Sign in on the{" "}
-            <Link to="/settings/music-services/details/">
-              &quot;connect services&quot; page
-            </Link>
-          </small>
-        </div>
-        <div
-          className="mb-4"
-          data-tip
-          data-tip-disable={
+            <small>
+              SoundCloud requires a free account.
+              <br />
+              Sign in on the{" "}
+              <Link to="/settings/music-services/details/">
+                &quot;connect services&quot; page
+              </Link>
+            </small>
+          </div>
+        </Tooltip>
+        <Tooltip
+          id="login-first"
+          delay={{ show: 0, hide: 500 }}
+          trigger={getLoginFirstTooltipTrigger(
             funkwhaleEnabled || FunkwhalePlayer.hasPermissions(funkwhaleAuth)
-          }
-          data-for="login-first"
+          )}
+          tooltip={loginFirstTooltip}
         >
-          <Switch
-            id="enable-funkwhale"
-            value="funkwhale"
-            disabled={
-              !funkwhaleEnabled &&
-              !FunkwhalePlayer.hasPermissions(funkwhaleAuth)
-            }
-            checked={funkwhaleEnabled}
-            onChange={() =>
-              updateSettings((prev) => ({
-                ...prev,
-                funkwhaleEnabled: !prev.funkwhaleEnabled,
-              }))
-            }
-            switchLabel={
-              <span
-                className={`text-brand ${
-                  !funkwhaleEnabled ? "text-muted" : ""
-                }`}
-              >
-                <span>
-                  <FontAwesomeIcon
-                    icon={faFunkwhale as IconProp}
-                    color={
-                      funkwhaleEnabled ? dataSourcesInfo.funkwhale.color : ""
-                    }
-                  />
+          <div className="mb-4">
+            <Switch
+              id="enable-funkwhale"
+              value="funkwhale"
+              disabled={
+                !funkwhaleEnabled &&
+                !FunkwhalePlayer.hasPermissions(funkwhaleAuth)
+              }
+              checked={funkwhaleEnabled}
+              onChange={() =>
+                updateSettings((prev) => ({
+                  ...prev,
+                  funkwhaleEnabled: !prev.funkwhaleEnabled,
+                }))
+              }
+              switchLabel={
+                <span
+                  className={`text-brand ${
+                    !funkwhaleEnabled ? "text-muted" : ""
+                  }`}
+                >
+                  <span>
+                    <FontAwesomeIcon
+                      icon={faFunkwhale}
+                      color={
+                        funkwhaleEnabled ? dataSourcesInfo.funkwhale.color : ""
+                      }
+                    />
+                  </span>
+                  <span>&nbsp;Funkwhale</span>
                 </span>
-                <span>&nbsp;Funkwhale</span>
-              </span>
-            }
-          />
-          <br />
-          <small>
-            Funkwhale is a federated audio platform. You will need to connect a
-            Funkwhale instance.
+              }
+            />
             <br />
-            Sign in on the{" "}
-            <Link to="/settings/music-services/details/">
-              &quot;connect services&quot; page
-            </Link>
-          </small>
-        </div>
-        <div
-          className="mb-4"
-          data-tip
-          data-tip-disable={
+            <small>
+              Funkwhale is a federated audio platform. You will need to connect
+              a Funkwhale instance.
+              <br />
+              Sign in on the{" "}
+              <Link to="/settings/music-services/details/">
+                &quot;connect services&quot; page
+              </Link>
+            </small>
+          </div>
+        </Tooltip>
+        <Tooltip
+          id="login-first"
+          delay={{ show: 0, hide: 500 }}
+          trigger={getLoginFirstTooltipTrigger(
             navidromeEnabled || Boolean(navidromeAuth?.instance_url)
-          }
-          data-for="login-first"
+          )}
+          tooltip={loginFirstTooltip}
         >
-          <Switch
-            id="enable-navidrome"
-            value="navidrome"
-            disabled={!navidromeEnabled && !navidromeAuth?.instance_url}
-            checked={navidromeEnabled}
-            onChange={() =>
-              updateSettings((prev) => ({
-                ...prev,
-                navidromeEnabled: !prev.navidromeEnabled,
-              }))
-            }
-            switchLabel={
-              <span
-                className={`text-brand ${
-                  !navidromeEnabled ? "text-muted" : ""
-                }`}
-              >
-                <span>
-                  <FontAwesomeIcon
-                    icon={faNavidrome as IconProp}
-                    color={
-                      navidromeEnabled ? dataSourcesInfo.navidrome.color : ""
-                    }
-                  />
+          <div className="mb-4">
+            <Switch
+              id="enable-navidrome"
+              value="navidrome"
+              disabled={!navidromeEnabled && !navidromeAuth?.instance_url}
+              checked={navidromeEnabled}
+              onChange={() =>
+                updateSettings((prev) => ({
+                  ...prev,
+                  navidromeEnabled: !prev.navidromeEnabled,
+                }))
+              }
+              switchLabel={
+                <span
+                  className={`text-brand ${
+                    !navidromeEnabled ? "text-muted" : ""
+                  }`}
+                >
+                  <span>
+                    <FontAwesomeIcon
+                      icon={faNavidrome}
+                      color={
+                        navidromeEnabled ? dataSourcesInfo.navidrome.color : ""
+                      }
+                    />
+                  </span>
+                  <span>&nbsp;Navidrome</span>
                 </span>
-                <span>&nbsp;Navidrome</span>
-              </span>
-            }
-          />
-          <br />
-          <small>
-            Navidrome is a self-hosted music streaming server. You will need to
-            connect a Navidrome instance.
+              }
+            />
             <br />
-            Sign in on the{" "}
-            <Link to="/settings/music-services/details/">
-              &quot;connect services&quot; page
-            </Link>
-          </small>
-        </div>
+            <small>
+              Navidrome is a self-hosted music streaming server. You will need
+              to connect a Navidrome instance.
+              <br />
+              Sign in on the{" "}
+              <Link to="/settings/music-services/details/">
+                &quot;connect services&quot; page
+              </Link>
+            </small>
+          </div>
+        </Tooltip>
         <div className="mb-4">
           <Switch
             id="enable-youtube"
@@ -585,7 +612,7 @@ function BrainzPlayerSettings() {
             >
               <div className="main-content text-brand">
                 <span className="drag-handle text-muted">
-                  <FontAwesomeIcon icon={faGripLines as IconProp} />
+                  <FontAwesomeIcon icon={faGripLines} />
                 </span>
                 <span>
                   <FontAwesomeIcon
@@ -599,10 +626,6 @@ function BrainzPlayerSettings() {
           ))}
         </ReactSortable>
       </details>
-      <ReactTooltip id="login-first" aria-haspopup="true" delayHide={500}>
-        You must login to this service in the &quot;Connect services&quot;
-        section before using it.
-      </ReactTooltip>
     </>
   );
 }

--- a/frontend/js/src/settings/flairs/FlairsSettings.tsx
+++ b/frontend/js/src/settings/flairs/FlairsSettings.tsx
@@ -9,7 +9,6 @@ import {
   faArrowRight,
   faQuestionCircle,
 } from "@fortawesome/free-solid-svg-icons";
-import ReactTooltip from "react-tooltip";
 import GlobalAppContext from "../../utils/GlobalAppContext";
 import { FlairEnum, Flair } from "../../utils/constants";
 import type { FlairName } from "../../utils/constants";
@@ -17,6 +16,7 @@ import Username from "../../common/Username";
 import queryClient from "../../utils/QueryClient";
 import useUserFlairs from "../../utils/FlairLoader";
 import useAutoSave from "../../hooks/useAutoSave";
+import Tooltip from "../../components/Tooltip";
 
 function CustomOption(
   props: OptionProps<{ value: Flair; label: FlairName; username: string }>
@@ -100,29 +100,30 @@ export default function FlairsSettings() {
     delay: 3000,
     onSave: submitFlairPreferences,
   });
+  const flairTooltip = (
+    <>
+      Every $5 donation unlocks flairs for 1 month,
+      <br />
+      with larger donations extending the duration.
+      <br />
+      Donations stack up, adding more months
+      <br />
+      of unlocked flairs with each contribution.
+    </>
+  );
 
   return (
     <div className="mb-4 donation-flairs-settings">
       <div className="mb-4">
-        <ReactTooltip id="flair-tooltip" place="bottom" multiline>
-          Every $5 donation unlocks flairs for 1 month,
-          <br />
-          with larger donations extending the duration.
-          <br />
-          Donations stack up, adding more months
-          <br />
-          of unlocked flairs with each contribution.
-        </ReactTooltip>
         <h3>Flair Settings</h3>
         <p>
           Unlock for a month or more by <Link to="/donate/">donating</Link>
           &nbsp;
-          <FontAwesomeIcon
-            icon={faQuestionCircle}
-            data-tip
-            data-for="flair-tooltip"
-            size="sm"
-          />
+          <Tooltip id="flair-tooltip" placement="bottom" tooltip={flairTooltip}>
+            <span>
+              <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+            </span>
+          </Tooltip>
           .<br />
           Some flairs are only visible on hover.
         </p>
@@ -135,12 +136,15 @@ export default function FlairsSettings() {
           <div className="alert alert-warning">
             Flairs are currently locked; you can choose a flair below but it
             will not be shown on the website until your next donation.{" "}
-            <FontAwesomeIcon
-              icon={faQuestionCircle}
-              data-tip
-              data-for="flair-tooltip"
-              size="sm"
-            />
+            <Tooltip
+              id="flair-tooltip"
+              placement="bottom"
+              tooltip={flairTooltip}
+            >
+              <span>
+                <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+              </span>
+            </Tooltip>
           </div>
         )}
         <p className="border-start bg-light border-info border-3 px-3 py-2 mb-3 fs-4">

--- a/frontend/js/src/settings/flairs/FlairsSettings.tsx
+++ b/frontend/js/src/settings/flairs/FlairsSettings.tsx
@@ -102,13 +102,11 @@ export default function FlairsSettings() {
   });
   const flairTooltip = (
     <>
-      Every $5 donation unlocks flairs for 1 month,
+      Every $5 donation unlocks flairs for 1 month, with larger donations
+      extending the duration.
       <br />
-      with larger donations extending the duration.
-      <br />
-      Donations stack up, adding more months
-      <br />
-      of unlocked flairs with each contribution.
+      Donations stack up, adding more months of unlocked flairs with each
+      contribution.
     </>
   );
 

--- a/frontend/js/src/settings/link-listens/LinkListens.tsx
+++ b/frontend/js/src/settings/link-listens/LinkListens.tsx
@@ -17,9 +17,9 @@ import NiceModal from "@ebay/nice-modal-react";
 import { groupBy, isNil, isNull, isString, pick, size, sortBy } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useQuery } from "@tanstack/react-query";
-import ReactTooltip from "react-tooltip";
 import Fuse from "fuse.js";
 import Loader from "../../components/Loader";
+import Tooltip from "../../components/Tooltip";
 import ListenCard from "../../common/listens/ListenCard";
 import ListenControl from "../../common/listens/ListenControl";
 import MBIDMappingModal from "../../common/listens/MBIDMappingModal";
@@ -321,27 +321,28 @@ export default function LinkListensPage() {
         <title>Link with MusicBrainz</title>
       </Helmet>
       <h2 className="page-title">Link with MusicBrainz</h2>
-      <ReactTooltip id="matching-tooltip" multiline>
-        We automatically match listens with MusicBrainz recordings when
-        possible,
-        <br />
-        which provides rich data like tags, album, artists, cover art, and more.
-        <br />
-        When a track can&apos;t be auto-matched you can manually link them on
-        this page.
-        <br />
-        Recordings may not exist in MusicBrainz, and need to be added there
-        first.
-      </ReactTooltip>
       <p>
         Your top 1,000 listens (grouped by album) that have&nbsp;
-        <u
-          className="link-listens-tooltip"
-          data-tip
-          data-for="matching-tooltip"
+        <Tooltip
+          id="matching-tooltip"
+          tooltip={
+            <>
+              We automatically match listens with MusicBrainz recordings when
+              possible,
+              <br />
+              which provides rich data like tags, album, artists, cover art, and
+              more.
+              <br />
+              When a track can&apos;t be auto-matched you can manually link them
+              on this page.
+              <br />
+              Recordings may not exist in MusicBrainz, and need to be added
+              there first.
+            </>
+          }
         >
-          not been automatically linked
-        </u>
+          <u className="link-listens-tooltip">not been automatically linked</u>
+        </Tooltip>
         &nbsp;to a MusicBrainz recording.
       </p>
       <p className="small">

--- a/frontend/js/src/settings/link-listens/MultiTrackMBIDMappingModal.tsx
+++ b/frontend/js/src/settings/link-listens/MultiTrackMBIDMappingModal.tsx
@@ -9,10 +9,10 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
 import { toast } from "react-toastify";
-import Tooltip from "react-tooltip";
 import Fuse from "fuse.js";
 import { omit, size, uniq } from "lodash";
 import { isValid } from "date-fns";
+import Tooltip from "../../components/Tooltip";
 import ListenCard from "../../common/listens/ListenCard";
 import { ToastMsg } from "../../notifications/Notifications";
 import GlobalAppContext from "../../utils/GlobalAppContext";
@@ -317,15 +317,6 @@ export default NiceModal.create(
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <Tooltip id="musicbrainz-helptext" type="info" multiline>
-            Search for an album matching the listens above.
-            <br />
-            Alternatively, you can search for a release or release-group using
-            the MusicBrainz search (musicbrainz.org/search).
-            <br />
-            When you have found the one that matches your listens, copy its URL
-            (link) into the search box above.
-          </Tooltip>
           <div>
             <p className="small form-text text-start">
               Search by album/artist name or paste a{" "}
@@ -333,12 +324,24 @@ export default NiceModal.create(
                 MusicBrainz URL or MBID
               </a>
               .
-              <FontAwesomeIcon
-                icon={faQuestionCircle}
-                data-tip
-                data-for="musicbrainz-helptext"
-                size="sm"
-              />
+              <Tooltip
+                id="musicbrainz-helptext"
+                tooltip={
+                  <>
+                    Search for an album matching the listens above.
+                    <br />
+                    Alternatively, you can search for a release or release-group
+                    using the MusicBrainz search (musicbrainz.org/search).
+                    <br />
+                    When you have found the one that matches your listens, copy
+                    its URL (link) into the search box above.
+                  </>
+                }
+              >
+                <span>
+                  <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+                </span>
+              </Tooltip>
             </p>
             <div className="card listen-card">
               <SearchAlbumOrMBID
@@ -362,19 +365,22 @@ export default NiceModal.create(
                 className="form-check-label"
               >
                 Include artist name when searching{" "}
-                <FontAwesomeIcon
-                  icon={faQuestionCircle}
-                  data-tip
-                  data-for="includeArtistNameHelp"
-                  size="sm"
-                />{" "}
+                <Tooltip
+                  id="includeArtistNameHelp"
+                  tooltip={
+                    <>
+                      Depending on the data we have available, including the
+                      artist name can result in worse matching. Tick this
+                      checkbox if you have a poor matching rate.
+                    </>
+                  }
+                >
+                  <span>
+                    <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+                  </span>
+                </Tooltip>{" "}
               </label>
             </div>
-            <Tooltip id="includeArtistNameHelp" type="info" multiline>
-              Depending on the data we have available, including the artist name
-              can result in worse matching. Tick this checkbox if you have a
-              poor matching rate.
-            </Tooltip>
             <div className="form-check">
               <input
                 className="form-check-input"
@@ -390,28 +396,32 @@ export default NiceModal.create(
                 style={{ fontWeight: "initial" }}
               >
                 Preserve special characters{" "}
-                <FontAwesomeIcon
-                  icon={faQuestionCircle}
-                  data-tip
-                  data-for="escapeSpecialCharactersHepl"
-                  size="sm"
-                />{" "}
+                <Tooltip
+                  id="escapeSpecialCharactersHepl"
+                  tooltip={
+                    <>
+                      Escape special characters such as{" "}
+                      <span className="code-block strong">
+                        ( ) [ ] ! * ~ ^ &quot; ~ ? \ / || &&
+                      </span>
+                      &nbsp;to preserve them in the search term.
+                      <br />
+                      Otherwise those characters may be ignored.
+                      <br />
+                      For example, to search for an album by the band
+                      &quot;!!!&quot;,
+                      <br />
+                      you will need to escape the characters like so:{" "}
+                      <pre>artist:(\!\!\!)</pre>
+                    </>
+                  }
+                >
+                  <span>
+                    <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+                  </span>
+                </Tooltip>{" "}
               </label>
             </div>
-            <Tooltip id="escapeSpecialCharactersHepl" type="info">
-              Escape special characters such as{" "}
-              <span className="code-block strong">
-                ( ) [ ] ! * ~ ^ &quot; ~ ? \ / || &&
-              </span>
-              &nbsp;to preserve them in the search term.
-              <br />
-              Otherwise those characters may be ignored.
-              <br />
-              For example, to search for an album by the band &quot;!!!&quot;,
-              <br />
-              you will need to escape the characters like so:{" "}
-              <pre>artist:(\!\!\!)</pre>
-            </Tooltip>
           </div>
           <hr />
           {selectedAlbum && (
@@ -529,18 +539,21 @@ export default NiceModal.create(
               style={{ fontWeight: "initial" }}
             >
               Include artist name when matching{" "}
-              <FontAwesomeIcon
-                icon={faQuestionCircle}
-                data-tip
-                data-for="includeArtistNameMatchHelp"
-                size="sm"
-              />{" "}
+              <Tooltip
+                id="includeArtistNameMatchHelp"
+                tooltip={
+                  <>
+                    Depending on the data we have available, including the
+                    artist name can result in worse matching. Tick this checkbox
+                    if you have a poor matching rate.
+                  </>
+                }
+              >
+                <span>
+                  <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+                </span>
+              </Tooltip>{" "}
             </label>
-            <Tooltip id="includeArtistNameMatchHelp" type="info" multiline>
-              Depending on the data we have available, including the artist name
-              can result in worse matching. Tick this checkbox if you have a
-              poor matching rate.
-            </Tooltip>
           </div>
         </Modal.Body>
         <Modal.Footer>

--- a/frontend/js/src/user/components/follow/CompatibilityCard.tsx
+++ b/frontend/js/src/user/components/follow/CompatibilityCard.tsx
@@ -4,8 +4,8 @@ import { includes as _includes } from "lodash";
 import { faCircleInfo, faSquarePlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router";
-import ReactTooltip from "react-tooltip";
 import Card from "../../../components/Card";
+import Tooltip from "../../../components/Tooltip";
 import SimilarityScore from "./SimilarityScore";
 
 export type CompatibilityCardProps = {
@@ -53,27 +53,32 @@ function CompatibilityCard(props: CompatibilityCardProps) {
           );
         })}
         {hasMoreThanFive && (
-          <>
-            <span data-tip data-for="more-artists-tooltip">
+          <Tooltip
+            id="more-artists-tooltip"
+            placement="top"
+            tooltip={
+              <>
+                {otherArtists.map((artist, index) => {
+                  return (
+                    <span>
+                      {index > 0 && ", "}
+                      {index > 0 && index === similarArtists.length - 1
+                        ? "and "
+                        : ""}
+                      {index > 0 && index % 5 === 0 && <br />}
+                      {`${artist.artist_name}`}
+                    </span>
+                  );
+                })}
+                {hasEvenMoreArtists && <span> and even more.</span>}
+              </>
+            }
+          >
+            <span>
               , and more.{" "}
               <FontAwesomeIcon icon={faSquarePlus} size="sm" color="gray" />
             </span>
-            <ReactTooltip id="more-artists-tooltip" place="top">
-              {otherArtists.map((artist, index) => {
-                return (
-                  <span>
-                    {index > 0 && ", "}
-                    {index > 0 && index === similarArtists.length - 1
-                      ? "and "
-                      : ""}
-                    {index > 0 && index % 5 === 0 && <br />}
-                    {`${artist.artist_name}`}
-                  </span>
-                );
-              })}
-              {hasEvenMoreArtists && <span> and even more.</span>}
-            </ReactTooltip>
-          </>
+          </Tooltip>
         )}
       </div>
     );
@@ -83,15 +88,27 @@ function CompatibilityCard(props: CompatibilityCardProps) {
 
   return (
     <Card id="compatibility-card" data-testid="compatibility-card">
-      <div className="info-icon" data-tip data-for="info-tooltip">
-        <Link
-          to={`/user/${encodeURIComponent(user.name)}/stats/?range=all_time`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <FontAwesomeIcon icon={faCircleInfo} />
-        </Link>
-      </div>
+      <Tooltip
+        id="info-tooltip"
+        placement="top"
+        tooltip={
+          <>
+            Artists displayed are the top matches, comparing the top 100 most
+            listened artists of all
+            <br /> time for both users. Click here for their statistics.
+          </>
+        }
+      >
+        <div className="info-icon">
+          <Link
+            to={`/user/${encodeURIComponent(user.name)}/stats/?range=all_time`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FontAwesomeIcon icon={faCircleInfo} />
+          </Link>
+        </div>
+      </Tooltip>
       <span>Your compatibility with {user.name}:</span>
       <SimilarityScore
         similarityScore={similarityScore}
@@ -100,11 +117,6 @@ function CompatibilityCard(props: CompatibilityCardProps) {
       />
       <hr />
       {content}
-      <ReactTooltip id="info-tooltip" place="top">
-        Artists displayed are the top matches, comparing the top 100 most
-        listened artists of all
-        <br /> time for both users. Click here for their statistics.
-      </ReactTooltip>
     </Card>
   );
 }

--- a/frontend/js/src/user/components/follow/CompatibilityCard.tsx
+++ b/frontend/js/src/user/components/follow/CompatibilityCard.tsx
@@ -4,8 +4,8 @@ import { includes as _includes } from "lodash";
 import { faCircleInfo, faSquarePlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router";
-import ReactTooltip from "react-tooltip";
 import Card from "../../../components/Card";
+import Tooltip from "../../../components/Tooltip";
 import SimilarityScore from "./SimilarityScore";
 
 export type CompatibilityCardProps = {
@@ -53,27 +53,32 @@ function CompatibilityCard(props: CompatibilityCardProps) {
           );
         })}
         {hasMoreThanFive && (
-          <>
-            <span data-tip data-for="more-artists-tooltip">
+          <Tooltip
+            id="more-artists-tooltip"
+            placement="top"
+            tooltip={
+              <>
+                {otherArtists.map((artist, index) => {
+                  return (
+                    <span>
+                      {index > 0 && ", "}
+                      {index > 0 && index === similarArtists.length - 1
+                        ? "and "
+                        : ""}
+                      {index > 0 && index % 5 === 0 && <br />}
+                      {`${artist.artist_name}`}
+                    </span>
+                  );
+                })}
+                {hasEvenMoreArtists && <span> and even more.</span>}
+              </>
+            }
+          >
+            <span>
               , and more.{" "}
               <FontAwesomeIcon icon={faSquarePlus} size="sm" color="gray" />
             </span>
-            <ReactTooltip id="more-artists-tooltip" place="top">
-              {otherArtists.map((artist, index) => {
-                return (
-                  <span>
-                    {index > 0 && ", "}
-                    {index > 0 && index === similarArtists.length - 1
-                      ? "and "
-                      : ""}
-                    {index > 0 && index % 5 === 0 && <br />}
-                    {`${artist.artist_name}`}
-                  </span>
-                );
-              })}
-              {hasEvenMoreArtists && <span> and even more.</span>}
-            </ReactTooltip>
-          </>
+          </Tooltip>
         )}
       </div>
     );
@@ -83,15 +88,27 @@ function CompatibilityCard(props: CompatibilityCardProps) {
 
   return (
     <Card id="compatibility-card" data-testid="compatibility-card">
-      <div className="info-icon" data-tip data-for="info-tooltip">
-        <Link
-          to={`/user/${encodeURIComponent(userName)}/stats/?range=all_time`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <FontAwesomeIcon icon={faCircleInfo} />
-        </Link>
-      </div>
+      <Tooltip
+        id="info-tooltip"
+        placement="top"
+        tooltip={
+          <>
+            Artists displayed are the top matches, comparing the top 100 most
+            listened artists of all
+            <br /> time for both users. Click here for their statistics.
+          </>
+        }
+      >
+        <div className="info-icon">
+          <Link
+            to={`/user/${encodeURIComponent(userName)}/stats/?range=all_time`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FontAwesomeIcon icon={faCircleInfo} />
+          </Link>
+        </div>
+      </Tooltip>
       <span>Your compatibility with {userName}:</span>
       <SimilarityScore
         similarityScore={similarityScore}
@@ -100,11 +117,6 @@ function CompatibilityCard(props: CompatibilityCardProps) {
       />
       <hr />
       {content}
-      <ReactTooltip id="info-tooltip" place="top">
-        Artists displayed are the top matches, comparing the top 100 most
-        listened artists of all
-        <br /> time for both users. Click here for their statistics.
-      </ReactTooltip>
     </Card>
   );
 }

--- a/frontend/js/src/user/components/follow/SimilarUsersModal.tsx
+++ b/frontend/js/src/user/components/follow/SimilarUsersModal.tsx
@@ -31,8 +31,7 @@ function SimilarUsersModal(props: SimilarUsersModalProps) {
           <hr />
           <div className="similar-users-empty text-center text-muted">
             Users with similar music tastes to{" "}
-            {userName === currentUserName ? "you" : userName} will appear
-            here.
+            {userName === currentUserName ? "you" : userName} will appear here.
           </div>
         </>
       );

--- a/frontend/js/src/user/year-in-music/2022/YearInMusic2022.tsx
+++ b/frontend/js/src/user/year-in-music/2022/YearInMusic2022.tsx
@@ -6,7 +6,6 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css/bundle";
 /* eslint-enable import/no-unresolved */
 import { CalendarDatum, ResponsiveCalendar } from "@nivo/calendar";
-import Tooltip from "react-tooltip";
 import { toast } from "react-toastify";
 import {
   get,
@@ -29,6 +28,7 @@ import { LazyLoadImage } from "react-lazy-load-image-component";
 import { Link, useLocation, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 import { generateAlbumArtThumbnailLink } from "../../../utils/utils";
@@ -297,14 +297,13 @@ export default class YearInMusic extends React.Component<
             >
               {topLevelPlaylist.title}{" "}
             </a>
-            <FontAwesomeIcon
-              icon={faQuestionCircle}
-              data-tip
-              data-for={`playlist-${index}-tooltip`}
-              size="xs"
-            />
-            <Tooltip id={`playlist-${index}-tooltip`}>
-              {topLevelPlaylist.annotation}
+            <Tooltip
+              id={`playlist-${index}-tooltip`}
+              tooltip={topLevelPlaylist.annotation}
+            >
+              <span>
+                <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+              </span>
             </Tooltip>
           </h4>
         </div>
@@ -785,15 +784,18 @@ export default class YearInMusic extends React.Component<
             <div className="card content-card" id="calendar">
               <h3 className="text-center">
                 {capitalize(yourOrUsersName)} listening activity{" "}
-                <FontAwesomeIcon
-                  icon={faQuestionCircle}
-                  data-tip
-                  data-for="listening-activity"
-                  size="xs"
-                />
-                <Tooltip id="listening-activity">
-                  How many tracks did {youOrUsername} listen to each day of the
-                  year?
+                <Tooltip
+                  id="listening-activity"
+                  tooltip={
+                    <>
+                      How many tracks did {youOrUsername} listen to each day of
+                      the year?
+                    </>
+                  }
+                >
+                  <span>
+                    <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                  </span>
                 </Tooltip>
               </h3>
               {listensPerDayForGraph ? (
@@ -857,16 +859,19 @@ export default class YearInMusic extends React.Component<
             <div className="card content-card" id="most-listened-year">
               <h3 className="text-center">
                 What year are {yourOrUsersName} favorite songs from?{" "}
-                <FontAwesomeIcon
-                  icon={faQuestionCircle}
-                  data-tip
-                  data-for="most-listened-year-helptext"
-                  size="xs"
-                />
-                <Tooltip id="most-listened-year-helptext">
-                  How much {isCurrentUser ? "were you" : `was ${user.name}`} on
-                  the lookout for new music this year? Not that we&apos;re
-                  judging.
+                <Tooltip
+                  id="most-listened-year-helptext"
+                  tooltip={
+                    <>
+                      How much {isCurrentUser ? "were you" : `was ${user.name}`}{" "}
+                      on the lookout for new music this year? Not that
+                      we&apos;re judging.
+                    </>
+                  }
+                >
+                  <span>
+                    <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                  </span>
                 </Tooltip>
               </h3>
               {mostListenedYearDataForGraph ? (
@@ -903,14 +908,13 @@ export default class YearInMusic extends React.Component<
             >
               <h3 className="text-center">
                 What countries are {yourOrUsersName} favorite artists from?{" "}
-                <FontAwesomeIcon
-                  icon={faQuestionCircle}
-                  data-tip
-                  data-for="user-artist-map-helptext"
-                  size="xs"
-                />
-                <Tooltip id="user-artist-map-helptext">
-                  Click on a country to see more details
+                <Tooltip
+                  id="user-artist-map-helptext"
+                  tooltip={<>Click on a country to see more details</>}
+                >
+                  <span>
+                    <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                  </span>
                 </Tooltip>
               </h3>
               {artistMapDataForGraph ? (
@@ -1024,17 +1028,20 @@ export default class YearInMusic extends React.Component<
                   />
                   <h4>
                     New albums from {yourOrUsersName} top artists{" "}
-                    <FontAwesomeIcon
-                      icon={faQuestionCircle}
-                      data-tip
-                      data-for="new-albums-helptext"
-                      size="xs"
-                    />
-                    <Tooltip id="new-albums-helptext">
-                      Albums and singles released in 2022 from artists{" "}
-                      {youOrUsername} listened to.
-                      <br />
-                      Missed anything?
+                    <Tooltip
+                      id="new-albums-helptext"
+                      tooltip={
+                        <>
+                          Albums and singles released in 2022 from artists{" "}
+                          {youOrUsername} listened to.
+                          <br />
+                          Missed anything?
+                        </>
+                      }
+                    >
+                      <span>
+                        <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                      </span>
                     </Tooltip>
                   </h4>
                 </div>
@@ -1114,17 +1121,20 @@ export default class YearInMusic extends React.Component<
                   />
                   <h4>
                     Music buddies{" "}
-                    <FontAwesomeIcon
-                      icon={faQuestionCircle}
-                      data-tip
-                      data-for="music-buddies-helptext"
-                      size="xs"
-                    />
-                    <Tooltip id="music-buddies-helptext">
-                      Here are the users with the most similar taste to{" "}
-                      {youOrUsername} this year.
-                      <br />
-                      Maybe check them out and follow them?
+                    <Tooltip
+                      id="music-buddies-helptext"
+                      tooltip={
+                        <>
+                          Here are the users with the most similar taste to{" "}
+                          {youOrUsername} this year.
+                          <br />
+                          Maybe check them out and follow them?
+                        </>
+                      }
+                    >
+                      <span>
+                        <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                      </span>
                     </Tooltip>
                   </h4>
                 </div>

--- a/frontend/js/src/user/year-in-music/2023/YearInMusic2023.tsx
+++ b/frontend/js/src/user/year-in-music/2023/YearInMusic2023.tsx
@@ -6,7 +6,6 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css/bundle";
 /* eslint-enable import/no-unresolved */
 import { CalendarDatum, ResponsiveCalendar } from "@nivo/calendar";
-import Tooltip from "react-tooltip";
 import { toast } from "react-toastify";
 import {
   get,
@@ -33,6 +32,7 @@ import humanizeDuration from "humanize-duration";
 import { Link, useLocation, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 import {
@@ -320,14 +320,13 @@ export default class YearInMusic extends React.Component<
             >
               {topLevelPlaylist.title}{" "}
             </a>
-            <FontAwesomeIcon
-              icon={faQuestionCircle}
-              data-tip
-              data-for={`playlist-${index}-tooltip`}
-              size="xs"
-            />
-            <Tooltip id={`playlist-${index}-tooltip`}>
-              {topLevelPlaylist.annotation}
+            <Tooltip
+              id={`playlist-${index}-tooltip`}
+              tooltip={topLevelPlaylist.annotation}
+            >
+              <span>
+                <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+              </span>
             </Tooltip>
           </h4>
         </div>
@@ -981,15 +980,18 @@ export default class YearInMusic extends React.Component<
                   <div className="" id="calendar">
                     <h3 className="text-center">
                       {capitalize(yourOrUsersName)} listening activity{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="listening-activity"
-                        size="xs"
-                      />
-                      <Tooltip id="listening-activity">
-                        How many tracks did {youOrUsername} listen to each day
-                        of the year?
+                      <Tooltip
+                        id="listening-activity"
+                        tooltip={
+                          <>
+                            How many tracks did {youOrUsername} listen to each
+                            day of the year?
+                          </>
+                        }
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
 
@@ -1033,17 +1035,20 @@ export default class YearInMusic extends React.Component<
                   <div className="" id="most-listened-year">
                     <h3 className="text-center">
                       What year are {yourOrUsersName} favorite songs from?{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="most-listened-year-helptext"
-                        size="xs"
-                      />
-                      <Tooltip id="most-listened-year-helptext">
-                        How much{" "}
-                        {isCurrentUser ? "were you" : `was ${user.name}`} on the
-                        lookout for new music this year? Not that we&apos;re
-                        judging
+                      <Tooltip
+                        id="most-listened-year-helptext"
+                        tooltip={
+                          <>
+                            How much{" "}
+                            {isCurrentUser ? "were you" : `was ${user.name}`} on
+                            the lookout for new music this year? Not that
+                            we&apos;re judging
+                          </>
+                        }
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
                     <div className="graph-container">
@@ -1080,14 +1085,13 @@ export default class YearInMusic extends React.Component<
                     <h3 className="text-center">
                       What countries are {yourOrUsersName} favorite artists
                       from?{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="user-artist-map-helptext"
-                        size="xs"
-                      />
-                      <Tooltip id="user-artist-map-helptext">
-                        Click on a country to see more details
+                      <Tooltip
+                        id="user-artist-map-helptext"
+                        tooltip={<>Click on a country to see more details</>}
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
                     <div className="graph-container">
@@ -1220,17 +1224,23 @@ export default class YearInMusic extends React.Component<
                       />
                       <h4>
                         New albums from {yourOrUsersName} top artists{" "}
-                        <FontAwesomeIcon
-                          icon={faQuestionCircle}
-                          data-tip
-                          data-for="new-albums-helptext"
-                          size="xs"
-                        />
-                        <Tooltip id="new-albums-helptext">
-                          Albums and singles released in 2023 from artists{" "}
-                          {youOrUsername} listened to.
-                          <br />
-                          Missed anything?
+                        <Tooltip
+                          id="new-albums-helptext"
+                          tooltip={
+                            <>
+                              Albums and singles released in 2023 from artists{" "}
+                              {youOrUsername} listened to.
+                              <br />
+                              Missed anything?
+                            </>
+                          }
+                        >
+                          <span>
+                            <FontAwesomeIcon
+                              icon={faQuestionCircle}
+                              size="xs"
+                            />
+                          </span>
                         </Tooltip>
                       </h4>
                     </div>
@@ -1309,17 +1319,23 @@ export default class YearInMusic extends React.Component<
                       />
                       <h4>
                         Music buddies{" "}
-                        <FontAwesomeIcon
-                          icon={faQuestionCircle}
-                          data-tip
-                          data-for="music-buddies-helptext"
-                          size="xs"
-                        />
-                        <Tooltip id="music-buddies-helptext">
-                          Here are the users with the most similar taste to{" "}
-                          {youOrUsername} this year.
-                          <br />
-                          Maybe check them out and follow them?
+                        <Tooltip
+                          id="music-buddies-helptext"
+                          tooltip={
+                            <>
+                              Here are the users with the most similar taste to{" "}
+                              {youOrUsername} this year.
+                              <br />
+                              Maybe check them out and follow them?
+                            </>
+                          }
+                        >
+                          <span>
+                            <FontAwesomeIcon
+                              icon={faQuestionCircle}
+                              size="xs"
+                            />
+                          </span>
                         </Tooltip>
                       </h4>
                     </div>

--- a/frontend/js/src/user/year-in-music/2024/YearInMusic2024.tsx
+++ b/frontend/js/src/user/year-in-music/2024/YearInMusic2024.tsx
@@ -12,7 +12,6 @@ import "swiper/css/bundle";
 /* eslint-enable import/no-unresolved */
 import { CalendarDatum, ResponsiveCalendar } from "@nivo/calendar";
 import { ResponsiveTreeMap } from "@nivo/treemap";
-import Tooltip from "react-tooltip";
 import { toast } from "react-toastify";
 import {
   get,
@@ -38,6 +37,7 @@ import humanizeDuration from "humanize-duration";
 import { Link, useLocation, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 import {
@@ -287,14 +287,13 @@ export default class YearInMusic extends React.Component<
             >
               {topLevelPlaylist.title}{" "}
             </a>
-            <FontAwesomeIcon
-              icon={faQuestionCircle}
-              data-tip
-              data-for={`playlist-${index}-tooltip`}
-              size="xs"
-            />
-            <Tooltip id={`playlist-${index}-tooltip`}>
-              {topLevelPlaylist.annotation}
+            <Tooltip
+              id={`playlist-${index}-tooltip`}
+              tooltip={topLevelPlaylist.annotation}
+            >
+              <span>
+                <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+              </span>
             </Tooltip>
           </h3>
         </div>
@@ -960,15 +959,18 @@ export default class YearInMusic extends React.Component<
                   <div className="" id="calendar">
                     <h3 className="text-center">
                       {capitalize(yourOrUsersName)} listening activity{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="listening-activity"
-                        size="xs"
-                      />
-                      <Tooltip id="listening-activity">
-                        How many tracks did {youOrUsername} listen to each day
-                        of the year?
+                      <Tooltip
+                        id="listening-activity"
+                        tooltip={
+                          <>
+                            How many tracks did {youOrUsername} listen to each
+                            day of the year?
+                          </>
+                        }
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
 
@@ -1012,17 +1014,20 @@ export default class YearInMusic extends React.Component<
                   <div className="" id="most-listened-year">
                     <h3 className="text-center">
                       What year are {yourOrUsersName} favorite songs from?{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="most-listened-year-helptext"
-                        size="xs"
-                      />
-                      <Tooltip id="most-listened-year-helptext">
-                        How much{" "}
-                        {isCurrentUser ? "were you" : `was ${user.name}`} on the
-                        lookout for new music this year? Not that we&apos;re
-                        judging
+                      <Tooltip
+                        id="most-listened-year-helptext"
+                        tooltip={
+                          <>
+                            How much{" "}
+                            {isCurrentUser ? "were you" : `was ${user.name}`} on
+                            the lookout for new music this year? Not that
+                            we&apos;re judging
+                          </>
+                        }
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
                     <div className="graph-container">
@@ -1059,14 +1064,13 @@ export default class YearInMusic extends React.Component<
                     <h3 className="text-center">
                       What countries are {yourOrUsersName} favorite artists
                       from?{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="user-artist-map-helptext"
-                        size="xs"
-                      />
-                      <Tooltip id="user-artist-map-helptext">
-                        Click on a country to see more details
+                      <Tooltip
+                        id="user-artist-map-helptext"
+                        tooltip={<>Click on a country to see more details</>}
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
                     <div className="graph-container">
@@ -1143,14 +1147,17 @@ export default class YearInMusic extends React.Component<
                   <div className="" id="genre-graph">
                     <h3 className="text-center">
                       What genres {hasOrHave} {youOrUsername} explored?{" "}
-                      <FontAwesomeIcon
-                        icon={faQuestionCircle}
-                        data-tip
-                        data-for="genre-graph-helptext"
-                        size="xs"
-                      />
-                      <Tooltip id="genre-graph-helptext">
-                        The top genres {youOrUsername} listened to this year
+                      <Tooltip
+                        id="genre-graph-helptext"
+                        tooltip={
+                          <>
+                            The top genres {youOrUsername} listened to this year
+                          </>
+                        }
+                      >
+                        <span>
+                          <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+                        </span>
                       </Tooltip>
                     </h3>
                     <div className="graph-container">
@@ -1242,17 +1249,23 @@ export default class YearInMusic extends React.Component<
                       />
                       <h3>
                         New albums from {yourOrUsersName} top artists{" "}
-                        <FontAwesomeIcon
-                          icon={faQuestionCircle}
-                          data-tip
-                          data-for="new-albums-helptext"
-                          size="xs"
-                        />
-                        <Tooltip id="new-albums-helptext">
-                          Albums and singles released in 2024 from artists{" "}
-                          {youOrUsername} listened to.
-                          <br />
-                          Missed anything?
+                        <Tooltip
+                          id="new-albums-helptext"
+                          tooltip={
+                            <>
+                              Albums and singles released in 2024 from artists{" "}
+                              {youOrUsername} listened to.
+                              <br />
+                              Missed anything?
+                            </>
+                          }
+                        >
+                          <span>
+                            <FontAwesomeIcon
+                              icon={faQuestionCircle}
+                              size="xs"
+                            />
+                          </span>
                         </Tooltip>
                       </h3>
                     </div>
@@ -1331,17 +1344,23 @@ export default class YearInMusic extends React.Component<
                       />
                       <h3>
                         Music buddies{" "}
-                        <FontAwesomeIcon
-                          icon={faQuestionCircle}
-                          data-tip
-                          data-for="music-buddies-helptext"
-                          size="xs"
-                        />
-                        <Tooltip id="music-buddies-helptext">
-                          Here are the users with the most similar taste to{" "}
-                          {youOrUsername} this year.
-                          <br />
-                          Maybe check them out and follow them?
+                        <Tooltip
+                          id="music-buddies-helptext"
+                          tooltip={
+                            <>
+                              Here are the users with the most similar taste to{" "}
+                              {youOrUsername} this year.
+                              <br />
+                              Maybe check them out and follow them?
+                            </>
+                          }
+                        >
+                          <span>
+                            <FontAwesomeIcon
+                              icon={faQuestionCircle}
+                              size="xs"
+                            />
+                          </span>
                         </Tooltip>
                       </h3>
                     </div>

--- a/frontend/js/src/user/year-in-music/components/YIMArtistMap.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMArtistMap.tsx
@@ -2,8 +2,8 @@ import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isEmpty } from "lodash";
 import * as React from "react";
-import Tooltip from "react-tooltip";
 import tinycolor from "tinycolor2";
+import Tooltip from "../../../components/Tooltip";
 import CustomChoropleth from "../../stats/components/Choropleth";
 
 export type YIMArtistMapData = Array<{
@@ -55,14 +55,13 @@ export default function YIMArtistMap(props: YIMArtistMapProps) {
     <div className="" id="user-artist-map" style={{ marginTop: "1.5em" }}>
       <h3 className="text-center">
         What countries are {yourOrUsersName} favorite artists from?{" "}
-        <FontAwesomeIcon
-          icon={faQuestionCircle}
-          data-tip
-          data-for="user-artist-map-helptext"
-          size="xs"
-        />
-        <Tooltip id="user-artist-map-helptext">
-          Click on a country to see more details
+        <Tooltip
+          id="user-artist-map-helptext"
+          tooltip={<>Click on a country to see more details</>}
+        >
+          <span>
+            <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+          </span>
         </Tooltip>
       </h3>
       <div className="graph-container card-bg">

--- a/frontend/js/src/user/year-in-music/components/YIMGenreGraph.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMGenreGraph.tsx
@@ -2,8 +2,8 @@ import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ResponsiveTreeMap } from "@nivo/treemap";
 import * as React from "react";
-import Tooltip from "react-tooltip";
 import tinycolor from "tinycolor2";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 type Node = {
@@ -42,14 +42,13 @@ export default function YIMGenreGraph(props: YIMGenreGraphProps) {
     <div className="" id="genre-graph">
       <h3 className="text-center">
         What genres {hasOrHave} {youOrUsername} explored?{" "}
-        <FontAwesomeIcon
-          icon={faQuestionCircle}
-          data-tip
-          data-for="genre-graph-helptext"
-          size="xs"
-        />
-        <Tooltip id="genre-graph-helptext">
-          The top genres {youOrUsername} listened to this year
+        <Tooltip
+          id="genre-graph-helptext"
+          tooltip={<>The top genres {youOrUsername} listened to this year</>}
+        >
+          <span>
+            <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+          </span>
         </Tooltip>
       </h3>
       <div className="graph-container card-bg">

--- a/frontend/js/src/user/year-in-music/components/YIMListeningActivity.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMListeningActivity.tsx
@@ -2,9 +2,9 @@ import { capitalize, isEmpty } from "lodash";
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import Tooltip from "react-tooltip";
 import { CalendarDatum, ResponsiveCalendar } from "@nivo/calendar";
 import tinycolor from "tinycolor2";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 export type YIMListeningActivityData = Array<{
@@ -63,14 +63,18 @@ export default function YIMListeningActivity({
     <div className="" id="calendar">
       <h3 className="text-center">
         {capitalize(yourOrUsersName)} listening activity{" "}
-        <FontAwesomeIcon
-          icon={faQuestionCircle}
-          data-tip
-          data-for="listening-activity"
-          size="xs"
-        />
-        <Tooltip id="listening-activity">
-          How many tracks did {youOrUsername} listen to each day of the year?
+        <Tooltip
+          id="listening-activity"
+          tooltip={
+            <>
+              How many tracks did {youOrUsername} listen to each day of the
+              year?
+            </>
+          }
+        >
+          <span>
+            <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+          </span>
         </Tooltip>
       </h3>
 

--- a/frontend/js/src/user/year-in-music/components/YIMMostListenedYear.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMMostListenedYear.tsx
@@ -1,11 +1,11 @@
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
-import Tooltip from "react-tooltip";
 import { ResponsiveBar } from "@nivo/bar";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { type AxisLegendPosition } from "@nivo/axes";
 import { isEmpty, range, uniq } from "lodash";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import { useMediaQuery } from "../../../explore/fresh-releases/utils";
 
@@ -63,15 +63,18 @@ export default function YIMMostListenedYear(props: YIMMostListenedYearProps) {
     <div className="" id="most-listened-year">
       <h3 className="text-center">
         What year are {yourOrUsersName} favorite songs from?{" "}
-        <FontAwesomeIcon
-          icon={faQuestionCircle}
-          data-tip
-          data-for="most-listened-year-helptext"
-          size="xs"
-        />
-        <Tooltip id="most-listened-year-helptext">
-          How much {isCurrentUser ? "were you" : `was ${userName}`} on the
-          lookout for new music this year? Not that we&apos;re judging
+        <Tooltip
+          id="most-listened-year-helptext"
+          tooltip={
+            <>
+              How much {isCurrentUser ? "were you" : `was ${userName}`} on the
+              lookout for new music this year? Not that we&apos;re judging
+            </>
+          }
+        >
+          <span>
+            <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+          </span>
         </Tooltip>
       </h3>
       <div className="graph-container card-bg">

--- a/frontend/js/src/user/year-in-music/components/YIMNewReleases.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMNewReleases.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import Tooltip from "react-tooltip";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import { getEntityLink } from "../../stats/utils";
 import { getArtistLink } from "../../../utils/utils";
@@ -42,17 +42,20 @@ export default function YIMNewReleases({
       <div className="heading">
         <h3>
           New albums from {yourOrUsersName} top artists{" "}
-          <FontAwesomeIcon
-            icon={faQuestionCircle}
-            data-tip
-            data-for="new-albums-helptext"
-            size="xs"
-          />
-          <Tooltip id="new-albums-helptext">
-            Albums and singles released in {year} from artists {youOrUsername}{" "}
-            listened to.
-            <br />
-            Missed anything?
+          <Tooltip
+            id="new-albums-helptext"
+            tooltip={
+              <>
+                Albums and singles released in {year} from artists{" "}
+                {youOrUsername} listened to.
+                <br />
+                Missed anything?
+              </>
+            }
+          >
+            <span>
+              <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+            </span>
           </Tooltip>
         </h3>
       </div>

--- a/frontend/js/src/user/year-in-music/components/YIMPlaylists.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMPlaylists.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import Tooltip from "react-tooltip";
 import { get } from "lodash";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import { JSPFTrackToListen } from "../../../playlists/utils";
 import ListenCard from "../../../common/listens/ListenCard";
@@ -48,14 +48,13 @@ export default function TopLevelPlaylist(props: {
         >
           {topLevelPlaylist.title}{" "}
         </a>
-        <FontAwesomeIcon
-          icon={faQuestionCircle}
-          data-tip
-          data-for={`playlist-${coverArtKey}-tooltip`}
-          size="xs"
-        />
-        <Tooltip id={`playlist-${coverArtKey}-tooltip`}>
-          {topLevelPlaylist.annotation}
+        <Tooltip
+          id={`playlist-${coverArtKey}-tooltip`}
+          tooltip={topLevelPlaylist.annotation}
+        >
+          <span>
+            <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+          </span>
         </Tooltip>
       </h3>
       <div className="card-bg">

--- a/frontend/js/src/user/year-in-music/components/YIMSimilarUsers.tsx
+++ b/frontend/js/src/user/year-in-music/components/YIMSimilarUsers.tsx
@@ -2,7 +2,7 @@ import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { toPairs } from "lodash";
 import React from "react";
-import Tooltip from "react-tooltip";
+import Tooltip from "../../../components/Tooltip";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import UserListModalEntry, {
   UserListModalEntryProps,
@@ -41,17 +41,20 @@ export default function YIMSimilarUsers({
       <div className="heading">
         <h3>
           Music buddies{" "}
-          <FontAwesomeIcon
-            icon={faQuestionCircle}
-            data-tip
-            data-for="music-buddies-helptext"
-            size="xs"
-          />
-          <Tooltip id="music-buddies-helptext">
-            Here are the users with the most similar taste to {youOrUsername} in{" "}
-            {year}.
-            <br />
-            Maybe check them out and follow them?
+          <Tooltip
+            id="music-buddies-helptext"
+            tooltip={
+              <>
+                Here are the users with the most similar taste to{" "}
+                {youOrUsername} in {year}.
+                <br />
+                Maybe check them out and follow them?
+              </>
+            }
+          >
+            <span>
+              <FontAwesomeIcon icon={faQuestionCircle} size="xs" />
+            </span>
           </Tooltip>
         </h3>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "react-simple-star-rating": "^4.0.0",
         "react-sortablejs": "^6.1.4",
         "react-toastify": "^8.2.0",
-        "react-tooltip": "^4.5.1",
         "react-use-draggable-scroll-safe": "^0.5.4",
         "react-youtube": "^7.12.0",
         "socket.io-client": "^4.8.3",
@@ -17348,40 +17347,6 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
-      }
-    },
-    "node_modules/react-tooltip": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.5.1.tgz",
-      "integrity": "sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==",
-      "dependencies": {
-        "prop-types": "^15.8.1",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "npm": ">=6.13"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/react-tooltip/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/react-tooltip/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "react-simple-star-rating": "^4.0.0",
         "react-sortablejs": "^6.1.4",
         "react-toastify": "^8.2.0",
-        "react-tooltip": "^4.5.1",
         "react-use-draggable-scroll-safe": "^0.5.4",
         "react-youtube": "^7.12.0",
         "socket.io-client": "^4.8.3",
@@ -17358,40 +17357,6 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
-      }
-    },
-    "node_modules/react-tooltip": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.5.1.tgz",
-      "integrity": "sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==",
-      "dependencies": {
-        "prop-types": "^15.8.1",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "npm": ">=6.13"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/react-tooltip/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/react-tooltip/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "react-simple-star-rating": "^4.0.0",
     "react-sortablejs": "^6.1.4",
     "react-toastify": "^8.2.0",
-    "react-tooltip": "^4.5.1",
     "react-use-draggable-scroll-safe": "^0.5.4",
     "react-youtube": "^7.12.0",
     "socket.io-client": "^4.8.3",


### PR DESCRIPTION
# Problem

Seeing #3693 and #3742 , instead of updating the reac-tooltip library, why not use the [Overlay components](https://react-bootstrap.netlify.app/docs/components/overlays) from react-bootstrap (a library we use for many other things) and get rid of a few dependencies?
 
# Solution

Refactored all the tooltips to use react-bootstrap.
Also implemented our own Tooltip component as a wrapper, to separate implementation and make it easy to change next time we want to replace the underlying library.

Most were trivial, and I used codex to refactor those, with thorough review.
That left three more complex components that I migrated by hand:
- CBReviewModal needed some changes to allow clicking inside the overlay. Used [Popover component](https://react-bootstrap.netlify.app/docs/components/overlays#popovers) instead of Tooltip
- BrainzPlayerSettings had some custom conditional visibility mechanism
- ProgressBar had a lot of custom code to control the position and content of the tooltip dynamically. This was harder to reimplement

More details in their respective commits.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

I used Codex for finding the simple use cases (simple tooltip text withg only hover/focus interactions) and refactor those in commit 32d2b4c1a
