### PR TITLE
LB-580: Document and test /player POST endpoints

### DIFF
--- a/docs/users/api/index.rst
+++ b/docs/users/api/index.rst
@@ -72,6 +72,7 @@ Reference
 
    core
    playlist
+   player
    recordings
    statistics
    popularity

--- a/docs/users/api/player.rst
+++ b/docs/users/api/player.rst
@@ -1,0 +1,10 @@
+Player
+======
+
+The player endpoints create temporary `JSPF <https://musicbrainz.org/doc/jspf>`_ playlists for
+instant playback from recording or release MBIDs.
+
+.. autoflask:: listenbrainz.webserver:create_app_rtfd()
+   :blueprints: player
+   :include-empty-docstring:
+   :undoc-static:

--- a/listenbrainz/webserver/views/player.py
+++ b/listenbrainz/webserver/views/player.py
@@ -20,22 +20,28 @@ player_bp = Blueprint("player", __name__)
 @player_bp.post("/")
 def load_instant():
     """
-    This endpoint takes in a list of recording_mbids and optional desc/name arguments  and then loads
-    the recording_mbid's metadata and creates a JSPF file from this data and sends it to the front end
-    so a playlist can be instantly played.
+    Create an instant JSPF playlist from a list of recording MBIDs.
+
+    This endpoint accepts a comma-separated list of recording MBIDs as a query
+    parameter, fetches their metadata, and returns a JSPF playlist suitable for
+    immediate playback. All parameters are passed as query string arguments.
+
+    The response is a JSON object containing a JSPF playlist with track entries
+    for each valid recording MBID.
 
     .. note::
         We recommend that you do not send more than 50 recording_mbids in one request -- our
         server infrastructure will likely give you a gateway error (502) if you do.
 
-    :param recording_mbids: A comma separated list of recording_mbids
+    :param recording_mbids: A comma separated list of recording MBIDs (query string).
     :type recording_mbids: ``str``
-    :param desc: A description for this instant playlist (optional).
+    :param desc: A description for this instant playlist (optional, defaults to "Instant playlist").
     :type desc: ``str``
-    :param name: A name for this instant playlist (optional).
+    :param name: A name for this instant playlist (optional, defaults to "Instant playlist").
     :type name: ``str``
-    :statuscode 200: playlist generated
-    :statuscode 400: invalid recording_mbid arguments
+    :statuscode 200: playlist generated, returns JSPF.
+    :statuscode 400: ``recording_mbids`` parameter is missing or contains an invalid UUID.
+    :resheader Content-Type: *application/json*
     """
 
     recordings = request.args.get("recording_mbids", default=None)
@@ -72,16 +78,23 @@ def load_instant():
 @player_bp.post("/release/<release_mbid>/")
 def load_release(release_mbid):
     """
-    This endpoint takes a release mbid, loads the tracks for this release and makes a playlist from it and
-    sends it to the front end via JSPF.
+    Create a JSPF playlist from all tracks on a MusicBrainz release.
 
-    :statuscode 200: playlist generated
-    :statuscode 400: invalid recording_mbid arguments
+    Given a release MBID, this endpoint looks up the release in MusicBrainz,
+    retrieves all tracks across all media, and returns them as a JSPF playlist.
+    Cover art information is included when available.
+
+    :param release_mbid: A valid MusicBrainz release MBID (URL path parameter).
+    :type release_mbid: ``str``
+    :statuscode 200: playlist generated, returns JSPF.
+    :statuscode 400: the provided ``release_mbid`` is not a valid UUID.
+    :statuscode 404: the release was not found in the MusicBrainz database.
+    :resheader Content-Type: *application/json*
     """
 
     release_mbid = release_mbid.strip()
     if not is_valid_uuid(release_mbid):
-        raise BadRequest(f"Recording mbid {release_mbid} is not valid.")
+        raise BadRequest(f"Release mbid {release_mbid} is not valid.")
 
     playlist = None
     if mb_engine:

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -167,15 +167,6 @@ class IndexViewsTestCase(IntegrationTestCase):
         r = self.client.get('/feed/')
         self.assert200(r)
 
-    @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
-    def test_instant_playlist(self, mock_recording_metadata):
-        resp = self.client.get(self.custom_url_for('player.load_instant', recording_mbids="87c94c4b-6aed-41a3-bbbd-aa9cd2154c5e"))
-        self.assert200(resp)
-
-    def test_release_playlist(self):
-        resp = self.client.get(self.custom_url_for('player.load_release', release_mbid="87c94c4b-6aed-41a3-bbbd-aa9cd2154c5e"))
-        self.assert200(resp)
-
 
 class IndexViewsTestCase2(ServerAppPerTestTestCase, DatabaseTestCase):
 

--- a/listenbrainz/webserver/views/test/test_player.py
+++ b/listenbrainz/webserver/views/test/test_player.py
@@ -1,20 +1,196 @@
-from unittest.mock import patch
+import json
+from unittest.mock import patch, MagicMock
 
 from listenbrainz.tests.integration import IntegrationTestCase
 
 
 class PlayerViewsTestCase(IntegrationTestCase):
 
-    @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
-    def test_player_get_instant(self, mock_recording_metadata):
-        resp = self.client.get(
-            self.custom_url_for('player.load_instant', recording_mbids="97e69767-5d34-4c97-b36a-f3b2b1ef9dae")
-        )
-        self.assert200(resp)
+    # ──────────────────────────────────────────────────
+    #  POST /player/  (load_instant)
+    # ──────────────────────────────────────────────────
 
     @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
-    def test_player_release(self, mock_recording_metadata):
-        resp = self.client.get(
-            self.custom_url_for('player.load_release', release_mbid="9db51cd6-38f6-3b42-8ad5-559963d68f35")
+    def test_load_instant_single_mbid(self, mock_fetch):
+        """POST with a single valid recording MBID returns 200 and JSPF with one track."""
+        mbid = "97e69767-5d34-4c97-b36a-f3b2b1ef9dae"
+        resp = self.client.post(
+            self.custom_url_for('player.load_instant', recording_mbids=mbid)
         )
+        self.assert200(resp)
+        data = json.loads(resp.data)
+
+        # Top-level structure
+        self.assertIn("playlist", data)
+        playlist = data["playlist"]["playlist"]
+        self.assertIn("title", playlist)
+        self.assertIn("track", playlist)
+        self.assertEqual(len(playlist["track"]), 1)
+
+        # Track has the correct recording identifier
+        track = playlist["track"][0]
+        self.assertIn("identifier", track)
+        self.assertIn(mbid, track["identifier"][0])
+
+        mock_fetch.assert_called_once()
+
+    @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
+    def test_load_instant_multiple_mbids(self, mock_fetch):
+        """POST with multiple comma-separated MBIDs returns a track for each."""
+        mbids = "97e69767-5d34-4c97-b36a-f3b2b1ef9dae,a076e8af-5791-4531-a0ef-6b0a21f8e81c,cc197bad-dc9c-440d-a5b5-d52ba2e14234"
+        resp = self.client.post(
+            self.custom_url_for('player.load_instant', recording_mbids=mbids)
+        )
+        self.assert200(resp)
+        data = json.loads(resp.data)
+        tracks = data["playlist"]["playlist"]["track"]
+        self.assertEqual(len(tracks), 3)
+
+    @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
+    def test_load_instant_custom_name_and_desc(self, mock_fetch):
+        """Custom name and desc are reflected in the JSPF title and annotation."""
+        mbid = "97e69767-5d34-4c97-b36a-f3b2b1ef9dae"
+        resp = self.client.post(
+            self.custom_url_for(
+                'player.load_instant',
+                recording_mbids=mbid,
+                name="My Playlist",
+                desc="A test description"
+            )
+        )
+        self.assert200(resp)
+        data = json.loads(resp.data)
+        playlist = data["playlist"]["playlist"]
+        self.assertEqual(playlist["title"], "My Playlist")
+        self.assertEqual(playlist["annotation"], "A test description")
+
+    @patch("listenbrainz.webserver.views.player.fetch_playlist_recording_metadata")
+    def test_load_instant_default_name_and_desc(self, mock_fetch):
+        """When name and desc are omitted, defaults to 'Instant playlist'."""
+        mbid = "97e69767-5d34-4c97-b36a-f3b2b1ef9dae"
+        resp = self.client.post(
+            self.custom_url_for('player.load_instant', recording_mbids=mbid)
+        )
+        self.assert200(resp)
+        data = json.loads(resp.data)
+        playlist = data["playlist"]["playlist"]
+        self.assertEqual(playlist["title"], "Instant playlist")
+        self.assertEqual(playlist["annotation"], "Instant playlist")
+
+    def test_load_instant_missing_recording_mbids(self):
+        """POST without recording_mbids returns 400."""
+        resp = self.client.post('/player/')
+        self.assert400(resp)
+
+    def test_load_instant_invalid_uuid(self):
+        """POST with an invalid UUID returns 400."""
+        resp = self.client.post(
+            self.custom_url_for('player.load_instant', recording_mbids="not-a-valid-uuid")
+        )
+        self.assert400(resp)
+
+    def test_load_instant_mixed_valid_invalid_uuids(self):
+        """POST with one valid and one invalid UUID returns 400."""
+        mbids = "97e69767-5d34-4c97-b36a-f3b2b1ef9dae,not-a-valid-uuid"
+        resp = self.client.post(
+            self.custom_url_for('player.load_instant', recording_mbids=mbids)
+        )
+        self.assert400(resp)
+
+    # ──────────────────────────────────────────────────
+    #  POST /player/release/<release_mbid>/  (load_release)
+    # ──────────────────────────────────────────────────
+
+    def test_load_release_invalid_uuid(self):
+        """POST with an invalid release UUID returns 400."""
+        resp = self.client.post('/player/release/not-a-valid-uuid/')
+        self.assert400(resp)
+
+    @patch("listenbrainz.webserver.views.player.mb_engine", new=True)
+    @patch("listenbrainz.webserver.views.player.get_release_by_mbid")
+    def test_load_release_not_found(self, mock_get_release):
+        """POST with a valid UUID for a non-existent release returns 404."""
+        mock_get_release.return_value = None
+        resp = self.client.post('/player/release/9db51cd6-38f6-3b42-8ad5-559963d68f35/')
+        self.assert404(resp)
+        data = json.loads(resp.data)
+        self.assertIn("error", data)
+
+    @patch("listenbrainz.webserver.views.player.get_caa_ids_for_release_mbids")
+    @patch("listenbrainz.webserver.views.player.psycopg2")
+    @patch("listenbrainz.webserver.views.player.mb_engine", new=True)
+    @patch("listenbrainz.webserver.views.player.get_release_by_mbid")
+    def test_load_release_valid(self, mock_get_release, mock_psycopg2, mock_get_caa):
+        """POST with a valid release MBID returns 200 and JSPF with tracks."""
+        release_mbid = "9db51cd6-38f6-3b42-8ad5-559963d68f35"
+
+        mock_get_release.return_value = {
+            "name": "OK Computer",
+            "mbid": release_mbid,
+            "artist-credit-phrase": "Radiohead",
+            "medium-list": [
+                {
+                    "track-list": [
+                        {
+                            "name": "Airbag",
+                            "position": 1,
+                            "recording_id": "b1d58a57-a0f3-4b20-aab0-d7afd3a58f09",
+                            "artist-credit-phrase": "Radiohead",
+                            "artist-credit": [
+                                {"artist": {"mbid": "a74b1b7f-71a5-4011-9441-d0b5e4122711"}}
+                            ],
+                        },
+                        {
+                            "name": "Paranoid Android",
+                            "position": 2,
+                            "recording_id": "e3cb1e21-8e24-4809-9f9e-2c79a6e6bdb0",
+                            "artist-credit-phrase": "Radiohead",
+                            "artist-credit": [
+                                {"artist": {"mbid": "a74b1b7f-71a5-4011-9441-d0b5e4122711"}}
+                            ],
+                        },
+                    ]
+                }
+            ],
+        }
+
+        # Mock psycopg2 connection + cursor context managers
+        mock_curs = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_curs)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_psycopg2.connect.return_value = mock_conn
+        mock_psycopg2.extras = MagicMock()
+
+        mock_get_caa.return_value = {
+            release_mbid: {"caa_id": 12345, "caa_release_mbid": release_mbid}
+        }
+
+        resp = self.client.post(f'/player/release/{release_mbid}/')
+        self.assert200(resp)
+        data = json.loads(resp.data)
+
+        playlist = data["playlist"]["playlist"]
+        self.assertEqual(len(playlist["track"]), 2)
+        self.assertEqual(playlist["track"][0]["title"], "Airbag")
+        self.assertEqual(playlist["track"][0]["creator"], "Radiohead")
+        self.assertEqual(playlist["track"][1]["title"], "Paranoid Android")
+
+    @patch("listenbrainz.webserver.views.player.mb_engine", new=None)
+    def test_load_release_no_mb_engine(self):
+        """When mb_engine is None, returns 200 with an empty playlist."""
+        resp = self.client.post('/player/release/9db51cd6-38f6-3b42-8ad5-559963d68f35/')
+        self.assert200(resp)
+        data = json.loads(resp.data)
+        self.assertEqual(data["playlist"], {})
+
+    # ──────────────────────────────────────────────────
+    #  GET /player/  (index — serves React SPA)
+    # ──────────────────────────────────────────────────
+
+    def test_player_index_get(self):
+        """GET /player/ serves the React SPA page (index.html)."""
+        resp = self.client.get('/player/')
         self.assert200(resp)


### PR DESCRIPTION
# Problem

This addresses [LB-580](https://tickets.metabrainz.org/browse/LB-580) (Document and test `/player` POST endpoint).

The `/player` blueprint endpoints (`load_instant` and `load_release`) had missing and inaccurate tests. 
The existing tests in `test_player.py` used `GET` requests instead of `POST` on these routes. Because there is a catch-all `GET /<path:path>/` route that serves the `index.html` React SPA, the tests were succeeding by rendering the index page instead of actually testing the `POST` endpoints.
Furthermore, the endpoints lacked proper documentation for Sphinx `autoflask`.

# Solution

1. **Test Rewrite (`test_player.py`)**:
   - Switched all relevant endpoints to use `client.post()` instead of `client.get()`.
   - Added comprehensive tests for `load_instant` and `load_release` to verify correct JSPF payload generation under different conditions.
   - Added tests for various error cases, including missing parameters and invalid UUIDs (verifying `400` and `404` responses).
   - Mocked MusicBrainz `mb_engine` and DB queries to properly test the `load_release` endpoint behavior.

2. **Documentation (`player.py` and `docs/`)**:
   - Improved docstrings for `load_instant` and `load_release` with standard Sphinx directives (`:param:`, `:statuscode:`, `:resheader:`).
   - Added a new Sphinx docs page `docs/users/api/player.rst` utilizing `autoflask` to auto-generate the API docs.
   - Added `player` to the Sphinx documentation toctree in `docs/users/api/index.rst`.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for communication
* [ ] I used AI tools for coding
* [x] I understand all the changes made in this PR

> Used an AI coding assistant to understand the existing codebase, identify the GET/POST routing issue, and structure the approach. However, all the actual coding and testing was done manually by me.

# Action
None.
