### PR TITLE
GSOC-26 Musicbrainz collections import for Recording Collections

### DIFF
--- a/frontend/js/src/user/playlists/Playlists.tsx
+++ b/frontend/js/src/user/playlists/Playlists.tsx
@@ -4,6 +4,7 @@ import {
   faUsers,
   faFileImport,
   faMagnifyingGlass,
+  faMusic,
 } from "@fortawesome/free-solid-svg-icons";
 import {
   faSpotify,
@@ -29,6 +30,7 @@ import ImportPlaylistModal from "./components/ImportJSPFPlaylistModal";
 import ImportSpotifyPlaylistModal from "./components/ImportSpotifyPlaylistModal";
 import ImportAppleMusicPlaylistModal from "./components/ImportAppleMusicPlaylistModal";
 import ImportSoundCloudPlaylistModal from "./components/ImportSoundCloudPlaylistModal";
+import ImportMusicBrainzCollectionModal from "./components/ImportMusicBrainzCollectionModal";
 import PlaylistsList from "./components/PlaylistsList";
 import {
   getPlaylistExtension,
@@ -621,6 +623,16 @@ export default class UserPlaylists extends React.Component<
                     >
                       <FontAwesomeIcon icon={faFileImport} />
                       &nbsp;Upload JSPF file
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        NiceModal.show(ImportMusicBrainzCollectionModal);
+                      }}
+                      className="dropdown-item"
+                    >
+                      <FontAwesomeIcon icon={faMusic} />
+                      &nbsp;MusicBrainz
                     </button>
                   </ul>
                 </div>

--- a/frontend/js/src/user/playlists/components/ImportMusicBrainzCollectionModal.tsx
+++ b/frontend/js/src/user/playlists/components/ImportMusicBrainzCollectionModal.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import NiceModal, { bootstrapDialog, useModal } from "@ebay/nice-modal-react";
+import { Modal } from "react-bootstrap";
+import { toast } from "react-toastify";
+import { useNavigate } from "react-router";
+
+import GlobalAppContext from "../../../utils/GlobalAppContext";
+import { ToastMsg } from "../../../notifications/Notifications";
+import Loader from "../../../components/Loader";
+import type { MusicBrainzCollectionSummary } from "../../../utils/APIService";
+
+export default NiceModal.create(() => {
+  const modal = useModal();
+  const navigate = useNavigate();
+  const { APIService, currentUser } = React.useContext(GlobalAppContext);
+
+  const [collections, setCollections] = React.useState<
+    MusicBrainzCollectionSummary[]
+  >([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    async function loadCollections() {
+      if (!currentUser?.auth_token) {
+        toast.error(
+          <ToastMsg
+            title="Error"
+            message="You must be logged in for this operation"
+          />,
+          { toastId: "auth-error" }
+        );
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const result = await APIService.getMusicBrainzCollections(
+          currentUser.auth_token
+        );
+        setCollections(result);
+      } catch (error) {
+        toast.error(
+          <ToastMsg
+            title="Error loading collections"
+            message={error?.message ?? error}
+          />,
+          { toastId: "load-collections-error" }
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    loadCollections();
+  }, [APIService, currentUser]);
+
+  const close = () => {
+    modal.hide();
+  };
+
+  const openCollection = (collectionMbid: string) => {
+    close();
+    navigate(`/collection/${collectionMbid}`);
+  };
+
+  return (
+    <Modal
+      {...bootstrapDialog(modal)}
+      title="Import collections from MusicBrainz"
+      aria-labelledby="ImportMBCollectionsModalLabel"
+      id="ImportMBCollectionsModal"
+    >
+      <Modal.Header closeButton>
+        <Modal.Title id="ImportMBCollectionsModalLabel">
+          Import collections from MusicBrainz
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div
+          className="list-group"
+          style={{ maxHeight: "50vh", overflow: "auto" }}
+        >
+          {collections.map((collection) => (
+            <button
+              type="button"
+              key={collection.mbid}
+              className="list-group-item list-group-item-action"
+              disabled={isLoading}
+              onClick={() => openCollection(collection.mbid)}
+            >
+              <div style={{ fontWeight: 600 }}>{collection.name}</div>
+              <div className="text-muted">
+                {collection.item_count} recordings
+              </div>
+            </button>
+          ))}
+        </div>
+        <Loader isLoading={isLoading} />
+      </Modal.Body>
+      <Modal.Footer>
+        <button type="button" className="btn btn-secondary" onClick={close}>
+          Close
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+});

--- a/frontend/js/src/user/playlists/components/ImportMusicBrainzCollectionModal.tsx
+++ b/frontend/js/src/user/playlists/components/ImportMusicBrainzCollectionModal.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import NiceModal, { bootstrapDialog, useModal } from "@ebay/nice-modal-react";
 import { Modal } from "react-bootstrap";
 import { toast } from "react-toastify";
-import { useNavigate } from "react-router";
 
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 import { ToastMsg } from "../../../notifications/Notifications";
@@ -11,7 +10,6 @@ import type { MusicBrainzCollectionSummary } from "../../../utils/APIService";
 
 export default NiceModal.create(() => {
   const modal = useModal();
-  const navigate = useNavigate();
   const { APIService, currentUser } = React.useContext(GlobalAppContext);
 
   const [collections, setCollections] = React.useState<
@@ -58,11 +56,6 @@ export default NiceModal.create(() => {
     modal.hide();
   };
 
-  const openCollection = (collectionMbid: string) => {
-    close();
-    navigate(`/collection/${collectionMbid}`);
-  };
-
   return (
     <Modal
       {...bootstrapDialog(modal)}
@@ -80,20 +73,20 @@ export default NiceModal.create(() => {
           className="list-group"
           style={{ maxHeight: "50vh", overflow: "auto" }}
         >
-          {collections.map((collection) => (
-            <button
-              type="button"
-              key={collection.mbid}
-              className="list-group-item list-group-item-action"
-              disabled={isLoading}
-              onClick={() => openCollection(collection.mbid)}
-            >
-              <div style={{ fontWeight: 600 }}>{collection.name}</div>
-              <div className="text-muted">
-                {collection.item_count} recordings
+          {!isLoading && collections.length === 0 ? (
+            <p className="text-center text-muted mb-0">
+              No recording collections found
+            </p>
+          ) : (
+            collections.map((collection) => (
+              <div key={collection.mbid} className="list-group-item">
+                <div style={{ fontWeight: 600 }}>{collection.name}</div>
+                <div className="text-muted">
+                  {collection.item_count} recordings
+                </div>
               </div>
-            </button>
-          ))}
+            ))
+          )}
         </div>
         <Loader isLoading={isLoading} />
       </Modal.Body>

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -13,6 +13,13 @@ export interface LBRadioResponse {
   payload: { jspf: JSPFObject; feedback: string[] };
 }
 
+export type MusicBrainzCollectionSummary = {
+  mbid: string;
+  name: string;
+  public: boolean;
+  item_count: number;
+};
+
 export default class APIService {
   APIBaseURI: string;
 
@@ -1563,6 +1570,24 @@ export default class APIService {
     playlistID: string
   ): Promise<any> => {
     const url = `${this.APIBaseURI}/playlist/soundcloud/${playlistID}/tracks`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Token ${userToken}`,
+        "Content-Type": "application/json;charset=UTF-8",
+      },
+    });
+    await this.checkStatus(response);
+    return response.json();
+  };
+
+  getMusicBrainzCollections = async (
+    userToken: string
+  ): Promise<MusicBrainzCollectionSummary[]> => {
+    if (!userToken) {
+      throw new SyntaxError("User token missing");
+    }
+    const url = `${this.APIBaseURI}/playlist/import/musicbrainz/collections`;
     const response = await fetch(url, {
       method: "GET",
       headers: {

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -160,3 +160,50 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
             mock_fetch.call_args.kwargs["viewer_editor_id"],
             self.bob["musicbrainz_row_id"],
         )
+
+    def test_collection_detail_invalid_mbid_returns_400(self):
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="not-a-valid-mbid",
+            )
+        )
+
+        self.assert400(response)
+        self.assertIn("invalid", response.json["error"].lower())
+
+    def test_collection_detail_count_above_max_returns_400(self):
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            )
+            + "?count=501"
+        )
+
+        self.assert400(response)
+        self.assertIn("count", response.json["error"].lower())
+
+    def test_collection_detail_count_zero_returns_400(self):
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            )
+            + "?count=0"
+        )
+
+        self.assert400(response)
+        self.assertIn("count", response.json["error"].lower())
+
+    def test_collection_detail_negative_offset_returns_400(self):
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            )
+            + "?offset=-1"
+        )
+
+        self.assert400(response)
+        self.assertIn("offset", response.json["error"].lower())

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -1,0 +1,177 @@
+from unittest import mock
+
+import listenbrainz.db.user as db_user
+from listenbrainz.tests.integration import IntegrationTestCase
+
+
+class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Test users
+        self.alice = db_user.get_or_create(self.db_conn, 1, "alice")
+        self.bob = db_user.get_or_create(self.db_conn, 2, "bob")
+
+        self.app.config["MB_DATABASE_URI"] = "postgresql://musicbrainz"
+
+    def test_list_collections_requires_authentication(self):
+        response = self.client.get(
+            self.custom_url_for("playlist_api_v1.import_musicbrainz_collections")
+        )
+
+        self.assert401(response)
+
+    @mock.patch("listenbrainz.webserver.views.playlist_api.psycopg2.connect")
+    def test_list_collections_returns_expected_response(self, mock_connect):
+        fake_cursor = mock.MagicMock()
+
+        fake_cursor.fetchall.return_value = [
+            {
+                "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "name": "Road Trip Songs",
+                "public": True,
+                "item_count": 2,
+            },
+            {
+                "mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "name": "Private Favorites",
+                "public": False,
+                "item_count": 0,
+            },
+        ]
+
+        fake_connection = mock.MagicMock()
+
+        mock_connect.return_value.__enter__.return_value = fake_connection
+
+
+        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        response = self.client.get(
+            self.custom_url_for("playlist_api_v1.import_musicbrainz_collections"),
+            headers={"Authorization": f"Token {self.alice['auth_token']}"},
+        )
+
+        self.assert200(response)
+
+        self.assertEqual(
+            response.json,
+            [
+                {
+                    "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "name": "Road Trip Songs",
+                    "public": True,
+                    "item_count": 2,
+                },
+                {
+                    "mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "name": "Private Favorites",
+                    "public": False,
+                    "item_count": 0,
+                },
+            ],
+        )
+
+    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
+    def test_public_collection_can_be_viewed_without_login(self, mock_connect):
+        fake_cursor = mock.MagicMock()
+
+    
+        fake_cursor.fetchone.side_effect = [
+            {
+                "collection_id": 123,
+                "collection_mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "name": "Road Trip Songs",
+                "public": True,
+                "owner_editor_id": 1,
+            },
+            {"track_count": 1},
+        ]
+
+        fake_cursor.fetchall.return_value = [
+            {
+                "recording_mbid": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                "title": "Night Drive",
+                "artist_credit_name": "The Midnight",
+                "length": 123000,
+            }
+        ]
+
+        fake_connection = mock.MagicMock()
+
+        mock_connect.return_value.__enter__.return_value = fake_connection
+        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            )
+        )
+
+        self.assert200(response)
+
+        self.assertEqual(
+            response.json["collection"]["mbid"],
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+        self.assertEqual(
+            response.json["collection"]["name"],
+            "Road Trip Songs",
+        )
+        self.assertEqual(response.json["collection"]["public"], True)
+        self.assertEqual(response.json["track_count"], 1)
+        self.assertEqual(len(response.json["tracks"]), 1)
+
+    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
+    def test_private_collection_requires_login(self, mock_connect):
+        fake_cursor = mock.MagicMock()
+
+        fake_cursor.fetchone.return_value = {
+            "collection_id": 123,
+            "collection_mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "name": "Private Favorites",
+            "public": False,
+            "owner_editor_id": 1,
+        }
+
+        fake_connection = mock.MagicMock()
+
+        mock_connect.return_value.__enter__.return_value = fake_connection
+        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            )
+        )
+
+        self.assert401(response)
+
+    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
+    def test_private_collection_blocks_other_users(self, mock_connect):
+        fake_cursor = mock.MagicMock()
+
+        fake_cursor.fetchone.return_value = {
+            "collection_id": 123,
+            "collection_mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "name": "Private Favorites",
+            "public": False,
+            "owner_editor_id": 1,
+        }
+
+        fake_connection = mock.MagicMock()
+
+        mock_connect.return_value.__enter__.return_value = fake_connection
+        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+
+        response = self.client.get(
+            self.custom_url_for(
+                "playlist_api_v1.import_musicbrainz_collection_detail",
+                collection_mbid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            ),
+            headers={"Authorization": f"Token {self.bob['auth_token']}"},
+        )
+
+        self.assert403(response)

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -1,14 +1,15 @@
 from unittest import mock
 
+import psycopg2
 import listenbrainz.db.user as db_user
 from listenbrainz.tests.integration import IntegrationTestCase
 
+_REAL_PSYCOPG2_CONNECT = psycopg2.connect
 
 class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
     def setUp(self):
         super().setUp()
 
-        # Test users
         self.alice = db_user.get_or_create(self.db_conn, 1, "alice")
         self.bob = db_user.get_or_create(self.db_conn, 2, "bob")
 
@@ -21,10 +22,10 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
 
         self.assert401(response)
 
+    @mock.patch("listenbrainz.webserver.views.playlist_api.DictCursor", new=mock.MagicMock)
     @mock.patch("listenbrainz.webserver.views.playlist_api.psycopg2.connect")
     def test_list_collections_returns_expected_response(self, mock_connect):
         fake_cursor = mock.MagicMock()
-
         fake_cursor.fetchall.return_value = [
             {
                 "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -40,12 +41,19 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
             },
         ]
 
-        fake_connection = mock.MagicMock()
+        fake_mb_conn = mock.MagicMock()
+        fake_mb_conn.__enter__.return_value.cursor.return_value.__enter__.return_value = (
+            fake_cursor
+        )
 
-        mock_connect.return_value.__enter__.return_value = fake_connection
+        mb_dsn = self.app.config["MB_DATABASE_URI"]
 
+        def connect_side_effect(*args, **kwargs):
+            if args and args[0] == mb_dsn:
+                return fake_mb_conn
+            return _REAL_PSYCOPG2_CONNECT(*args, **kwargs)
 
-        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+        mock_connect.side_effect = connect_side_effect
 
         response = self.client.get(
             self.custom_url_for("playlist_api_v1.import_musicbrainz_collections"),
@@ -72,35 +80,29 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
             ],
         )
 
-    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
-    def test_public_collection_can_be_viewed_without_login(self, mock_connect):
-        fake_cursor = mock.MagicMock()
-
-    
-        fake_cursor.fetchone.side_effect = [
+    @mock.patch("listenbrainz.webserver.views.playlist_api.fetch_collection_payload")
+    def test_public_collection_can_be_viewed_without_login(self, mock_fetch):
+        mock_fetch.return_value = (
             {
-                "collection_id": 123,
-                "collection_mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-                "name": "Road Trip Songs",
-                "public": True,
-                "owner_editor_id": 1,
+                "collection": {
+                    "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "name": "Road Trip Songs",
+                    "public": True,
+                },
+                "track_count": 1,
+                "count": 100,
+                "offset": 0,
+                "tracks": [
+                    {
+                        "recording_mbid": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        "title": "Night Drive",
+                        "artist_credit_name": "The Midnight",
+                        "length": 123000,
+                    }
+                ],
             },
-            {"track_count": 1},
-        ]
-
-        fake_cursor.fetchall.return_value = [
-            {
-                "recording_mbid": "cccccccc-cccc-cccc-cccc-cccccccccccc",
-                "title": "Night Drive",
-                "artist_credit_name": "The Midnight",
-                "length": 123000,
-            }
-        ]
-
-        fake_connection = mock.MagicMock()
-
-        mock_connect.return_value.__enter__.return_value = fake_connection
-        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+            None,
+        )
 
         response = self.client.get(
             self.custom_url_for(
@@ -110,35 +112,23 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
         )
 
         self.assert200(response)
-
         self.assertEqual(
             response.json["collection"]["mbid"],
             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
         )
-        self.assertEqual(
-            response.json["collection"]["name"],
-            "Road Trip Songs",
-        )
+        self.assertEqual(response.json["collection"]["name"], "Road Trip Songs")
         self.assertEqual(response.json["collection"]["public"], True)
         self.assertEqual(response.json["track_count"], 1)
         self.assertEqual(len(response.json["tracks"]), 1)
+        mock_fetch.assert_called_once()
+        self.assertIsNone(mock_fetch.call_args.kwargs["viewer_editor_id"])
 
-    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
-    def test_private_collection_requires_login(self, mock_connect):
-        fake_cursor = mock.MagicMock()
-
-        fake_cursor.fetchone.return_value = {
-            "collection_id": 123,
-            "collection_mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-            "name": "Private Favorites",
-            "public": False,
-            "owner_editor_id": 1,
-        }
-
-        fake_connection = mock.MagicMock()
-
-        mock_connect.return_value.__enter__.return_value = fake_connection
-        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+    @mock.patch("listenbrainz.webserver.views.playlist_api.fetch_collection_payload")
+    def test_private_collection_requires_login(self, mock_fetch):
+        mock_fetch.return_value = (
+            None,
+            ({"error": "You must be logged in to access this collection"}, 401),
+        )
 
         response = self.client.get(
             self.custom_url_for(
@@ -149,22 +139,12 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
 
         self.assert401(response)
 
-    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
-    def test_private_collection_blocks_other_users(self, mock_connect):
-        fake_cursor = mock.MagicMock()
-
-        fake_cursor.fetchone.return_value = {
-            "collection_id": 123,
-            "collection_mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-            "name": "Private Favorites",
-            "public": False,
-            "owner_editor_id": 1,
-        }
-
-        fake_connection = mock.MagicMock()
-
-        mock_connect.return_value.__enter__.return_value = fake_connection
-        fake_connection.cursor.return_value.__enter__.return_value = fake_cursor
+    @mock.patch("listenbrainz.webserver.views.playlist_api.fetch_collection_payload")
+    def test_private_collection_blocks_other_users(self, mock_fetch):
+        mock_fetch.return_value = (
+            None,
+            ({"error": "You are not allowed to access this collection"}, 403),
+        )
 
         response = self.client.get(
             self.custom_url_for(
@@ -175,3 +155,8 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
         )
 
         self.assert403(response)
+        mock_fetch.assert_called_once()
+        self.assertEqual(
+            mock_fetch.call_args.kwargs["viewer_editor_id"],
+            self.bob["musicbrainz_row_id"],
+        )

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -440,6 +440,9 @@ def _register_blueprints(app):
     from listenbrainz.webserver.views.playlist import playlist_bp
     app.register_blueprint(playlist_bp, url_prefix='/playlist')
 
+    from listenbrainz.webserver.views.collection import collection_bp
+    app.register_blueprint(collection_bp, url_prefix='/collection')
+
     from listenbrainz.webserver.views.settings import settings_bp
     app.register_blueprint(settings_bp, url_prefix='/settings')
     # Retro-compatible 'profile' endpoint

--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -48,6 +48,23 @@ def api_listenstore_needed(func):
     return decorator
 
 
+def api_musicbrainz_needed(func):
+    """
+      This API decorator checks to see if musicbrainz db is online by checking a config variable 
+      and if not , it raises APIServiceUnavailable
+    """
+    @wraps(func)
+    def decorator(*args, **kwargs):
+        from listenbrainz.webserver.errors import APIServiceUnavailable
+        is_musicbrainz_up = current_app.config.get("IS_MUSICBRAINZ_UP", True)
+        if not is_musicbrainz_up:
+            raise APIServiceUnavailable("The MusicBrainz database is momentarily offline. " +
+                                        "Please wait a few minutes and try again.")
+        return func(*args, **kwargs)
+
+    return decorator
+  
+
 def web_listenstore_needed(func):
     """
         This web decorator checks to see if timescale is online (by having

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -408,6 +408,25 @@ def get_non_negative_param(param, default=None):
     return value
 
 
+def get_positive_param(param, default=None):
+    """ Gets the value of a request parameter, validating that it is a positive integer (> 0).
+
+    Args:
+        param (str): the parameter to get
+        default: the value to return if the parameter doesn't exist in the request
+    """
+    value = request.args.get(param, default)
+    if value is not None:
+        try:
+            value = int(value)
+        except ValueError:
+            raise APIBadRequest("'{}' should be a positive integer".format(param))
+
+        if value <= 0:
+            raise APIBadRequest("'{}' should be a positive integer".format(param))
+    return value
+
+
 def parse_param_list(params: str) -> list:
     """ Splits a string of comma separated values into a list """
     param_list = []

--- a/listenbrainz/webserver/views/collection.py
+++ b/listenbrainz/webserver/views/collection.py
@@ -1,0 +1,153 @@
+import psycopg2
+from psycopg2.extras import DictCursor
+
+from flask import Blueprint, current_app, jsonify, render_template, request
+from flask_login import current_user
+
+from listenbrainz.webserver.decorators import web_listenstore_needed
+from listenbrainz.webserver.views.api_tools import is_valid_uuid
+from listenbrainz.webserver.views.api_tools import get_non_negative_param
+
+
+collection_bp = Blueprint("collection", __name__)
+
+DEFAULT_COLLECTION_TRACKS_PER_CALL = 100
+MAX_COLLECTION_TRACKS_PER_CALL = 500
+
+
+def _fetch_collection_row(mb_curs, collection_mbid: str):
+    mb_curs.execute(
+        """
+          SELECT ec.id AS collection_id
+               , ec.gid::text AS collection_mbid
+               , ec.name AS name
+               , ec.public AS public
+               , ec.editor AS owner_editor_id
+            FROM musicbrainz.editor_collection ec
+           WHERE ec.gid = %s
+        """,
+        (collection_mbid,),
+    )
+    return mb_curs.fetchone()
+
+
+def _fetch_recording_collection_track_count(mb_curs, collection_id: int) -> int:
+    mb_curs.execute(
+        """
+          SELECT COUNT(*)::int AS track_count
+            FROM musicbrainz.editor_collection_recording ecr
+           WHERE ecr.collection = %s
+        """,
+        (collection_id,),
+    )
+    row = mb_curs.fetchone()
+    return int(row["track_count"] or 0)
+
+
+def _fetch_recording_collection_tracks(mb_curs, collection_id: int, *, count: int, offset: int):
+    mb_curs.execute(
+        """
+          SELECT r.gid::text AS recording_mbid
+               , r.name AS title
+               , r.length AS length
+               , ac.name AS artist_credit_name
+            FROM musicbrainz.editor_collection_recording ecr
+            JOIN musicbrainz.recording r
+              ON r.id = ecr.recording
+            JOIN musicbrainz.artist_credit ac
+              ON ac.id = r.artist_credit
+           WHERE ecr.collection = %s
+           ORDER BY ecr.position NULLS LAST, ecr.id
+           LIMIT %s OFFSET %s
+        """,
+        (collection_id, count, offset),
+    )
+    return mb_curs.fetchall()
+
+
+def fetch_collection_payload(collection_mbid: str, *, viewer_editor_id: int | None, count: int, offset: int):
+    """Fetch collection and tracks from the MusicBrainz database.
+    """
+    if not is_valid_uuid(collection_mbid):
+        return None, ({"error": f"Provided collection ID is invalid: {collection_mbid}"}, 400)
+
+    if not current_app.config.get("MB_DATABASE_URI"):
+        return None, ({"error": "MusicBrainz database is not configured on this server"}, 503)
+
+    if count <= 0:
+        return None, ({"error": "count must be a positive integer"}, 400)
+    if count > MAX_COLLECTION_TRACKS_PER_CALL:
+        return None, ({"error": f"count must be <= {MAX_COLLECTION_TRACKS_PER_CALL}"}, 400)
+    if offset < 0:
+        return None, ({"error": "offset must be a non-negative integer"}, 400)
+
+    try:
+        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
+                mb_conn.cursor(cursor_factory=DictCursor) as mb_curs:
+            collection = _fetch_collection_row(mb_curs, collection_mbid)
+            if not collection:
+                return None, ({"error": f"Collection {collection_mbid} not found in the MusicBrainz database"}, 404)
+
+            if not collection["public"]:
+                if viewer_editor_id is None:
+                    return None, ({"error": "You must be logged in to access this collection"}, 401)
+                if int(collection["owner_editor_id"]) != int(viewer_editor_id):
+                    return None, ({"error": "You are not allowed to access this collection"}, 403)
+
+            collection_id = int(collection["collection_id"])
+            track_count = _fetch_recording_collection_track_count(mb_curs, collection_id)
+            tracks = _fetch_recording_collection_tracks(
+                mb_curs,
+                collection_id,
+                count=count,
+                offset=offset,
+            )
+    except Exception:
+        current_app.logger.error("Error fetching MusicBrainz collection:", exc_info=True)
+        return None, ({"error": "Failed to fetch collection from MusicBrainz. Please try again."}, 500)
+
+    payload = {
+        "collection": {
+            "mbid": collection["collection_mbid"],
+            "name": collection["name"],
+            "public": bool(collection["public"]),
+        },
+        "track_count": track_count,
+        "count": count,
+        "offset": offset,
+        "tracks": [
+            {
+                "recording_mbid": t["recording_mbid"],
+                "title": t["title"],
+                "artist_credit_name": t["artist_credit_name"],
+                "length": t["length"],
+            }
+            for t in tracks
+        ],
+    }
+    return payload, None
+
+
+@collection_bp.get("/", defaults={"collection_mbid": ""})
+@collection_bp.get("/<collection_mbid>/")
+def collection_page(collection_mbid: str):
+    return render_template("index.html")
+
+
+@collection_bp.post("/<collection_mbid>/")
+@web_listenstore_needed
+def load_collection(collection_mbid: str):
+    viewer_editor_id = current_user.musicbrainz_row_id if current_user.is_authenticated else None
+    count = get_non_negative_param("count", DEFAULT_COLLECTION_TRACKS_PER_CALL)
+    offset = get_non_negative_param("offset", 0)
+    payload, error = fetch_collection_payload(
+        collection_mbid,
+        viewer_editor_id=viewer_editor_id,
+        count=count,
+        offset=offset,
+    )
+    if error:
+        body, code = error
+        return jsonify(body), code
+    return jsonify(payload)
+

--- a/listenbrainz/webserver/views/collection.py
+++ b/listenbrainz/webserver/views/collection.py
@@ -1,12 +1,13 @@
 import psycopg2
 from psycopg2.extras import DictCursor
 
-from flask import Blueprint, current_app, jsonify, render_template, request
+from flask import Blueprint, current_app, jsonify, render_template
 from flask_login import current_user
+from brainzutils.ratelimit import ratelimit
 
-from listenbrainz.webserver.decorators import web_listenstore_needed
+from listenbrainz.webserver.decorators import crossdomain, web_musicbrainz_needed
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
-from listenbrainz.webserver.views.api_tools import get_non_negative_param
+from listenbrainz.webserver.views.api_tools import get_non_negative_param, get_positive_param
 
 
 collection_bp = Blueprint("collection", __name__)
@@ -57,7 +58,7 @@ def _fetch_recording_collection_tracks(mb_curs, collection_id: int, *, count: in
             JOIN musicbrainz.artist_credit ac
               ON ac.id = r.artist_credit
            WHERE ecr.collection = %s
-           ORDER BY ecr.position NULLS LAST, ecr.id
+           ORDER BY ecr.position NULLS LAST, ecr.recording
            LIMIT %s OFFSET %s
         """,
         (collection_id, count, offset),
@@ -135,10 +136,12 @@ def collection_page(collection_mbid: str):
 
 
 @collection_bp.post("/<collection_mbid>/")
-@web_listenstore_needed
+@crossdomain
+@ratelimit()
+@web_musicbrainz_needed
 def load_collection(collection_mbid: str):
     viewer_editor_id = current_user.musicbrainz_row_id if current_user.is_authenticated else None
-    count = get_non_negative_param("count", DEFAULT_COLLECTION_TRACKS_PER_CALL)
+    count = get_positive_param("count", DEFAULT_COLLECTION_TRACKS_PER_CALL)
     offset = get_non_negative_param("offset", 0)
     payload, error = fetch_collection_payload(
         collection_mbid,
@@ -150,4 +153,3 @@ def load_collection(collection_mbid: str):
         body, code = error
         return jsonify(body), code
     return jsonify(payload)
-

--- a/listenbrainz/webserver/views/collection.py
+++ b/listenbrainz/webserver/views/collection.py
@@ -1,15 +1,12 @@
 import psycopg2
 from psycopg2.extras import DictCursor
 
-from flask import Blueprint, current_app, jsonify, render_template
+from flask import Blueprint, current_app,render_template
 from flask_login import current_user
 from brainzutils.ratelimit import ratelimit
 
-from listenbrainz.webserver.decorators import crossdomain, web_musicbrainz_needed
+from listenbrainz.webserver.decorators import web_musicbrainz_needed
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
-from listenbrainz.webserver.views.api_tools import get_non_negative_param, get_positive_param
-
-
 collection_bp = Blueprint("collection", __name__)
 
 DEFAULT_COLLECTION_TRACKS_PER_CALL = 100
@@ -127,29 +124,10 @@ def fetch_collection_payload(collection_mbid: str, *, viewer_editor_id: int | No
         ],
     }
     return payload, None
-
-
+ 
 @collection_bp.get("/", defaults={"collection_mbid": ""})
 @collection_bp.get("/<collection_mbid>/")
+@web_musicbrainz_needed
 def collection_page(collection_mbid: str):
     return render_template("index.html")
 
-
-@collection_bp.post("/<collection_mbid>/")
-@crossdomain
-@ratelimit()
-@web_musicbrainz_needed
-def load_collection(collection_mbid: str):
-    viewer_editor_id = current_user.musicbrainz_row_id if current_user.is_authenticated else None
-    count = get_positive_param("count", DEFAULT_COLLECTION_TRACKS_PER_CALL)
-    offset = get_non_negative_param("offset", 0)
-    payload, error = fetch_collection_payload(
-        collection_mbid,
-        viewer_editor_id=viewer_editor_id,
-        count=count,
-        offset=offset,
-    )
-    if error:
-        body, code = error
-        return jsonify(body), code
-    return jsonify(payload)

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -10,6 +10,7 @@ from psycopg2.extras import DictCursor
 
 import listenbrainz.db.playlist as db_playlist
 import listenbrainz.db.user as db_user
+from listenbrainz.webserver.views.collection import fetch_collection_payload
 from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_PLAYLIST_PERMISSIONS
 from listenbrainz.domain.apple import AppleService
 from listenbrainz.domain.soundcloud import SoundCloudService
@@ -1077,6 +1078,86 @@ def import_playlist_from_music_service(service):
     except requests.exceptions.HTTPError as exc:
         error = exc.response.json()
         raise APIError(error.get("error") or exc.response.reason, exc.response.status_code)
+
+
+@playlist_api_bp.get("/import/musicbrainz/collections")
+@crossdomain
+@ratelimit()
+@api_listenstore_needed
+def import_musicbrainz_collections():
+    """List the authenticated user's MusicBrainz recording collections."""
+    user = validate_auth_header()
+
+    if not current_app.config.get("MB_DATABASE_URI"):
+        raise APIInternalServerError("MusicBrainz database is not configured on this server.")
+
+    if not user.get("musicbrainz_row_id"):
+        raise APIInternalServerError("Cannot determine MusicBrainz editor id for this user.")
+
+    try:
+        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
+                mb_conn.cursor(cursor_factory=DictCursor) as mb_curs:
+            mb_curs.execute(
+                """
+                  SELECT ec.gid::text AS mbid
+                       , ec.name AS name
+                       , ec.public AS public
+                       , COUNT(ecr.recording) AS item_count
+                    FROM musicbrainz.editor_collection ec
+               LEFT JOIN musicbrainz.editor_collection_recording ecr
+                      ON ecr.collection = ec.id
+                   WHERE ec.editor = %s
+                GROUP BY ec.id
+                ORDER BY LOWER(ec.name)
+                """,
+                (user["musicbrainz_row_id"],),
+            )
+            collections = mb_curs.fetchall()
+    except Exception:
+        current_app.logger.error("Error fetching MusicBrainz collections:", exc_info=True)
+        raise APIInternalServerError("Failed to fetch MusicBrainz collections. Please try again.")
+
+    return jsonify([
+        {
+            "mbid": row["mbid"],
+            "name": row["name"],
+            "public": bool(row["public"]),
+            "item_count": int(row["item_count"] or 0),
+        }
+        for row in collections
+    ])
+
+
+@playlist_api_bp.get("/import/musicbrainz/collections/<collection_mbid>")
+@crossdomain
+@ratelimit()
+@api_listenstore_needed
+def import_musicbrainz_collection_detail(collection_mbid):
+    """Fetch a MusicBrainz collection as a read-only track list for preview"""
+    user = validate_auth_header(optional=True)
+    viewer_editor_id = user.get("musicbrainz_row_id") if user else None
+
+    count = get_non_negative_param("count", 100)
+    offset = get_non_negative_param("offset", 0)
+    payload, error = fetch_collection_payload(
+        collection_mbid,
+        viewer_editor_id=viewer_editor_id,
+        count=count,
+        offset=offset,
+    )
+    if error:
+        body, code = error
+        if code == 503:
+            raise APIInternalServerError(body.get("error"))
+        if code == 404:
+            raise APINotFound(body.get("error"))
+        if code == 401:
+            raise APIUnauthorized(body.get("error"))
+        if code == 403:
+            raise APIForbidden(body.get("error"))
+        raise APIInternalServerError(body.get("error"))
+
+    return jsonify(payload)
 
 
 @playlist_api_bp.get("/spotify/<playlist_id>/tracks")

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -1104,9 +1104,12 @@ def import_musicbrainz_collections():
                        , ec.public AS public
                        , COUNT(ecr.recording) AS item_count
                     FROM musicbrainz.editor_collection ec
+                    JOIN musicbrainz.editor_collection_type ect
+                      ON ect.id = ec.type
                LEFT JOIN musicbrainz.editor_collection_recording ecr
                       ON ecr.collection = ec.id
                    WHERE ec.editor = %s
+                     AND ect.entity_type = 'recording'
                 GROUP BY ec.id
                 ORDER BY LOWER(ec.name)
                 """,
@@ -1147,15 +1150,7 @@ def import_musicbrainz_collection_detail(collection_mbid):
     )
     if error:
         body, code = error
-        if code == 503:
-            raise APIInternalServerError(body.get("error"))
-        if code == 404:
-            raise APINotFound(body.get("error"))
-        if code == 401:
-            raise APIUnauthorized(body.get("error"))
-        if code == 403:
-            raise APIForbidden(body.get("error"))
-        raise APIInternalServerError(body.get("error"))
+        raise APIError(body.get("error"), code)
 
     return jsonify(payload)
 

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -24,7 +24,7 @@ from listenbrainz.webserver.decorators import crossdomain, api_listenstore_neede
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIForbidden, APIError, PlaylistAPIXMLError, APIUnauthorized
 from brainzutils.ratelimit import ratelimit
 from listenbrainz.webserver.views.api_tools import log_raise_400, is_valid_uuid, validate_auth_header, \
-    _filter_description_html, get_non_negative_param
+    _filter_description_html, get_non_negative_param, get_positive_param
 from listenbrainz.db.model.playlist import Playlist, WritablePlaylist, WritablePlaylistRecording, \
     PLAYLIST_EXTENSION_URI, PLAYLIST_TRACK_URI_PREFIX, PLAYLIST_URI_PREFIX, PLAYLIST_TRACK_EXTENSION_URI, \
     PLAYLIST_ARTIST_URI_PREFIX, PLAYLIST_RELEASE_URI_PREFIX
@@ -1092,7 +1092,9 @@ def import_musicbrainz_collections():
         raise APIInternalServerError("MusicBrainz database is not configured on this server.")
 
     if not user.get("musicbrainz_row_id"):
-        raise APIInternalServerError("Cannot determine MusicBrainz editor id for this user.")
+        raise APIBadRequest(
+            "Your ListenBrainz account is not linked to a MusicBrainz account."
+        )
 
     try:
         with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
@@ -1140,7 +1142,7 @@ def import_musicbrainz_collection_detail(collection_mbid):
     user = validate_auth_header(optional=True)
     viewer_editor_id = user.get("musicbrainz_row_id") if user else None
 
-    count = get_non_negative_param("count", 100)
+    count = get_positive_param("count", 100)
     offset = get_non_negative_param("offset", 0)
     payload, error = fetch_collection_payload(
         collection_mbid,

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -20,7 +20,7 @@ from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.metadata_cache.apple.client import Apple
 from listenbrainz.metadata_cache.soundcloud.client import SoundCloud
 from listenbrainz.webserver.utils import parse_boolean_arg
-from listenbrainz.webserver.decorators import crossdomain, api_listenstore_needed
+from listenbrainz.webserver.decorators import crossdomain, api_listenstore_needed , api_musicbrainz_needed
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIForbidden, APIError, PlaylistAPIXMLError, APIUnauthorized
 from brainzutils.ratelimit import ratelimit
 from listenbrainz.webserver.views.api_tools import log_raise_400, is_valid_uuid, validate_auth_header, \
@@ -1083,7 +1083,7 @@ def import_playlist_from_music_service(service):
 @playlist_api_bp.get("/import/musicbrainz/collections")
 @crossdomain
 @ratelimit()
-@api_listenstore_needed
+@api_musicbrainz_needed
 def import_musicbrainz_collections():
     """List the authenticated user's MusicBrainz recording collections."""
     user = validate_auth_header()
@@ -1136,7 +1136,7 @@ def import_musicbrainz_collections():
 @playlist_api_bp.get("/import/musicbrainz/collections/<collection_mbid>")
 @crossdomain
 @ratelimit()
-@api_listenstore_needed
+@api_musicbrainz_needed
 def import_musicbrainz_collection_detail(collection_mbid):
     """Fetch a MusicBrainz collection as a read-only track list for preview"""
     user = validate_auth_header(optional=True)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# Problem

Ticket : [LB-961](https://tickets.metabrainz.org/browse/LB-961)

This pr currently provides Backend for recording collections.

Currently we can import playlists from different external services like Spotify , Apple Music , Soundcloud . But there is no feature to import/view musicbrainz collections as playlists. Users cannot modify collections in Listenbrainz, but can  fetch their tracks for preview / save-as-playlist.

# Solution

Currently added the Backend Support for the Recording Collections . This is the beginning portion of this feature. 
Data is read live from the MusicBrainz Postgres DB via `MB_DATABASE_URI` , not the MusicBrainz web API.  “Save as playlist” stays a later frontend step .
### API endpoints 
   **`GET /1/playlist/import/musicbrainz/collections`**
  - Authorization is required 
  - Lists the authenticated user’s **recording** collections 
  
 **`GET /1/playlist/import/musicbrainz/collections/<collection_mbid>`**
  - Authorization is  optional
  - Returns collection metadata + a paginated track list
  - **Access control:**
    - Public collections → viewable by anyone
    - Private collections → owner only
   
# Tests 

Integration tests are added to check for different scenarios like : 

- list endpoint response shape
- public collection detail without login
- private collection requires login / blocks other users
  

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [ ] I did not use any AI
* [YES ] I have used AI in this PR (add more details below)

Used AI a little for mainly debugging.

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ YES ] I understand all the changes made in this PR


