### PR TITLE
Add notify-spotify-refresh-token-expiry to crontab

### DIFF
--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -62,3 +62,6 @@ MAILTO=""
 
 # delete old and expired user data exports
 0 11 * * * root /usr/local/bin/python /code/listenbrainz/manage.py delete-old-user-data-exports >> /logs/user_data_exports.log 2>&1
+
+# [run daily] warn spotify users of expiring auth tokens
+0 12 * * * root /usr/local/bin/python /code/listenbrainz/manage.py notify-spotify-refresh-token-expiry >> /logs/spotify_token_expiry_notifications.log 2>&1


### PR DESCRIPTION
Notifies spotify users with token expiring in a month or in a week to disconnect/reconnect their spotify account
Run task every day at 12.

Also see blog post: https://blog.metabrainz.org/2026/07/19/spotify-users-will-need-to-reconnect-every-6-months-to-listenbrainz/