### PR TITLE
Give Spotify users advance notice of refresh token expiry 

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -125,7 +125,7 @@ CREATE TABLE external_service_oauth (
     refresh_token           TEXT,
     token_expires           TIMESTAMP WITH TIME ZONE,
     refresh_token_expires   TIMESTAMP WITH TIME ZONE,
-    refresh_token_expiry_notified TIMESTAMP WITH TIME ZONE,
+    refresh_token_expiry_last_notified TIMESTAMP WITH TIME ZONE,
     last_updated            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     scopes                  TEXT[]
 );

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -124,6 +124,8 @@ CREATE TABLE external_service_oauth (
     access_token            TEXT,
     refresh_token           TEXT,
     token_expires           TIMESTAMP WITH TIME ZONE,
+    refresh_token_expires   TIMESTAMP WITH TIME ZONE,
+    refresh_token_expiry_notified TIMESTAMP WITH TIME ZONE,
     last_updated            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     scopes                  TEXT[]
 );

--- a/admin/sql/updates/2026-07-15-add-spotify-refresh-token-expiry.sql
+++ b/admin/sql/updates/2026-07-15-add-spotify-refresh-token-expiry.sql
@@ -1,3 +1,3 @@
 ALTER TABLE external_service_oauth
     ADD COLUMN refresh_token_expires TIMESTAMP WITH TIME ZONE,
-    ADD COLUMN refresh_token_expiry_notified TIMESTAMP WITH TIME ZONE;
+    ADD COLUMN refresh_token_expiry_last_notified TIMESTAMP WITH TIME ZONE;

--- a/admin/sql/updates/2026-07-15-add-spotify-refresh-token-expiry.sql
+++ b/admin/sql/updates/2026-07-15-add-spotify-refresh-token-expiry.sql
@@ -1,0 +1,3 @@
+ALTER TABLE external_service_oauth
+    ADD COLUMN refresh_token_expires TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN refresh_token_expiry_notified TIMESTAMP WITH TIME ZONE;

--- a/admin/sql/updates/2026-07-15-backfill-spotify-refresh-token-expiry.sql
+++ b/admin/sql/updates/2026-07-15-backfill-spotify-refresh-token-expiry.sql
@@ -1,0 +1,6 @@
+UPDATE external_service_oauth
+   SET refresh_token_expires = '2026-07-20 00:00:00+00'::TIMESTAMP WITH TIME ZONE
+ WHERE service = 'spotify'
+   AND refresh_token IS NOT NULL
+   AND refresh_token != ''
+   AND refresh_token_expires IS NULL;

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -10,7 +10,7 @@ import sqlalchemy
 def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token: Optional[str], refresh_token: Optional[str],
                token_expires_ts: Optional[int], record_listens: bool, scopes: Optional[List[str]], external_user_id: Optional[str] = None,
                latest_listened_at: Optional[datetime] = None, refresh_token_expires: Optional[datetime] = None,
-               refresh_token_expiry_notified: Optional[datetime] = None):
+               refresh_token_expiry_last_notified: Optional[datetime] = None):
     """ Add a row to the external_service_oauth table for specified user with corresponding tokens and information.
 
     Args:
@@ -25,7 +25,7 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
         external_user_id: the user's id in the external linked service
         latest_listened_at: last listen import time
         refresh_token_expires: timestamp at which the refresh token expires
-        refresh_token_expiry_notified: timestamp at which the refresh token expiry notification was sent
+        refresh_token_expiry_last_notified: timestamp at which the last refresh token expiry notification was sent
     """
     # regardless of whether a row is inserted or updated, the end result of the query
     # should remain the same. if not so, weird things can happen as it is likely we
@@ -38,10 +38,10 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
     result = db_conn.execute(sqlalchemy.text("""
         INSERT INTO external_service_oauth AS eso
         (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
-         refresh_token_expiry_notified, scopes)
+         refresh_token_expiry_last_notified, scopes)
         VALUES
         (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
-         :refresh_token_expires, :refresh_token_expiry_notified, :scopes)
+         :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
         ON CONFLICT (user_id, service)
         DO UPDATE SET
             external_user_id = EXCLUDED.external_user_id,
@@ -49,7 +49,7 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
             refresh_token = EXCLUDED.refresh_token,
             token_expires = EXCLUDED.token_expires,
             refresh_token_expires = EXCLUDED.refresh_token_expires,
-            refresh_token_expiry_notified = EXCLUDED.refresh_token_expiry_notified,
+            refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
             scopes = EXCLUDED.scopes,
             last_updated = NOW()
         RETURNING id
@@ -61,7 +61,7 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
         "refresh_token": refresh_token,
         "token_expires": token_expires,
         "refresh_token_expires": refresh_token_expires,
-        "refresh_token_expiry_notified": refresh_token_expiry_notified,
+        "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
         "scopes": scopes,
     })
 
@@ -144,8 +144,8 @@ def update_token(db_conn, user_id: int, service: ExternalServiceType, access_tok
                  , refresh_token = :refresh_token
                  , token_expires = :token_expires
                  , refresh_token_expires = COALESCE(:refresh_token_expires, refresh_token_expires)
-                 , refresh_token_expiry_notified = CASE
-                       WHEN :refresh_token_expires IS NULL THEN refresh_token_expiry_notified
+                 , refresh_token_expiry_last_notified = CASE
+                       WHEN :refresh_token_expires IS NULL THEN refresh_token_expiry_last_notified
                        ELSE NULL
                    END
                  , last_updated = now()
@@ -185,7 +185,7 @@ def get_token(db_conn, user_id: int, service: ExternalServiceType) -> Union[dict
              , eso.last_updated
              , token_expires
              , refresh_token_expires
-             , refresh_token_expiry_notified
+             , refresh_token_expiry_last_notified
              , scopes
              , external_user_id
              , li.latest_listened_at
@@ -204,7 +204,9 @@ def get_token(db_conn, user_id: int, service: ExternalServiceType) -> Union[dict
 
 
 def get_users_with_expiring_refresh_tokens(db_conn, service: ExternalServiceType):
-    """Get users whose tracked refresh token for the specified service expires within one month and have not been notified."""
+    """Get users whose tracked refresh token for the specified service is due for an expiry notification."""
+    #  The refresh_token_expiry_last_notified conditional calculates if the user has been notified in the last month.
+    # If they have, wait until a week is left before expiry and send another email.
     result = db_conn.execute(sqlalchemy.text("""
         SELECT eso.id AS external_service_oauth_id
              , eso.user_id
@@ -219,7 +221,13 @@ def get_users_with_expiring_refresh_tokens(db_conn, service: ExternalServiceType
            AND eso.refresh_token != ''
            AND eso.refresh_token_expires > NOW()
            AND eso.refresh_token_expires <= NOW() + INTERVAL '1 month'
-           AND eso.refresh_token_expiry_notified IS NULL
+           AND (
+                    eso.refresh_token_expiry_last_notified IS NULL
+                 OR (
+                        eso.refresh_token_expires <= NOW() + INTERVAL '1 week'
+                    AND eso.refresh_token_expiry_last_notified < eso.refresh_token_expires - INTERVAL '1 week'
+                 )
+           )
       ORDER BY eso.refresh_token_expires ASC
     """), {
         "service": service.value,
@@ -231,7 +239,7 @@ def mark_refresh_token_expiry_notified(db_conn, external_service_oauth_id: int):
     """Mark a refresh-token expiry notification as sent for the specified OAuth row."""
     db_conn.execute(sqlalchemy.text("""
         UPDATE external_service_oauth
-           SET refresh_token_expiry_notified = NOW()
+           SET refresh_token_expiry_last_notified = NOW()
          WHERE id = :external_service_oauth_id
     """), {
         "external_service_oauth_id": external_service_oauth_id,

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -9,7 +9,8 @@ import sqlalchemy
 
 def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token: Optional[str], refresh_token: Optional[str],
                token_expires_ts: Optional[int], record_listens: bool, scopes: Optional[List[str]], external_user_id: Optional[str] = None,
-               latest_listened_at: Optional[datetime] = None):
+               latest_listened_at: Optional[datetime] = None, refresh_token_expires: Optional[datetime] = None,
+               refresh_token_expiry_notified: Optional[datetime] = None):
     """ Add a row to the external_service_oauth table for specified user with corresponding tokens and information.
 
     Args:
@@ -23,6 +24,8 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
         scopes: the oauth scopes
         external_user_id: the user's id in the external linked service
         latest_listened_at: last listen import time
+        refresh_token_expires: timestamp at which the refresh token expires
+        refresh_token_expiry_notified: timestamp at which the refresh token expiry notification was sent
     """
     # regardless of whether a row is inserted or updated, the end result of the query
     # should remain the same. if not so, weird things can happen as it is likely we
@@ -34,15 +37,19 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
     token_expires = datetime.fromtimestamp(token_expires_ts, timezone.utc) if token_expires_ts else None
     result = db_conn.execute(sqlalchemy.text("""
         INSERT INTO external_service_oauth AS eso
-        (user_id, external_user_id, service, access_token, refresh_token, token_expires, scopes)
+        (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
+         refresh_token_expiry_notified, scopes)
         VALUES
-        (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires, :scopes)
+        (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
+         :refresh_token_expires, :refresh_token_expiry_notified, :scopes)
         ON CONFLICT (user_id, service)
         DO UPDATE SET
             external_user_id = EXCLUDED.external_user_id,
             access_token = EXCLUDED.access_token,
             refresh_token = EXCLUDED.refresh_token,
             token_expires = EXCLUDED.token_expires,
+            refresh_token_expires = EXCLUDED.refresh_token_expires,
+            refresh_token_expiry_notified = EXCLUDED.refresh_token_expiry_notified,
             scopes = EXCLUDED.scopes,
             last_updated = NOW()
         RETURNING id
@@ -53,6 +60,8 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
         "access_token": access_token,
         "refresh_token": refresh_token,
         "token_expires": token_expires,
+        "refresh_token_expires": refresh_token_expires,
+        "refresh_token_expiry_notified": refresh_token_expiry_notified,
         "scopes": scopes,
     })
 
@@ -109,7 +118,7 @@ def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_imp
 
 
 def update_token(db_conn, user_id: int, service: ExternalServiceType, access_token: str,
-                 refresh_token: str | None, expires_at: int):
+                 refresh_token: str | None, expires_at: int, refresh_token_expires: datetime | None = None):
     """ Update the token for user with specified LB user ID and external service.
 
     Args:
@@ -119,6 +128,7 @@ def update_token(db_conn, user_id: int, service: ExternalServiceType, access_tok
         access_token: the new access token
         refresh_token: the new token used to refresh access tokens, if omitted the old token in the database remains unchanged
         expires_at: the unix timestamp at which the access token expires
+        refresh_token_expires: timestamp at which the new refresh token expires, if the refresh token was rotated
     """
     token_expires = datetime.fromtimestamp(expires_at, timezone.utc)
     params = {
@@ -133,11 +143,17 @@ def update_token(db_conn, user_id: int, service: ExternalServiceType, access_tok
                SET access_token = :access_token
                  , refresh_token = :refresh_token
                  , token_expires = :token_expires
+                 , refresh_token_expires = COALESCE(:refresh_token_expires, refresh_token_expires)
+                 , refresh_token_expiry_notified = CASE
+                       WHEN :refresh_token_expires IS NULL THEN refresh_token_expiry_notified
+                       ELSE NULL
+                   END
                  , last_updated = now()
              WHERE user_id = :user_id
                AND service = :service
         """
         params["refresh_token"] = refresh_token
+        params["refresh_token_expires"] = refresh_token_expires
     else:
         query = """
             UPDATE external_service_oauth
@@ -168,6 +184,8 @@ def get_token(db_conn, user_id: int, service: ExternalServiceType) -> Union[dict
              , refresh_token
              , eso.last_updated
              , token_expires
+             , refresh_token_expires
+             , refresh_token_expiry_notified
              , scopes
              , external_user_id
              , li.latest_listened_at
@@ -183,6 +201,30 @@ def get_token(db_conn, user_id: int, service: ExternalServiceType) -> Union[dict
             'service': service.value
         })
     return result.mappings().first()
+
+
+def get_users_with_expiring_refresh_tokens(db_conn, service: ExternalServiceType):
+    """Get users whose tracked refresh token for the specified service expires within one month and have not been notified."""
+    result = db_conn.execute(sqlalchemy.text("""
+        SELECT eso.id AS external_service_oauth_id
+             , eso.user_id
+             , "user".musicbrainz_id
+             , "user".email
+             , eso.refresh_token_expires
+          FROM external_service_oauth eso
+          JOIN "user"
+            ON "user".id = eso.user_id
+         WHERE eso.service = :service
+           AND eso.refresh_token IS NOT NULL
+           AND eso.refresh_token != ''
+           AND eso.refresh_token_expires > NOW()
+           AND eso.refresh_token_expires <= NOW() + INTERVAL '1 month'
+           AND eso.refresh_token_expiry_notified IS NULL
+      ORDER BY eso.refresh_token_expires ASC
+    """), {
+        "service": service.value,
+    })
+    return result.mappings().all()
 
 
 def get_services(db_conn, user_id: int) -> list[str]:

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -227,6 +227,18 @@ def get_users_with_expiring_refresh_tokens(db_conn, service: ExternalServiceType
     return result.mappings().all()
 
 
+def mark_refresh_token_expiry_notified(db_conn, external_service_oauth_id: int):
+    """Mark a refresh-token expiry notification as sent for the specified OAuth row."""
+    db_conn.execute(sqlalchemy.text("""
+        UPDATE external_service_oauth
+           SET refresh_token_expiry_notified = NOW()
+         WHERE id = :external_service_oauth_id
+    """), {
+        "external_service_oauth_id": external_service_oauth_id,
+    })
+    db_conn.commit()
+
+
 def get_services(db_conn, user_id: int) -> list[str]:
     """ Get the list of connected services for a given user
 

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -43,7 +43,7 @@ def get_user(db_conn, user_id: int) -> Optional[dict]:
              , external_service_oauth.last_updated
              , token_expires
              , refresh_token_expires
-             , refresh_token_expiry_notified
+             , refresh_token_expiry_last_notified
              , scopes
              , latest_listened_at
              , status

--- a/listenbrainz/db/spotify.py
+++ b/listenbrainz/db/spotify.py
@@ -42,6 +42,8 @@ def get_user(db_conn, user_id: int) -> Optional[dict]:
              , refresh_token
              , external_service_oauth.last_updated
              , token_expires
+             , refresh_token_expires
+             , refresh_token_expiry_notified
              , scopes
              , latest_listened_at
              , status

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from data.model.external_service import ExternalServiceType
 from listenbrainz.db.testing import DatabaseTestCase
@@ -81,6 +81,113 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(spotify_user['access_token'], 'testtoken')
         self.assertEqual(spotify_user['refresh_token'], 'refreshtesttoken')
 
+    def test_update_token_preserves_refresh_token_expiry_without_new_refresh_token(self):
+        refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=10)
+        refresh_token_expiry_notified = datetime.now(timezone.utc)
+        db_oauth.save_token(
+            self.db_conn,
+            user_id=self.user['id'],
+            service=ExternalServiceType.SPOTIFY,
+            access_token='token',
+            refresh_token='refresh_token',
+            token_expires_ts=int(time.time()),
+            record_listens=True,
+            scopes=['user-read-recently-played'],
+            refresh_token_expires=refresh_token_expires,
+            refresh_token_expiry_notified=refresh_token_expiry_notified,
+        )
+
+        db_oauth.update_token(
+            self.db_conn,
+            user_id=self.user['id'],
+            service=ExternalServiceType.SPOTIFY,
+            access_token='new-access-token',
+            refresh_token=None,
+            expires_at=int(time.time()),
+        )
+
+        spotify_user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
+        self.assertEqual('refresh_token', spotify_user['refresh_token'])
+        self.assertEqual(refresh_token_expires, spotify_user['refresh_token_expires'])
+        self.assertEqual(refresh_token_expiry_notified, spotify_user['refresh_token_expiry_notified'])
+
+    def test_update_token_resets_refresh_token_expiry_with_new_refresh_token(self):
+        refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=10)
+        refresh_token_expiry_notified = datetime.now(timezone.utc)
+        db_oauth.save_token(
+            self.db_conn,
+            user_id=self.user['id'],
+            service=ExternalServiceType.SPOTIFY,
+            access_token='token',
+            refresh_token='refresh_token',
+            token_expires_ts=int(time.time()),
+            record_listens=True,
+            scopes=['user-read-recently-played'],
+            refresh_token_expires=refresh_token_expires,
+            refresh_token_expiry_notified=refresh_token_expiry_notified,
+        )
+        new_refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=100)
+
+        db_oauth.update_token(
+            self.db_conn,
+            user_id=self.user['id'],
+            service=ExternalServiceType.SPOTIFY,
+            access_token='new-access-token',
+            refresh_token='new-refresh-token',
+            expires_at=int(time.time()),
+            refresh_token_expires=new_refresh_token_expires,
+        )
+
+        spotify_user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
+        self.assertEqual('new-refresh-token', spotify_user['refresh_token'])
+        self.assertEqual(new_refresh_token_expires, spotify_user['refresh_token_expires'])
+        self.assertIsNone(spotify_user['refresh_token_expiry_notified'])
+
+    def test_get_users_with_expiring_refresh_tokens(self):
+        users = [
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 2, 'expiring', 'expiring@example.com'),
+                        fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 3, 'future', 'future@example.com'),
+                        fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 4, 'expired', 'expired@example.com'),
+                        fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 5, 'notified', 'notified@example.com'),
+                        fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 6, 'lastfm', 'lastfm@example.com'),
+                        fetch_email=True),
+        ]
+        now = datetime.now(timezone.utc)
+        test_cases = [
+            (users[0], ExternalServiceType.SPOTIFY, now + timedelta(days=15), None),
+            (users[1], ExternalServiceType.SPOTIFY, now + timedelta(days=45), None),
+            (users[2], ExternalServiceType.SPOTIFY, now - timedelta(days=1), None),
+            (users[3], ExternalServiceType.SPOTIFY, now + timedelta(days=15), now),
+            (users[4], ExternalServiceType.LASTFM, now + timedelta(days=15), None),
+        ]
+        for user, service, refresh_token_expires, refresh_token_expiry_notified in test_cases:
+            db_oauth.save_token(
+                self.db_conn,
+                user_id=user['id'],
+                service=service,
+                access_token='token',
+                refresh_token='refresh_token',
+                token_expires_ts=int(time.time()),
+                record_listens=False,
+                scopes=[],
+                refresh_token_expires=refresh_token_expires,
+                refresh_token_expiry_notified=refresh_token_expiry_notified,
+            )
+
+        expiring_users = db_oauth.get_users_with_expiring_refresh_tokens(self.db_conn, ExternalServiceType.SPOTIFY)
+
+        self.assertEqual(1, len(expiring_users))
+        self.assertEqual(users[0]['id'], expiring_users[0]['user_id'])
+        self.assertEqual('expiring@example.com', expiring_users[0]['email'])
+
+        expiring_lastfm_users = db_oauth.get_users_with_expiring_refresh_tokens(self.db_conn, ExternalServiceType.LASTFM)
+        self.assertEqual(1, len(expiring_lastfm_users))
+        self.assertEqual(users[4]['id'], expiring_lastfm_users[0]['user_id'])
+
     def test_get_oauth(self):
         user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual(user['user_id'], self.user['id'])
@@ -89,6 +196,8 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(user['access_token'], 'token')
         self.assertEqual(user['refresh_token'], 'refresh_token')
         self.assertIn('token_expires', user)
+        self.assertIn('refresh_token_expires', user)
+        self.assertIn('refresh_token_expiry_notified', user)
 
     def test_delete_token_unlink(self):
         db_oauth.delete_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=True)

--- a/listenbrainz/db/tests/test_external_service_oauth.py
+++ b/listenbrainz/db/tests/test_external_service_oauth.py
@@ -83,7 +83,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
 
     def test_update_token_preserves_refresh_token_expiry_without_new_refresh_token(self):
         refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=10)
-        refresh_token_expiry_notified = datetime.now(timezone.utc)
+        refresh_token_expiry_last_notified = datetime.now(timezone.utc)
         db_oauth.save_token(
             self.db_conn,
             user_id=self.user['id'],
@@ -94,7 +94,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             record_listens=True,
             scopes=['user-read-recently-played'],
             refresh_token_expires=refresh_token_expires,
-            refresh_token_expiry_notified=refresh_token_expiry_notified,
+            refresh_token_expiry_last_notified=refresh_token_expiry_last_notified,
         )
 
         db_oauth.update_token(
@@ -109,11 +109,11 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         spotify_user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual('refresh_token', spotify_user['refresh_token'])
         self.assertEqual(refresh_token_expires, spotify_user['refresh_token_expires'])
-        self.assertEqual(refresh_token_expiry_notified, spotify_user['refresh_token_expiry_notified'])
+        self.assertEqual(refresh_token_expiry_last_notified, spotify_user['refresh_token_expiry_last_notified'])
 
     def test_update_token_resets_refresh_token_expiry_with_new_refresh_token(self):
         refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=10)
-        refresh_token_expiry_notified = datetime.now(timezone.utc)
+        refresh_token_expiry_last_notified = datetime.now(timezone.utc)
         db_oauth.save_token(
             self.db_conn,
             user_id=self.user['id'],
@@ -124,7 +124,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             record_listens=True,
             scopes=['user-read-recently-played'],
             refresh_token_expires=refresh_token_expires,
-            refresh_token_expiry_notified=refresh_token_expiry_notified,
+            refresh_token_expiry_last_notified=refresh_token_expiry_last_notified,
         )
         new_refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=100)
 
@@ -141,7 +141,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         spotify_user = db_oauth.get_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY)
         self.assertEqual('new-refresh-token', spotify_user['refresh_token'])
         self.assertEqual(new_refresh_token_expires, spotify_user['refresh_token_expires'])
-        self.assertIsNone(spotify_user['refresh_token_expiry_notified'])
+        self.assertIsNone(spotify_user['refresh_token_expiry_last_notified'])
 
     def test_get_users_with_expiring_refresh_tokens(self):
         users = [
@@ -155,6 +155,12 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
                         fetch_email=True),
             db_user.get(self.db_conn, db_user.create(self.db_conn, 6, 'lastfm', 'lastfm@example.com'),
                         fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 7, 'expiring_week', 'week@example.com'),
+                        fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 8, 'week_notified', 'week-notified@example.com'),
+                        fetch_email=True),
+            db_user.get(self.db_conn, db_user.create(self.db_conn, 9, 'expiring_week_second', 'week-second@example.com'),
+                        fetch_email=True),
         ]
         now = datetime.now(timezone.utc)
         test_cases = [
@@ -163,8 +169,11 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
             (users[2], ExternalServiceType.SPOTIFY, now - timedelta(days=1), None),
             (users[3], ExternalServiceType.SPOTIFY, now + timedelta(days=15), now),
             (users[4], ExternalServiceType.LASTFM, now + timedelta(days=15), None),
+            (users[5], ExternalServiceType.SPOTIFY, now + timedelta(days=6), None),
+            (users[6], ExternalServiceType.SPOTIFY, now + timedelta(days=6), now),
+            (users[7], ExternalServiceType.SPOTIFY, now + timedelta(days=6), now - timedelta(days=10)),
         ]
-        for user, service, refresh_token_expires, refresh_token_expiry_notified in test_cases:
+        for user, service, refresh_token_expires, refresh_token_expiry_last_notified in test_cases:
             db_oauth.save_token(
                 self.db_conn,
                 user_id=user['id'],
@@ -175,14 +184,15 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
                 record_listens=False,
                 scopes=[],
                 refresh_token_expires=refresh_token_expires,
-                refresh_token_expiry_notified=refresh_token_expiry_notified,
+                refresh_token_expiry_last_notified=refresh_token_expiry_last_notified,
             )
 
         expiring_users = db_oauth.get_users_with_expiring_refresh_tokens(self.db_conn, ExternalServiceType.SPOTIFY)
 
-        self.assertEqual(1, len(expiring_users))
-        self.assertEqual(users[0]['id'], expiring_users[0]['user_id'])
-        self.assertEqual('expiring@example.com', expiring_users[0]['email'])
+        self.assertCountEqual([users[5]['id'], users[7]['id'], users[0]['id']],
+                              [user['user_id'] for user in expiring_users])
+        self.assertCountEqual(['week@example.com', 'week-second@example.com', 'expiring@example.com'],
+                              [user['email'] for user in expiring_users])
 
         expiring_lastfm_users = db_oauth.get_users_with_expiring_refresh_tokens(self.db_conn, ExternalServiceType.LASTFM)
         self.assertEqual(1, len(expiring_lastfm_users))
@@ -197,7 +207,7 @@ class OAuthDatabaseTestCase(DatabaseTestCase):
         self.assertEqual(user['refresh_token'], 'refresh_token')
         self.assertIn('token_expires', user)
         self.assertIn('refresh_token_expires', user)
-        self.assertIn('refresh_token_expiry_notified', user)
+        self.assertIn('refresh_token_expiry_last_notified', user)
 
     def test_delete_token_unlink(self):
         db_oauth.delete_token(self.db_conn, self.user['id'], ExternalServiceType.SPOTIFY, remove_import_log=True)

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -59,9 +59,9 @@ def get_refresh_token_expires():
 
 
 def notify_refresh_token_expiry(db_conn):
-    """Send one pre-expiry notification for Spotify refresh tokens expiring within one month."""
-    users = external_service_oauth.get_users_with_expiring_refresh_tokens(db_conn, ExternalServiceType.SPOTIFY)
+    """Send pre-expiry notifications for Spotify refresh tokens expiring within one month and one week."""
     link = current_app.config['SERVER_ROOT_URL'] + '/settings/music-services/details/'
+    users = external_service_oauth.get_users_with_expiring_refresh_tokens(db_conn, ExternalServiceType.SPOTIFY)
     stats = {
         "sent": 0,
         "skipped": 0,

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -50,6 +50,7 @@ SPOTIFY_INVALID_GRANT_ERROR_MESSAGE = (
     "Please reconnect Spotify to resume imports."
 )
 SPOTIFY_REFRESH_TOKEN_TTL = relativedelta(months=6)
+SPOTIFY_REFRESH_TOKEN_EXPIRY_EMAIL_SUBJECT = "[Action required] Reconnect Spotify to keep importing your history"
 
 
 def get_refresh_token_expires():
@@ -57,6 +58,45 @@ def get_refresh_token_expires():
     return datetime.fromtimestamp(int(time.time()), timezone.utc) + SPOTIFY_REFRESH_TOKEN_TTL
 
 
+def notify_refresh_token_expiry(db_conn):
+    """Send one pre-expiry notification for Spotify refresh tokens expiring within one month."""
+    users = external_service_oauth.get_users_with_expiring_refresh_tokens(db_conn, ExternalServiceType.SPOTIFY)
+    link = current_app.config['SERVER_ROOT_URL'] + '/settings/music-services/details/'
+    stats = {
+        "sent": 0,
+        "skipped": 0,
+        "failed": 0,
+    }
+
+    for user in users:
+        if not user["email"]:
+            stats["skipped"] += 1
+            current_app.logger.info("Skipping Spotify refresh-token expiry email for %s: no email address",
+                                    user["musicbrainz_id"])
+            continue
+
+        text = render_template(
+            "emails/spotify_refresh_token_expiry.txt",
+            username=user["musicbrainz_id"],
+            link=link,
+            refresh_token_expires=user["refresh_token_expires"],
+        )
+        try:
+            send_mail(
+                subject=SPOTIFY_REFRESH_TOKEN_EXPIRY_EMAIL_SUBJECT,
+                text=text,
+                recipients=[user["email"]],
+                from_name='ListenBrainz',
+                from_addr='noreply@' + current_app.config['MAIL_FROM_DOMAIN'],
+            )
+            external_service_oauth.mark_refresh_token_expiry_notified(db_conn, user["external_service_oauth_id"])
+            stats["sent"] += 1
+        except Exception:
+            stats["failed"] += 1
+            current_app.logger.error("Could not send Spotify refresh-token expiry email to %s",
+                                     user["musicbrainz_id"], exc_info=True)
+
+    return stats
 
 
 def _get_spotify_token(grant_type: str, token: str) -> requests.Response:

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -1,11 +1,14 @@
 import time
 import base64
+from datetime import datetime, timezone
 from typing import Sequence, Optional
 
 import requests
 import spotipy
 
-from flask import current_app
+from brainzutils.mail import send_mail
+from dateutil.relativedelta import relativedelta
+from flask import current_app, render_template
 from spotipy import SpotifyOAuth
 
 from data.model.external_service import ExternalServiceType
@@ -46,6 +49,14 @@ SPOTIFY_INVALID_GRANT_ERROR_MESSAGE = (
     "Your Spotify connection has expired or been revoked. "
     "Please reconnect Spotify to resume imports."
 )
+SPOTIFY_REFRESH_TOKEN_TTL = relativedelta(months=6)
+
+
+def get_refresh_token_expires():
+    """Return the expiry timestamp for a newly issued Spotify refresh token."""
+    return datetime.fromtimestamp(int(time.time()), timezone.utc) + SPOTIFY_REFRESH_TOKEN_TTL
+
+
 
 
 def _get_spotify_token(grant_type: str, token: str) -> requests.Response:
@@ -109,7 +120,8 @@ class SpotifyService(ImporterService):
 
         external_service_oauth.save_token(db_conn, user_id=user_id, service=self.service, access_token=access_token,
                                           refresh_token=refresh_token, token_expires_ts=expires_at,
-                                          record_listens=active, scopes=scopes, external_user_id=external_user_id)
+                                          record_listens=active, scopes=scopes, external_user_id=external_user_id,
+                                          refresh_token_expires=get_refresh_token_expires())
         return True
 
     def get_authorize_url(self, permissions: Sequence[str]):
@@ -177,12 +189,13 @@ class SpotifyService(ImporterService):
 
         response = response.json()
         access_token = response['access_token']
-        if "refresh_token" in response:
-            refresh_token = response['refresh_token']
+        new_refresh_token = response.get("refresh_token")
         expires_at = int(time.time()) + response['expires_in']
         external_service_oauth.update_token(db_conn, user_id=user_id, service=self.service,
-                                            access_token=access_token, refresh_token=refresh_token,
-                                            expires_at=expires_at)
+                                            access_token=access_token, refresh_token=new_refresh_token,
+                                            expires_at=expires_at,
+                                            refresh_token_expires=get_refresh_token_expires()
+                                            if new_refresh_token else None)
         return self.get_user(user_id)
 
     def revoke_user(self, user_id: int):

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -96,7 +96,7 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual('refreshtokentoken', user['refresh_token'])
         self.assertEqual(datetime.fromtimestamp(3600, tz=timezone.utc), user['token_expires'])
         self.assertEqual(datetime(1970, 7, 1, tzinfo=timezone.utc), user['refresh_token_expires'])
-        self.assertIsNone(user['refresh_token_expiry_notified'])
+        self.assertIsNone(user['refresh_token_expiry_last_notified'])
 
     @requests_mock.Mocker()
     @mock.patch('time.time')
@@ -113,6 +113,8 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual('old-refresh-token', user['refresh_token'])
         self.assertEqual(datetime.fromtimestamp(3600, tz=timezone.utc), user['token_expires'])
         self.assertEqual(self.spotify_user['refresh_token_expires'], user['refresh_token_expires'])
+        self.assertEqual(self.spotify_user['refresh_token_expiry_last_notified'],
+                         user['refresh_token_expiry_last_notified'])
 
     @requests_mock.Mocker()
     def test_refresh_user_token_bad(self, mock_requests):
@@ -166,17 +168,21 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual('refresh-token', user['refresh_token'])
         self.assertEqual("test_user_id", user["external_user_id"])
         self.assertEqual(datetime(1970, 7, 1, tzinfo=timezone.utc), user['refresh_token_expires'])
-        self.assertIsNone(user['refresh_token_expiry_notified'])
+        self.assertIsNone(user['refresh_token_expiry_last_notified'])
 
     @mock.patch("listenbrainz.domain.spotify.send_mail")
     @mock.patch("listenbrainz.manage.webserver.create_app")
     def test_notify_spotify_refresh_token_expiry_command(self, mock_create_app, mock_send_mail):
         mock_create_app.return_value = self.app
-        user_with_email_id = db_user.create(self.db_conn, 444, 'expiring_spotify_user', 'user@example.com')
+        month_user_id = db_user.create(self.db_conn, 444, 'expiring_spotify_user', 'user@example.com')
+        week_user_id = db_user.create(self.db_conn, 445, 'expiring_spotify_user_week', 'week@example.com')
         user_without_email_id = db_user.create(self.db_conn, 555, 'expiring_spotify_user_without_email')
-        refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=15)
 
-        for user_id in (user_with_email_id, user_without_email_id):
+        for user_id, refresh_token_expires, refresh_token_expiry_last_notified in (
+            (month_user_id, datetime.now(timezone.utc) + timedelta(days=15), None),
+            (week_user_id, datetime.now(timezone.utc) + timedelta(days=6), datetime.now(timezone.utc) - timedelta(days=10)),
+            (user_without_email_id, datetime.now(timezone.utc) + timedelta(days=15), None),
+        ):
             db_oauth.save_token(
                 self.db_conn,
                 user_id=user_id,
@@ -187,22 +193,31 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
                 record_listens=True,
                 scopes=['user-read-currently-playing', 'user-read-recently-played'],
                 refresh_token_expires=refresh_token_expires,
+                refresh_token_expiry_last_notified=refresh_token_expiry_last_notified,
             )
 
         result = CliRunner().invoke(cli, ["notify_spotify_refresh_token_expiry"])
 
         self.assertEqual(0, result.exit_code)
-        self.assertIn("1 sent, 1 skipped, 0 failed", result.output)
-        mock_send_mail.assert_called_once()
-        self.assertEqual("[Action required] Reconnect Spotify to keep importing your history", mock_send_mail.call_args.kwargs["subject"])
-        self.assertEqual(["user@example.com"], mock_send_mail.call_args.kwargs["recipients"])
-        self.assertIn("/settings/music-services/details/", mock_send_mail.call_args.kwargs["text"])
+        self.assertIn("2 sent, 1 skipped, 0 failed", result.output)
+        self.assertEqual(2, mock_send_mail.call_count)
+        self.assertCountEqual(
+            [["user@example.com"], ["week@example.com"]],
+            [call.kwargs["recipients"] for call in mock_send_mail.call_args_list],
+        )
+        for call in mock_send_mail.call_args_list:
+            self.assertEqual("[Action required] Reconnect Spotify to keep importing your history",
+                             call.kwargs["subject"])
+            self.assertIn("/settings/music-services/details/", call.kwargs["text"])
 
-        user = db_oauth.get_token(self.db_conn, user_with_email_id, ExternalServiceType.SPOTIFY)
-        self.assertIsNotNone(user["refresh_token_expiry_notified"])
+        month_user = db_oauth.get_token(self.db_conn, month_user_id, ExternalServiceType.SPOTIFY)
+        self.assertIsNotNone(month_user["refresh_token_expiry_last_notified"])
+
+        week_user = db_oauth.get_token(self.db_conn, week_user_id, ExternalServiceType.SPOTIFY)
+        self.assertIsNotNone(week_user["refresh_token_expiry_last_notified"])
 
         result = CliRunner().invoke(cli, ["notify_spotify_refresh_token_expiry"])
 
         self.assertEqual(0, result.exit_code)
         self.assertIn("0 sent, 1 skipped, 0 failed", result.output)
-        mock_send_mail.assert_called_once()
+        self.assertEqual(2, mock_send_mail.call_count)

--- a/listenbrainz/domain/tests/test_spotify.py
+++ b/listenbrainz/domain/tests/test_spotify.py
@@ -1,13 +1,17 @@
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 import spotipy
 
+from click.testing import CliRunner
 import requests_mock
 
 import listenbrainz.db.user as db_user
+from data.model.external_service import ExternalServiceType
+from listenbrainz.db import external_service_oauth as db_oauth
 from listenbrainz.domain.external_service import ExternalServiceAPIError, ExternalServiceInvalidGrantError
 from listenbrainz.domain.spotify import SpotifyService, OAUTH_TOKEN_URL
+from listenbrainz.manage import cli
 
 from listenbrainz.tests.integration import NonAPIIntegrationTestCase
 
@@ -91,6 +95,8 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual('tokentoken', user['access_token'])
         self.assertEqual('refreshtokentoken', user['refresh_token'])
         self.assertEqual(datetime.fromtimestamp(3600, tz=timezone.utc), user['token_expires'])
+        self.assertEqual(datetime(1970, 7, 1, tzinfo=timezone.utc), user['refresh_token_expires'])
+        self.assertIsNone(user['refresh_token_expiry_notified'])
 
     @requests_mock.Mocker()
     @mock.patch('time.time')
@@ -106,6 +112,7 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual('tokentoken', user['access_token'])
         self.assertEqual('old-refresh-token', user['refresh_token'])
         self.assertEqual(datetime.fromtimestamp(3600, tz=timezone.utc), user['token_expires'])
+        self.assertEqual(self.spotify_user['refresh_token_expires'], user['refresh_token_expires'])
 
     @requests_mock.Mocker()
     def test_refresh_user_token_bad(self, mock_requests):
@@ -158,3 +165,44 @@ class SpotifyServiceTestCase(NonAPIIntegrationTestCase):
         self.assertEqual('access-token', user['access_token'])
         self.assertEqual('refresh-token', user['refresh_token'])
         self.assertEqual("test_user_id", user["external_user_id"])
+        self.assertEqual(datetime(1970, 7, 1, tzinfo=timezone.utc), user['refresh_token_expires'])
+        self.assertIsNone(user['refresh_token_expiry_notified'])
+
+    @mock.patch("listenbrainz.domain.spotify.send_mail")
+    @mock.patch("listenbrainz.manage.webserver.create_app")
+    def test_notify_spotify_refresh_token_expiry_command(self, mock_create_app, mock_send_mail):
+        mock_create_app.return_value = self.app
+        user_with_email_id = db_user.create(self.db_conn, 444, 'expiring_spotify_user', 'user@example.com')
+        user_without_email_id = db_user.create(self.db_conn, 555, 'expiring_spotify_user_without_email')
+        refresh_token_expires = datetime.now(timezone.utc) + timedelta(days=15)
+
+        for user_id in (user_with_email_id, user_without_email_id):
+            db_oauth.save_token(
+                self.db_conn,
+                user_id=user_id,
+                service=ExternalServiceType.SPOTIFY,
+                access_token='access-token',
+                refresh_token='refresh-token',
+                token_expires_ts=int(time.time()),
+                record_listens=True,
+                scopes=['user-read-currently-playing', 'user-read-recently-played'],
+                refresh_token_expires=refresh_token_expires,
+            )
+
+        result = CliRunner().invoke(cli, ["notify_spotify_refresh_token_expiry"])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("1 sent, 1 skipped, 0 failed", result.output)
+        mock_send_mail.assert_called_once()
+        self.assertEqual("[Action required] Reconnect Spotify to keep importing your history", mock_send_mail.call_args.kwargs["subject"])
+        self.assertEqual(["user@example.com"], mock_send_mail.call_args.kwargs["recipients"])
+        self.assertIn("/settings/music-services/details/", mock_send_mail.call_args.kwargs["text"])
+
+        user = db_oauth.get_token(self.db_conn, user_with_email_id, ExternalServiceType.SPOTIFY)
+        self.assertIsNotNone(user["refresh_token_expiry_notified"])
+
+        result = CliRunner().invoke(cli, ["notify_spotify_refresh_token_expiry"])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("0 sent, 1 skipped, 0 failed", result.output)
+        mock_send_mail.assert_called_once()

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -326,6 +326,18 @@ def notify_yim_users(year: int):
         year_in_music.notify_yim_users(webserver.db_conn, webserver.ts_conn, year)
 
 
+@cli.command(name="notify_spotify_refresh_token_expiry")
+def notify_spotify_refresh_token_expiry():
+    application = webserver.create_app()
+    with application.app_context():
+        from listenbrainz.domain.spotify import notify_refresh_token_expiry
+        stats = notify_refresh_token_expiry(webserver.db_conn)
+        click.echo(
+            "Spotify refresh-token expiry notifications: "
+            f"{stats['sent']} sent, {stats['skipped']} skipped, {stats['failed']} failed"
+        )
+
+
 @cli.command()
 @click.option("--create-all",
               is_flag=True,

--- a/listenbrainz/model/external_service_oauth.py
+++ b/listenbrainz/model/external_service_oauth.py
@@ -16,7 +16,7 @@ class ExternalService(db.Model):
     refresh_token = db.Column(db.String)
     token_expires = db.Column(db.DateTime(timezone=True))
     refresh_token_expires = db.Column(db.DateTime(timezone=True))
-    refresh_token_expiry_notified = db.Column(db.DateTime(timezone=True))
+    refresh_token_expiry_last_notified = db.Column(db.DateTime(timezone=True))
     last_updated = db.Column(db.DateTime(timezone=True), server_default=db.func.now())
     scopes = db.Column(db.ARRAY(db.String))
     user = db.relationship('User')
@@ -31,7 +31,7 @@ class ExternalServiceAdminView(AdminModelView):
         'refresh_token',
         'token_expires',
         'refresh_token_expires',
-        'refresh_token_expiry_notified',
+        'refresh_token_expiry_last_notified',
         'last_updated',
         'scopes'
     ]
@@ -45,7 +45,7 @@ class ExternalServiceAdminView(AdminModelView):
         'refresh_token',
         'token_expires',
         'refresh_token_expires',
-        'refresh_token_expiry_notified',
+        'refresh_token_expiry_last_notified',
         'last_updated',
         'scopes'
     ]
@@ -61,7 +61,7 @@ class ExternalServiceAdminView(AdminModelView):
         'last_updated',
         'token_expires',
         'refresh_token_expires',
-        'refresh_token_expiry_notified',
+        'refresh_token_expiry_last_notified',
     ]
 
     column_formatters = {

--- a/listenbrainz/model/external_service_oauth.py
+++ b/listenbrainz/model/external_service_oauth.py
@@ -15,6 +15,8 @@ class ExternalService(db.Model):
     access_token = db.Column(db.String, nullable=False)
     refresh_token = db.Column(db.String)
     token_expires = db.Column(db.DateTime(timezone=True))
+    refresh_token_expires = db.Column(db.DateTime(timezone=True))
+    refresh_token_expiry_notified = db.Column(db.DateTime(timezone=True))
     last_updated = db.Column(db.DateTime(timezone=True), server_default=db.func.now())
     scopes = db.Column(db.ARRAY(db.String))
     user = db.relationship('User')
@@ -28,6 +30,8 @@ class ExternalServiceAdminView(AdminModelView):
         'access_token',
         'refresh_token',
         'token_expires',
+        'refresh_token_expires',
+        'refresh_token_expiry_notified',
         'last_updated',
         'scopes'
     ]
@@ -40,6 +44,8 @@ class ExternalServiceAdminView(AdminModelView):
         'access_token',
         'refresh_token',
         'token_expires',
+        'refresh_token_expires',
+        'refresh_token_expiry_notified',
         'last_updated',
         'scopes'
     ]
@@ -54,6 +60,8 @@ class ExternalServiceAdminView(AdminModelView):
         'service',
         'last_updated',
         'token_expires',
+        'refresh_token_expires',
+        'refresh_token_expiry_notified',
     ]
 
     column_formatters = {

--- a/listenbrainz/webserver/templates/emails/spotify_refresh_token_expiry.txt
+++ b/listenbrainz/webserver/templates/emails/spotify_refresh_token_expiry.txt
@@ -1,0 +1,12 @@
+Hi {{ username }}!
+
+Spotify <a href="https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration">requires you</a> to reconnect ListenBrainz every six months.
+<b>Your current Spotify connection will stop working within the next month.</b>
+
+
+Please disconnect and reconnect Spotify to keep your listening history imports running without interrumption:
+{{ link }}
+
+
+Best,
+The ListenBrainz Team


### PR DESCRIPTION
# Problem

Following up from #3766 , we want to notify users ahead of time that they need to reconnect their Spotify account, to avoid disruptions and lost listening history.
This PR adds email notice one month before expiry, and again one week before expiry, if they haven't reconnected yet. This is in addition to existing emails sent when the token has expired.

* [x] I have run the code and manually tested the changes

# AI usage
* [x] I have used AI in this PR (add more details below)

Used Codex to write most of this PR, with steering, supervision and review, as well as to review both PRs
 
#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR


# Action
I am not sure what action to take for this coming Monday, but in case we want to send everyone an email ahead of time, there is an SQL script (admin/sql/updates/2026-07-15-backfill-spotify-refresh-token-expiry.sql) to set all spotify user's new `refresh_token_expires` column (will be NULL by default) to a timestamp of this Monday July 20th (can be run independently of deployment of the first PR).

If we then run the `notify_spotify_refresh_token_expiry` command, emails should be sent to all spotify users to prompt them to disconnect/reconnect