### PR TITLE
User Onboarding: Add database schema, logic and api endpoints.

### DIFF
--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -175,4 +175,10 @@ ALTER TABLE navidrome_tokens
     REFERENCES navidrome_servers (id)
     ON DELETE CASCADE;
 
+ALTER TABLE user_onboarding_state
+    ADD CONSTRAINT user_onboarding_state_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+
 COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -73,4 +73,6 @@ CREATE INDEX user_id_ndx_navidrome_tokens ON navidrome_tokens (user_id);
 CREATE INDEX server_id_ndx_navidrome_tokens ON navidrome_tokens (navidrome_server_id);
 CREATE UNIQUE INDEX unique_user_server_navidrome_tokens ON navidrome_tokens (user_id, navidrome_server_id);
 
+CREATE INDEX user_onboarding_state_user_id_ndx ON user_onboarding_state (user_id);
+
 COMMIT;

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -43,4 +43,6 @@ ALTER TABLE navidrome_servers ADD CONSTRAINT navidrome_servers_id_pkey PRIMARY K
 
 ALTER TABLE navidrome_tokens ADD CONSTRAINT navidrome_tokens_id_pkey PRIMARY KEY (id);
 
+ALTER TABLE user_onboarding_state ADD CONSTRAINT user_onboarding_state_pkey PRIMARY KEY (user_id, tour_id);
+
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -280,6 +280,16 @@ CREATE TABLE navidrome_tokens (
     created             TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+CREATE TABLE user_onboarding_state (
+    user_id      INTEGER     NOT NULL,
+    tour_id      VARCHAR(50) NOT NULL,
+    status       VARCHAR(20) NOT NULL DEFAULT 'not_started',
+    current_step INTEGER     NOT NULL DEFAULT 0,
+    unlock_ready BOOLEAN     NOT NULL DEFAULT FALSE,
+    unlocked_at  TIMESTAMP WITH TIME ZONE,
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
 -- The following line is now executed by the init-db action from manage.py. If you create a DB without the init-db function
 -- you will need to execute the following GRANT in order to complete your DB setup.
 --GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO listenbrainz;

--- a/admin/sql/updates/2026-07-13-add-user-onboarding-state-table.sql
+++ b/admin/sql/updates/2026-07-13-add-user-onboarding-state-table.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_onboarding_state (
+    user_id      INTEGER     NOT NULL,
+    tour_id      VARCHAR(50) NOT NULL,
+    status       VARCHAR(20) NOT NULL DEFAULT 'not_started',
+    current_step INTEGER     NOT NULL DEFAULT 0,
+    unlock_ready BOOLEAN     NOT NULL DEFAULT FALSE,
+    unlocked_at  TIMESTAMP WITH TIME ZONE,
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE user_onboarding_state ADD CONSTRAINT user_onboarding_state_pkey PRIMARY KEY (user_id, tour_id);
+
+ALTER TABLE user_onboarding_state
+    ADD CONSTRAINT user_onboarding_state_user_id_foreign_key
+    FOREIGN KEY (user_id)
+    REFERENCES "user" (id)
+    ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS user_onboarding_state_user_id_ndx ON user_onboarding_state (user_id);
+
+COMMIT;

--- a/admin/sql/updates/2026-07-13-add-user-onboarding-state-table.sql
+++ b/admin/sql/updates/2026-07-13-add-user-onboarding-state-table.sql
@@ -20,4 +20,10 @@ ALTER TABLE user_onboarding_state
 
 CREATE INDEX IF NOT EXISTS user_onboarding_state_user_id_ndx ON user_onboarding_state (user_id);
 
+-- Pre seed existing users with setup tour marked as skipped so they don't see the auto start popup
+INSERT INTO user_onboarding_state (user_id, tour_id, status, current_step, unlock_ready)
+SELECT id, 'setup', 'skipped', 0, TRUE
+FROM "user"
+ON CONFLICT (user_id, tour_id) DO NOTHING;
+
 COMMIT;

--- a/listenbrainz/db/onboarding.py
+++ b/listenbrainz/db/onboarding.py
@@ -1,0 +1,196 @@
+from typing import Dict
+
+import sqlalchemy
+from listenbrainz import db
+from listenbrainz.webserver import ts_conn
+
+TOURS = ("setup", "listens", "stats", "social")
+
+# Unlock conditions evaluated for each tour
+def _check_unlock_conditions(db_conn, ts_db_conn, user_id: int, tour_id: str) -> bool:
+    """Return True if the tour's unlock condition is met."""
+    if tour_id == "setup":
+        return True
+
+    if tour_id == "listens":
+        # Unlock when user has at least one listen
+        try:
+            result = ts_db_conn.execute(
+                sqlalchemy.text(
+                    "SELECT 1 FROM listen WHERE user_id = :user_id LIMIT 1"
+                ),
+                {"user_id": user_id},
+            )
+            return result.fetchone() is not None
+        except Exception:
+            return False
+
+    if tour_id == "stats":
+        # Unlock when all 6 required stat types exist for the user (week range)
+        REQUIRED_STATS = (
+            "listening_activity",
+            "artists",
+            "release_groups",
+            "recordings",
+            "daily_activity",
+            "artist_map",
+        )
+        result = db_conn.execute(
+            sqlalchemy.text(
+                """
+                SELECT COUNT(DISTINCT stat_type)
+                  FROM user_data
+                 WHERE user_id = :user_id
+                   AND stat_type = ANY(:stat_types)
+                   AND stats_range = 'week'
+                """
+            ),
+            {"user_id": user_id, "stat_types": list(REQUIRED_STATS)},
+        )
+        row = result.fetchone()
+        return row is not None and row[0] >= len(REQUIRED_STATS)
+
+    if tour_id == "social":
+        # Unlock when user follows at least one user AND has similar_users data
+        follows = db_conn.execute(
+            sqlalchemy.text(
+                """
+                SELECT 1 FROM user_relationship
+                 WHERE user_0 = :user_id
+                   AND relationship_type = 'follow'
+                 LIMIT 1
+                """
+            ),
+            {"user_id": user_id},
+        ).fetchone()
+        if not follows:
+            return False
+        similar = db_conn.execute(
+            sqlalchemy.text(
+                "SELECT 1 FROM recommendation.similar_user WHERE user_id = :user_id LIMIT 1"
+            ),
+            {"user_id": user_id},
+        ).fetchone()
+        return similar is not None
+
+    return False
+
+
+def get_onboarding_state(db_conn, user_id: int) -> Dict:
+    """Return onboarding state for all implemented tours."""
+    for tour_id in TOURS:
+        unlock_default = tour_id == "setup"
+        db_conn.execute(
+            sqlalchemy.text(
+                """
+                INSERT INTO user_onboarding_state (user_id, tour_id, status, current_step, unlock_ready)
+                VALUES (:user_id, :tour_id, 'not_started', 0, :unlock_ready)
+                ON CONFLICT (user_id, tour_id) DO NOTHING
+                """
+            ),
+            {"user_id": user_id, "tour_id": tour_id, "unlock_ready": unlock_default},
+        )
+    db_conn.commit()
+
+    result = db_conn.execute(
+        sqlalchemy.text(
+            """
+            SELECT tour_id, status, current_step, unlock_ready
+              FROM user_onboarding_state
+             WHERE user_id = :user_id
+               AND tour_id = ANY(:tour_ids)
+            """
+        ),
+        {"user_id": user_id, "tour_ids": list(TOURS)},
+    )
+    rows = result.mappings().all()
+    state = {row["tour_id"]: dict(row) for row in rows}
+
+    # Evaluate unlock conditions for locked tours.
+    needs_commit = False
+    for tour_id in TOURS:
+        tour = state.get(tour_id, {})
+        if not tour.get("unlock_ready", False):
+            try:
+                unlocked = _check_unlock_conditions(db_conn, ts_conn, user_id, tour_id)
+            except Exception:
+                try:
+                    db_conn.rollback()
+                except Exception:
+                    pass
+                unlocked = False
+
+            if unlocked:
+                db_conn.execute(
+                    sqlalchemy.text(
+                        """
+                        UPDATE user_onboarding_state
+                           SET unlock_ready = TRUE,
+                               unlocked_at = NOW(),
+                               updated_at = NOW()
+                         WHERE user_id = :user_id AND tour_id = :tour_id
+                        """
+                    ),
+                    {"user_id": user_id, "tour_id": tour_id},
+                )
+                state[tour_id]["unlock_ready"] = True
+                needs_commit = True
+
+    if needs_commit:
+        db_conn.commit()
+
+    return {
+        tour_id: {
+            "status": data.get("status", "not_started"),
+            "current_step": data.get("current_step", 0),
+            "unlock_ready": data.get("unlock_ready", False),
+        }
+        for tour_id, data in state.items()
+    }
+
+
+def upsert_onboarding_state(
+    db_conn,
+    user_id: int,
+    tour_id: str,
+    status: str,
+    current_step: int,
+) -> None:
+    """Update the status and step for a specific tour."""
+    if tour_id not in TOURS:
+        return
+    db_conn.execute(
+        sqlalchemy.text(
+            """
+            INSERT INTO user_onboarding_state (user_id, tour_id, status, current_step, updated_at)
+            VALUES (:user_id, :tour_id, :status, :current_step, NOW())
+            ON CONFLICT (user_id, tour_id)
+            DO UPDATE SET
+                status       = EXCLUDED.status,
+                current_step = EXCLUDED.current_step,
+                updated_at   = NOW()
+            """
+        ),
+        {
+            "user_id": user_id,
+            "tour_id": tour_id,
+            "status": status,
+            "current_step": current_step,
+        },
+    )
+    db_conn.commit()
+
+
+def create_setup_onboarding_row(db_conn, user_id: int) -> None:
+    """Seed the setup tour row for a brand new user."""
+    db_conn.execute(
+        sqlalchemy.text(
+            """
+            INSERT INTO user_onboarding_state (user_id, tour_id, status, current_step, unlock_ready)
+            VALUES (:user_id, 'setup', 'not_started', 0, TRUE)
+            ON CONFLICT DO NOTHING
+            """
+        ),
+        {"user_id": user_id},
+    )
+    db_conn.commit()

--- a/listenbrainz/db/onboarding.py
+++ b/listenbrainz/db/onboarding.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 import sqlalchemy
 from listenbrainz import db
+from listenbrainz.db import couchdb
 from listenbrainz.webserver import ts_conn
 
 TOURS = ("setup", "listens", "stats", "social")
@@ -26,7 +27,7 @@ def _check_unlock_conditions(db_conn, ts_db_conn, user_id: int, tour_id: str) ->
             return False
 
     if tour_id == "stats":
-        # Unlock when all 6 required stat types exist for the user (week range)
+        # Unlock when weekly stat type exists for the user.
         REQUIRED_STATS = (
             "listening_activity",
             "artists",
@@ -35,20 +36,15 @@ def _check_unlock_conditions(db_conn, ts_db_conn, user_id: int, tour_id: str) ->
             "daily_activity",
             "artist_map",
         )
-        result = db_conn.execute(
-            sqlalchemy.text(
-                """
-                SELECT COUNT(DISTINCT stat_type)
-                  FROM user_data
-                 WHERE user_id = :user_id
-                   AND stat_type = ANY(:stat_types)
-                   AND stats_range = 'week'
-                """
-            ),
-            {"user_id": user_id, "stat_types": list(REQUIRED_STATS)},
-        )
-        row = result.fetchone()
-        return row is not None and row[0] >= len(REQUIRED_STATS)
+        try:
+            for stat_type in REQUIRED_STATS:
+                prefix = f"{stat_type}_week"
+                data = couchdb.fetch_data(prefix, user_id)
+                if data is not None:
+                    return True
+            return False
+        except Exception:
+            return False
 
     if tour_id == "social":
         # Unlock when user follows at least one user AND has similar_users data

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -548,3 +548,6 @@ def _register_blueprints(app):
 
     from listenbrainz.webserver.views.internet_archive_api import internet_archive_api_bp
     app.register_blueprint(internet_archive_api_bp, url_prefix=API_PREFIX+"/internet_archive")
+
+    from listenbrainz.webserver.views.onboarding_api import onboarding_api_bp
+    app.register_blueprint(onboarding_api_bp, url_prefix=API_PREFIX)

--- a/listenbrainz/webserver/views/onboarding_api.py
+++ b/listenbrainz/webserver/views/onboarding_api.py
@@ -1,0 +1,114 @@
+"""API endpoints for user onboarding state."""
+import orjson
+from flask import Blueprint, jsonify, request
+
+import listenbrainz.db.onboarding as db_onboarding
+import listenbrainz.db.user as db_user
+from listenbrainz.webserver import db_conn
+from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.errors import APIBadRequest, APINotFound, APIUnauthorized
+from listenbrainz.webserver.views.api_tools import validate_auth_header
+from brainzutils.ratelimit import ratelimit
+
+onboarding_api_bp = Blueprint("onboarding_api_v1", __name__)
+
+STATUSES = {"not_started", "in_progress", "skipped", "completed"}
+TOURS = {"setup", "listens", "stats", "social"}
+
+
+@onboarding_api_bp.get("/user/<mb_username:user_name>/onboarding")
+@crossdomain
+@ratelimit()
+def get_onboarding_state(user_name):
+    """Return onboarding state for all tours for the given user.
+
+    .. code-block:: json
+
+        {
+          "setup": {
+            "status": "completed",
+            "current_step": 6,
+            "unlock_ready": true
+          },
+          "listens": {
+            "status": "in_progress",
+            "current_step": 2,
+            "unlock_ready": true
+          },
+          "social": {
+            "status": "not_started",
+            "current_step": 0,
+            "unlock_ready": false
+          }
+        }
+
+    :statuscode 200: Success
+    :statuscode 401: Invalid or missing auth token
+    :statuscode 404: User not found
+    """
+    auth_user = validate_auth_header()
+    if auth_user["musicbrainz_id"] != user_name:
+        raise APIUnauthorized("You can only view your own onboarding state.")
+
+    user = db_user.get_by_mb_id(db_conn, user_name)
+    if user is None:
+        raise APINotFound("Cannot find user: %s" % user_name)
+
+    state = db_onboarding.get_onboarding_state(db_conn, user["id"])
+    return jsonify(state)
+
+
+@onboarding_api_bp.post("/user/<mb_username:user_name>/onboarding")
+@crossdomain
+@ratelimit()
+def update_onboarding_state(user_name):
+    """Update progress for a specific onboarding tour.
+
+    .. code-block:: json
+
+        {
+          "tour_id": "listens",
+          "status": "in_progress",
+          "current_step": 3
+        }
+
+    :reqheader Authorization: Token <user token>
+    :reqheader Content-Type: application/json
+    :resheader Content-Type: *application/json*
+    :statuscode 200: Success
+    :statuscode 400: Invalid request body
+    :statuscode 401: Invalid or missing auth token
+    :statuscode 404: User not found
+    """
+    auth_user = validate_auth_header()
+    if auth_user["musicbrainz_id"] != user_name:
+        raise APIUnauthorized("You can only update your own onboarding state.")
+
+    user = db_user.get_by_mb_id(db_conn, user_name)
+    if user is None:
+        raise APINotFound("Cannot find user: %s" % user_name)
+
+    try:
+        data = orjson.loads(request.get_data())
+    except (ValueError, TypeError) as e:
+        raise APIBadRequest("Invalid JSON: %s" % str(e))
+
+    tour_id = data.get("tour_id")
+    status = data.get("status")
+    current_step = data.get("current_step")
+
+    if tour_id not in TOURS:
+        raise APIBadRequest("Invalid tour_id. Must be one of: %s" % ", ".join(sorted(TOURS)))
+    if status not in STATUSES:
+        raise APIBadRequest("Invalid status. Must be one of: %s" % ", ".join(sorted(STATUSES)))
+    if not isinstance(current_step, int) or current_step < 0:
+        raise APIBadRequest("current_step must be a non-negative integer.")
+
+    db_onboarding.upsert_onboarding_state(
+        db_conn,
+        user_id=user["id"],
+        tour_id=tour_id,
+        status=status,
+        current_step=current_step,
+    )
+    return jsonify({"status": "success"})


### PR DESCRIPTION
This PR implements the core database schema, logic, and api endpoints for user onboarding:

#### 1. Database Schema 

* Created the `user_onboarding_state` table to track tour `status` , `current_step`, and `unlock_ready` flag for each tour.

#### 2. Backend Logic
* Implemented `listenbrainz/db/onboarding.py` to handle querying and updating tour states, along with assessing unlock conditions (e.g. checking if a user has listens, follows, or stats generated before unlocking respective tours).

#### 3. API Endpoints
* Implemented `listenbrainz/webserver/views/onboarding_api.py` 
  * `GET /1/user/<username>/onboarding`: Fetch current statuses for all tours for that user.
  * `POST /1/user/<username>/onboarding`: Upsert tour progress and step indices for that user.

I tested both api endpoint and its working fine, also tested the unlock conditions.

### AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

Use gemini to test sql query for unlock condition by injecting mock data.

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR


### Action

Run [admin/sql/updates/2026-07-13-add-user-onboarding-state-table.sql](https://github.com/meekhumor/listenbrainz-server/blob/onboarding-backend/admin/sql/updates/2026-07-13-add-user-onboarding-state-table.sql) to migrate existing databases. It also includes a pre seeding query that marks the setup Tour as `skipped` for legacy users to prevent them from seeing unwanted auto start popups.
