### PR TITLE
LB-1217: Add range parameter to listen-count endpoint

### DIFF
--- a/listenbrainz/tests/integration/test_stats_api.py
+++ b/listenbrainz/tests/integration/test_stats_api.py
@@ -404,6 +404,45 @@ class StatsAPITestCase(IntegrationTestCase):
                                            query_string={'range': range_})
                 self.assertListeningActivityEqual(payload, response)
 
+    def test_listen_count_with_range(self):
+        """ The core listen-count endpoint returns the current-period listen
+        total, derived from the listening_activity stat, when a range is given. """
+        endpoint = "api_v1.get_listen_count"
+
+        # The week fixture (user 1) has 14 daily segments; the current week is
+        # the last 7 days, which sum to 137 (matches the website's total).
+        with open(self.path_to_data_file('user_listening_activity_db_data_for_api_test_week.json')) as f:
+            payload = json.load(f)
+            payload[0]["user_id"] = self.user["id"]
+        db_stats.insert("listening_activity_week_20220718", 0, 5, payload)
+
+        response = self.client.get(
+            self.custom_url_for(endpoint, user_name=self.user['musicbrainz_id']),
+            query_string={'range': 'week'}
+        )
+        self.assert200(response)
+        data = json.loads(response.data)['payload']
+        self.assertEqual(data['count'], 137)
+        self.assertEqual(data['range'], 'week')
+        self.assertEqual(data['from_ts'], 1588550400)  # Monday of the current week
+        self.assertEqual(data['to_ts'], 5)  # stat's to_ts, passed through (test fixtures use 0/5)
+        self.assertIn('last_updated', data)
+
+    def test_listen_count_with_invalid_range(self):
+        response = self.client.get(
+            self.custom_url_for("api_v1.get_listen_count", user_name=self.user['musicbrainz_id']),
+            query_string={'range': 'foobar'}
+        )
+        self.assert400(response)
+
+    def test_listen_count_range_without_stats(self):
+        """ 204 when the requested range has no computed stats for the user. """
+        response = self.client.get(
+            self.custom_url_for("api_v1.get_listen_count", user_name=self.no_stat_user['musicbrainz_id']),
+            query_string={'range': 'week'}
+        )
+        self.assertStatus(response, 204)
+
     def test_artist_evolution_activity_stat(self):
         endpoint = self.non_entity_endpoints["artist_evolution_activity"]["endpoint"]
         with self.subTest(f"test valid response is received for artist_evolution_activity stats"):

--- a/listenbrainz/tests/unit/test_stats_utils.py
+++ b/listenbrainz/tests/unit/test_stats_utils.py
@@ -1,0 +1,97 @@
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from dateutil.relativedelta import relativedelta
+
+from listenbrainz.webserver.views.stats_utils import current_period_listen_count
+
+
+def _ts(dt: datetime) -> int:
+    return int(dt.replace(tzinfo=timezone.utc).timestamp())
+
+
+def _record(from_ts: int, listen_count: int) -> SimpleNamespace:
+    # current_period_listen_count only needs from_ts and listen_count, which
+    # ListeningActivityRecord also exposes.
+    return SimpleNamespace(from_ts=from_ts, listen_count=listen_count)
+
+
+def _daily(start: datetime, counts):
+    """ One daily segment per count, starting at ``start``. """
+    return [_record(_ts(start + relativedelta(days=i)), c) for i, c in enumerate(counts)]
+
+
+def _monthly(start: datetime, counts):
+    """ One monthly segment per count, starting at ``start``. """
+    return [_record(_ts(start + relativedelta(months=i)), c) for i, c in enumerate(counts)]
+
+
+class CurrentPeriodListenCountTestCase(unittest.TestCase):
+    """ Unit tests for the pure listening-activity current-period helper. """
+
+    def test_week_sums_only_the_current_week(self):
+        # Same data as user_listening_activity_db_data_for_api_test_week.json
+        # (user 1): 14 daily segments, first 7 = previous week, last 7 = current.
+        counts = [26, 57, 33, 40, 26, 17, 26, 32, 26, 28, 21, 26, 0, 4]
+        records = _daily(datetime(2020, 4, 27), counts)  # Monday 27 April 2020
+
+        count, from_ts = current_period_listen_count("week", records)
+
+        self.assertEqual(count, 32 + 26 + 28 + 21 + 26 + 0 + 4)  # 137
+        self.assertEqual(from_ts, _ts(datetime(2020, 5, 4)))  # Monday of current week
+
+    def test_all_time_sums_every_segment(self):
+        counts = [26, 57, 33, 40, 26, 17, 26, 32, 26, 28, 21, 26, 0, 4]
+        records = _daily(datetime(2020, 4, 27), counts)
+
+        count, from_ts = current_period_listen_count("all_time", records)
+
+        self.assertEqual(count, sum(counts))  # 362
+        self.assertEqual(from_ts, _ts(datetime(2020, 4, 27)))
+
+    def test_month_split_handles_variable_month_lengths(self):
+        # February 2021 (28 days) then March 2021 (31 days).
+        records = _daily(datetime(2021, 2, 1), [1] * 28 + [10] * 31)
+
+        count, from_ts = current_period_listen_count("month", records)
+
+        self.assertEqual(count, 31 * 10)
+        self.assertEqual(from_ts, _ts(datetime(2021, 3, 1)))
+
+    def test_year_split_uses_monthly_segments(self):
+        records = _monthly(datetime(2020, 1, 1), [1] * 12 + [5] * 12)
+
+        count, from_ts = current_period_listen_count("year", records)
+
+        self.assertEqual(count, 12 * 5)
+        self.assertEqual(from_ts, _ts(datetime(2021, 1, 1)))
+
+    def test_quarter_split_advances_three_months(self):
+        prev_days = (datetime(2021, 10, 1) - datetime(2021, 7, 1)).days
+        this_days = (datetime(2022, 1, 1) - datetime(2021, 10, 1)).days
+        records = _daily(datetime(2021, 7, 1), [2] * prev_days + [3] * this_days)
+
+        count, from_ts = current_period_listen_count("quarter", records)
+
+        self.assertEqual(count, 3 * this_days)
+        self.assertEqual(from_ts, _ts(datetime(2021, 10, 1)))
+
+    def test_half_yearly_split_advances_six_months(self):
+        records = _monthly(datetime(2021, 1, 1), [1] * 6 + [4] * 6)
+
+        count, _ = current_period_listen_count("half_yearly", records)
+
+        self.assertEqual(count, 6 * 4)
+
+    def test_unordered_records_still_split_correctly(self):
+        counts = [26, 57, 33, 40, 26, 17, 26, 32, 26, 28, 21, 26, 0, 4]
+        records = _daily(datetime(2020, 4, 27), counts)
+        records = list(reversed(records))
+
+        count, _ = current_period_listen_count("week", records)
+
+        self.assertEqual(count, 137)
+
+    def test_empty_records(self):
+        self.assertEqual(current_period_listen_count("week", []), (0, None))

--- a/listenbrainz/tests/unit/test_stats_utils.py
+++ b/listenbrainz/tests/unit/test_stats_utils.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 
 from dateutil.relativedelta import relativedelta
 
-from listenbrainz.webserver.views.stats_utils import current_period_listen_count
+from data.model.common_stat import StatisticsRange
+from listenbrainz.webserver.views.stats_utils import LISTENING_ACTIVITY_PERIOD_OFFSET, \
+    current_period_listen_count
 
 
 def _ts(dt: datetime) -> int:
@@ -92,6 +94,54 @@ class CurrentPeriodListenCountTestCase(unittest.TestCase):
         count, _ = current_period_listen_count("week", records)
 
         self.assertEqual(count, 137)
+
+    def test_this_week_partial_current_period(self):
+        # this_* stats end at the latest listen, so the current period is
+        # usually partial: 7 full days of last week + 3 days so far this week.
+        records = _daily(datetime(2020, 4, 27), [26, 57, 33, 40, 26, 17, 26, 32, 26, 28])
+
+        count, from_ts = current_period_listen_count("this_week", records)
+
+        self.assertEqual(count, 32 + 26 + 28)
+        self.assertEqual(from_ts, _ts(datetime(2020, 5, 4)))
+
+    def test_this_week_on_monday_spans_two_full_weeks(self):
+        # when the latest listen falls on a Monday, spark starts the range on
+        # the Monday of two weeks ago, producing 14 full daily segments; the
+        # current period is still the last 7 (same split as the frontend).
+        counts = [26, 57, 33, 40, 26, 17, 26, 32, 26, 28, 21, 26, 0, 4]
+        records = _daily(datetime(2020, 4, 27), counts)
+
+        count, from_ts = current_period_listen_count("this_week", records)
+
+        self.assertEqual(count, 137)
+        self.assertEqual(from_ts, _ts(datetime(2020, 5, 4)))
+
+    def test_this_month_partial_current_period(self):
+        # 31 days of July + only 2 days of August so far.
+        records = _daily(datetime(2021, 7, 1), [1] * 31 + [20, 30])
+
+        count, from_ts = current_period_listen_count("this_month", records)
+
+        self.assertEqual(count, 50)
+        self.assertEqual(from_ts, _ts(datetime(2021, 8, 1)))
+
+    def test_this_year_partial_current_period(self):
+        # 12 months of last year + 8 months of this year so far.
+        records = _monthly(datetime(2020, 1, 1), [1] * 12 + [5] * 8)
+
+        count, from_ts = current_period_listen_count("this_year", records)
+
+        self.assertEqual(count, 8 * 5)
+        self.assertEqual(from_ts, _ts(datetime(2021, 1, 1)))
+
+    def test_every_statistics_range_has_a_period_offset(self):
+        # every range the endpoint accepts (except all_time, which sums all
+        # segments) must have an offset, otherwise a valid request would 500
+        for name in StatisticsRange.__members__:
+            if name == "all_time":
+                continue
+            self.assertIn(name, LISTENING_ACTIVITY_PERIOD_OFFSET)
 
     def test_empty_records(self):
         self.assertEqual(current_period_listen_count("week", []), (0, None))

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -7,19 +7,22 @@ from brainzutils.ratelimit import ratelimit
 from flask import Blueprint, request, jsonify, current_app
 
 import listenbrainz.db.playlist as db_playlist
+import listenbrainz.db.stats as db_stats
 import listenbrainz.db.user as db_user
 import listenbrainz.db.external_service_oauth as db_external_service_oauth
 import listenbrainz.webserver.redis_connection as redis_connection
 from listenbrainz.db.lb_radio_artist import lb_radio_artist
+from data.model.common_stat import StatisticsRange
 from data.model.external_service import ExternalServiceType
+from data.model.user_listening_activity import ListeningActivityRecord
 from listenbrainz.db import listens_importer, tags
 from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.listenstore.timescale_listenstore import TimescaleListenStoreException
 from listenbrainz.webserver import timescale_connection, db_conn, ts_conn
 from listenbrainz.webserver.decorators import api_listenstore_needed
 from listenbrainz.webserver.decorators import crossdomain
-from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINotFound, APIServiceUnavailable, \
-    APIUnauthorized, ListenValidationError, APIForbidden
+from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APINoContent, APINotFound, \
+    APIServiceUnavailable, APIUnauthorized, ListenValidationError, APIForbidden
 from listenbrainz.webserver.listens_cache import invalidate_user_listen_caches
 from listenbrainz.webserver.models import SubmitListenUserMetadata
 from listenbrainz.webserver.utils import REJECT_LISTENS_WITHOUT_EMAIL_ERROR, REJECT_LISTENS_FROM_PAUSED_USER_ERROR, parse_boolean_arg
@@ -27,6 +30,7 @@ from listenbrainz.webserver.views.api_tools import insert_payload, log_raise_400
     is_valid_uuid, MAX_LISTEN_PAYLOAD_SIZE, MAX_LISTENS_PER_REQUEST, MAX_LISTEN_SIZE, LISTEN_TYPE_SINGLE, \
     LISTEN_TYPE_IMPORT, LISTEN_TYPE_PLAYING_NOW, validate_auth_header, \
     get_non_negative_param, _parse_int_arg, _validate_get_listens_endpoint_params
+from listenbrainz.webserver.views.stats_utils import current_period_listen_count
 from listenbrainz.messybrainz import submit_recording
 
 api_bp = Blueprint('api_v1', __name__)
@@ -209,7 +213,34 @@ def get_listen_count(user_name):
         The returned listen count has an element 'payload' with only key: 'count'
         which unsurprisingly contains the listen count for the user.
 
+        By default the overall (all-time) listen count is returned. To get the
+        listen count for a single statistics period, pass the optional ``range``
+        query parameter. When a range other than ``all_time`` is requested, the
+        count is derived from the user's precomputed listening activity
+        statistics (matching the per-period total shown on the ListenBrainz
+        website) and the response additionally contains the ``range`` it applies
+        to along with its ``from_ts``, ``to_ts`` and ``last_updated`` timestamps:
+
+        .. code-block:: json
+
+            {
+                "payload": {
+                    "count": 137,
+                    "range": "week",
+                    "from_ts": 1588550400,
+                    "to_ts": 1589155199,
+                    "last_updated": 1592807084
+                }
+            }
+
+    :param range: Optional, time interval for which the listen count should be
+        returned, possible values are :data:`~data.model.common_stat.ALLOWED_STATISTICS_RANGE`,
+        defaults to ``all_time``.
+    :type range: ``str``
     :statuscode 200: Yay, you have listen counts!
+    :statuscode 204: Statistics for the user haven't been calculated for the
+        requested ``range``, empty response will be returned.
+    :statuscode 400: Bad request, the requested ``range`` is invalid.
     :statuscode 404: The requested user was not found.
     :resheader Content-Type: *application/json*
     """
@@ -217,14 +248,34 @@ def get_listen_count(user_name):
     if user is None:
         raise APINotFound("Cannot find user: %s" % user_name)
 
-    try:
-        listen_count = timescale_connection._ts.get_listen_count_for_user(user["id"])
-    except psycopg2.OperationalError as err:
-        current_app.logger.error("cannot fetch user listen count: ", str(err))
-        raise APIServiceUnavailable("Cannot fetch user listen count right now.")
+    stats_range = request.args.get("range", default="all_time")
+
+    if stats_range == "all_time":
+        try:
+            listen_count = timescale_connection._ts.get_listen_count_for_user(user["id"])
+        except psycopg2.OperationalError as err:
+            current_app.logger.error("cannot fetch user listen count: ", str(err))
+            raise APIServiceUnavailable("Cannot fetch user listen count right now.")
+
+        return jsonify({'payload': {
+            'count': listen_count
+        }})
+
+    if stats_range not in StatisticsRange.__members__:
+        raise APIBadRequest(f"Invalid range: {stats_range}")
+
+    stats = db_stats.get(user["id"], "listening_activity", stats_range, ListeningActivityRecord)
+    if stats is None:
+        raise APINoContent('')
+
+    count, from_ts = current_period_listen_count(stats_range, stats.data.__root__)
 
     return jsonify({'payload': {
-        'count': listen_count
+        'count': count,
+        'range': stats_range,
+        'from_ts': from_ts,
+        'to_ts': stats.to_ts,
+        'last_updated': stats.last_updated,
     }})
 
 

--- a/listenbrainz/webserver/views/api.py
+++ b/listenbrainz/webserver/views/api.py
@@ -205,7 +205,6 @@ def get_listens(user_name):
 @api_bp.get("/user/<mb_username:user_name>/listen-count")
 @crossdomain
 @ratelimit()
-@api_listenstore_needed
 def get_listen_count(user_name):
     """
         Get the number of listens for a user ``user_name``.
@@ -228,10 +227,13 @@ def get_listen_count(user_name):
                     "count": 137,
                     "range": "week",
                     "from_ts": 1588550400,
-                    "to_ts": 1589155199,
+                    "to_ts": 1589155200,
                     "last_updated": 1592807084
                 }
             }
+
+        ``from_ts`` is the start of the period the count applies to and
+        ``to_ts`` is the exclusive end of the underlying statistic's window.
 
     :param range: Optional, time interval for which the listen count should be
         returned, possible values are :data:`~data.model.common_stat.ALLOWED_STATISTICS_RANGE`,
@@ -251,6 +253,11 @@ def get_listen_count(user_name):
     stats_range = request.args.get("range", default="all_time")
 
     if stats_range == "all_time":
+        # only the all_time count is served from the listenstore; ranged counts
+        # come from precomputed stats and stay available if timescale is down
+        if timescale_connection._ts is None:
+            raise APIServiceUnavailable("The listen database is momentarily offline. "
+                                        "Please wait a few minutes and try again.")
         try:
             listen_count = timescale_connection._ts.get_listen_count_for_user(user["id"])
         except psycopg2.OperationalError as err:

--- a/listenbrainz/webserver/views/stats_utils.py
+++ b/listenbrainz/webserver/views/stats_utils.py
@@ -1,0 +1,62 @@
+""" Helpers for deriving values from precomputed statistics.
+
+    Kept free of Flask/DB imports so the pure logic can be unit tested in
+    isolation.
+"""
+from datetime import datetime, timezone
+from typing import Optional, Tuple
+
+from dateutil.relativedelta import relativedelta
+
+#: Offset from the start of the previous period to the start of the current
+#: period, for each listening-activity range. The listening_activity stat spans
+#: two consecutive periods (previous + current) so the website can render a
+#: comparison, so the current period begins one such offset after the stat's
+#: first segment.
+LISTENING_ACTIVITY_PERIOD_OFFSET = {
+    "this_week": relativedelta(weeks=1),
+    "week": relativedelta(weeks=1),
+    "this_month": relativedelta(months=1),
+    "month": relativedelta(months=1),
+    "quarter": relativedelta(months=3),
+    "half_yearly": relativedelta(months=6),
+    "this_year": relativedelta(years=1),
+    "year": relativedelta(years=1),
+}
+
+
+def current_period_listen_count(stats_range: str, records) -> Tuple[int, Optional[int]]:
+    """ Sum the listens of the *current* period of a listening_activity stat.
+
+        The listening_activity stat stores per-segment listen counts covering
+        two consecutive periods (the previous and the current one) so that the
+        website can draw a comparison chart. This returns the total for the
+        current (most recent) period only, matching the number displayed on
+        listenbrainz.org.
+
+        Args:
+            stats_range: one of the listening-activity ranges, or ``all_time``.
+            records: iterable of segments, each with ``from_ts`` and
+                ``listen_count`` attributes (e.g. ListeningActivityRecord).
+
+        Returns:
+            A ``(listen_count, from_ts)`` tuple where ``from_ts`` is the start of
+            the current period (or ``None`` when there are no records). For
+            ``all_time`` every segment is summed since there is no previous
+            period to exclude.
+    """
+    records = list(records)
+    if not records:
+        return 0, None
+
+    base_ts = min(record.from_ts for record in records)
+    if stats_range == "all_time":
+        total = sum(record.listen_count for record in records)
+        return total, base_ts
+
+    offset = LISTENING_ACTIVITY_PERIOD_OFFSET[stats_range]
+    period_start = datetime.fromtimestamp(base_ts, tz=timezone.utc) + offset
+    period_start_ts = int(period_start.timestamp())
+
+    total = sum(record.listen_count for record in records if record.from_ts >= period_start_ts)
+    return total, period_start_ts


### PR DESCRIPTION
# Problem
This addresses **LB-1217** (Extend `/(user_name)/listen-count` endpoint with range parameter).

Currently the API only exposes a user's overall (all-time) listen count via `GET /1/user/(user_name)/listen-count`. There is no way to get the listen count for a single statistics period (week, month, year, …).

The website already shows this per-period total on the reports page (e.g. `/user/<name>/reports/?range=week`), but it is not directly available via the API. It also cannot be trivially reconstructed from the `listening-activity` endpoint, because that response spans **both** the previous and the current period with no clear boundary between them.

# Solution

**Endpoint (`api.py`):**
* Added an optional `range` query parameter (any of `ALLOWED_STATISTICS_RANGE`, defaults to `all_time`).
* `all_time` / no `range` keeps the existing behaviour exactly — the precise listen count from TimescaleDB — so the change is fully backward compatible.
* For any other valid range, the count is derived from the user's precomputed `listening_activity` statistic and matches the per-period total shown on the website.
* Invalid range returns `400`; a range whose stats haven't been computed yet returns `204` (consistent with the other stats endpoints).
* The range response additionally includes `range`, `from_ts`, `to_ts` and `last_updated`.

**Current-period logic (`stats_utils.py`, new):**
* Added a pure helper `current_period_listen_count()`. The `listening_activity` stat spans two consecutive periods (previous + current) so the site can draw a comparison; the helper sums only the current period's segments.

**Tests:**
* Unit tests (`test_stats_utils.py`) for the helper — week, month, year, quarter, half_yearly, all_time, plus unordered and empty input.
* Integration tests (`test_stats_api.py`) for the endpoint — valid range count, invalid range (`400`) and missing stats (`204`).

**Documentation:**
* Documented the new `range` parameter, the `204`/`400` status codes and an example response in the endpoint docstring, which renders on the API docs page via the existing `autoflask` directive.

* [ ] I have run the code and manually tested the changes

# AI usage
* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for communication
* [x] I used AI tools for coding
* [ ] I understand all the changes made in this PR

> The code in this PR (the endpoint changes, the current_period_listen_count helper, and the tests) was written with the help of an AI coding assistant working under my direction. I decided the approach (deriving the per-period count from the existing listening_activity statistic), reviewed every change, and ran the unit tests, integration tests and manual endpoint checks myself to verify the returned output.

# Action
None.
