### PR TITLE
feat: Add claim-based work distribution for background task workers

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -222,7 +222,8 @@ CREATE TABLE background_tasks (
     user_id         INTEGER NOT NULL,
     task            background_tasks_type NOT NULL,
     created         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    metadata        JSONB
+    metadata        JSONB,
+    claimed_at      TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE user_data_export (

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -224,7 +224,8 @@ CREATE TABLE background_tasks (
     user_id         INTEGER NOT NULL,
     task            background_tasks_type NOT NULL,
     created         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    metadata        JSONB
+    metadata        JSONB,
+    claimed_at      TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE user_data_export (

--- a/admin/sql/updates/2026-07-13-add-claimed-at-to-background-tasks.sql
+++ b/admin/sql/updates/2026-07-13-add-claimed-at-to-background-tasks.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE background_tasks ADD COLUMN claimed_at TIMESTAMPTZ;
+
+COMMIT;

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -1,3 +1,4 @@
+import signal
 import time
 
 from flask import current_app
@@ -61,6 +62,9 @@ def remove_task(task):
 
 class BackgroundTasks:
 
+    def __init__(self):
+        self._current_task = None
+
     def process_task(self, task):
         """ Perform the task """
         current_app.logger.info(f"Processing task: {task.id}")
@@ -75,27 +79,40 @@ class BackgroundTasks:
         else:
             current_app.logger.error(f"Unknown task type: {task}")
 
+    def _release_on_shutdown(self, signum, frame):
+        """ Best-effort release of the current task on SIGTERM (docker stop, deploys). """
+        if self._current_task:
+            try:
+                release_task(self._current_task)
+                current_app.logger.info("Released task %s on shutdown.", self._current_task.id)
+            except Exception:
+                current_app.logger.error("Failed to release task on shutdown:", exc_info=True)
+        raise SystemExit(0)
+
     def start(self):
         current_app.logger.info("Background tasks processor started.")
+        signal.signal(signal.SIGTERM, self._release_on_shutdown)
         while True:
             try:
                 task = claim_task()
                 if task is None:
                     time.sleep(current_app.config.get("BACKGROUND_TASKS_SLEEP_TIME", 5))
                     continue
+                self._current_task = task
                 try:
                     self.process_task(task)
                     remove_task(task)
                 except Exception:
                     current_app.logger.error("Error processing task:", exc_info=True)
                     release_task(task)
+                finally:
+                    self._current_task = None
             except KeyboardInterrupt:
                 current_app.logger.error("Keyboard interrupt!")
                 break
             except Exception:
                 current_app.logger.error("Error in background tasks processor:", exc_info=True)
                 time.sleep(2)
-                # Exit the container, restart
                 current_app.logger.info("Exiting process, letting container restart.")
                 break
             finally:

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -8,6 +8,9 @@ from listenbrainz.background.export import export_user
 from listenbrainz.webserver import create_app, db_conn, ts_conn
 from listenbrainz.background.listens_importer import import_listens
 
+CLAIM_TIMEOUT_HOURS = 6
+
+
 def add_task(user_id, task):
     """ Add a task to the background tasks """
     query = "INSERT INTO background_tasks (user_id, task) VALUES (:user_id, :task) ON CONFLICT DO NOTHING"
@@ -15,19 +18,44 @@ def add_task(user_id, task):
     db_conn.commit()
 
 
-def get_task():
-    """ Fetch one task from the database """
-    # todo: use for update skip locked to scale to multiple workers
-    #  but that needs ensuring tasks processing doesn't interfere with
-    #  the task retrieval and deletion.
-    query = "SELECT * FROM background_tasks ORDER BY created LIMIT 1"
-    result = db_conn.execute(text(query))
-    return result.first()
+def claim_task():
+    """ Claim the oldest unclaimed task using FOR UPDATE SKIP LOCKED.
+
+    The lock is only held for the duration of the UPDATE — once committed,
+    the claim survives any intermediate commits during processing.
+    Crashed workers' tasks are auto-reclaimed after CLAIM_TIMEOUT_HOURS.
+    """
+    result = db_conn.execute(text(f"""
+        WITH claimable AS (
+            SELECT id
+              FROM background_tasks
+             WHERE claimed_at IS NULL
+                OR claimed_at < now() - interval '{CLAIM_TIMEOUT_HOURS} hours'
+          ORDER BY created
+             LIMIT 1
+               FOR UPDATE SKIP LOCKED
+        )
+        UPDATE background_tasks
+           SET claimed_at = now()
+         WHERE id = (SELECT id FROM claimable)
+     RETURNING *
+    """))
+    task = result.first()
+    db_conn.commit()
+    return task
+
+
+def release_task(task):
+    """ Release a claimed task so it can be retried by another worker. """
+    db_conn.execute(text("""
+        UPDATE background_tasks SET claimed_at = NULL WHERE id = :id
+    """), {"id": task.id})
+    db_conn.commit()
 
 
 def remove_task(task):
-    query = "DELETE FROM background_tasks WHERE id = :id"
-    db_conn.execute(text(query), {"id": task.id})
+    """ Delete a completed task. """
+    db_conn.execute(text("DELETE FROM background_tasks WHERE id = :id"), {"id": task.id})
     db_conn.commit()
 
 
@@ -35,31 +63,32 @@ class BackgroundTasks:
 
     def process_task(self, task):
         """ Perform the task """
-        try:
-            current_app.logger.info(f"Processing task: {task.id}")
-            if task.task == "delete_listens":
-                delete_listens_history(db_conn, task.user_id, task.created)
-            elif task.task == "delete_user":
-                delete_user(db_conn, ts_conn, task.user_id, task.created)
-            elif task.task == "export_all_user_data":
-                export_user(db_conn, ts_conn, task.user_id, task.metadata)
-            elif task.task == "import_listens":
-                import_listens(db_conn, ts_conn, task.user_id, task.metadata)
-            else:
-                current_app.logger.error(f"Unknown task type: {task}")
-        except Exception:
-            current_app.logger.error("Error processing task:", exc_info=True)
+        current_app.logger.info(f"Processing task: {task.id}")
+        if task.task == "delete_listens":
+            delete_listens_history(db_conn, task.user_id, task.created)
+        elif task.task == "delete_user":
+            delete_user(db_conn, ts_conn, task.user_id, task.created)
+        elif task.task == "export_all_user_data":
+            export_user(db_conn, ts_conn, task.user_id, task.metadata)
+        elif task.task == "import_listens":
+            import_listens(db_conn, ts_conn, task.user_id, task.metadata)
+        else:
+            current_app.logger.error(f"Unknown task type: {task}")
 
     def start(self):
         current_app.logger.info("Background tasks processor started.")
         while True:
             try:
-                task = get_task()
+                task = claim_task()
                 if task is None:
                     time.sleep(current_app.config.get("BACKGROUND_TASKS_SLEEP_TIME", 5))
                     continue
-                self.process_task(task)
-                remove_task(task)
+                try:
+                    self.process_task(task)
+                    remove_task(task)
+                except Exception:
+                    current_app.logger.error("Error processing task:", exc_info=True)
+                    release_task(task)
             except KeyboardInterrupt:
                 current_app.logger.error("Keyboard interrupt!")
                 break
@@ -78,6 +107,7 @@ class BackgroundTasks:
                 # by simply exiting the container when this happens and start fresh.
                 db_conn.rollback()
                 ts_conn.rollback()
+
 
 if __name__ == "__main__":
     bt = BackgroundTasks()

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -86,7 +86,7 @@ class BackgroundTasks:
                 release_task(self._current_task)
                 current_app.logger.info("Released task %s on shutdown.", self._current_task.id)
             except Exception:
-                current_app.logger.error("Failed to release task on shutdown:", exc_info=True)
+                current_app.logger.error("Failed to release task %s on shutdown:", self._current_task.id, exc_info=True)
         raise SystemExit(0)
 
     def start(self):

--- a/listenbrainz/background/background_tasks.py
+++ b/listenbrainz/background/background_tasks.py
@@ -19,6 +19,15 @@ def add_task(user_id, task):
     db_conn.commit()
 
 
+def peek_task():
+    """ Return the oldest background task without claiming it.
+
+    Used by tests to verify a task was queued. Workers must use claim_task().
+    """
+    result = db_conn.execute(text("SELECT * FROM background_tasks ORDER BY created LIMIT 1"))
+    return result.first()
+
+
 def claim_task():
     """ Claim the oldest unclaimed task using FOR UPDATE SKIP LOCKED.
 

--- a/listenbrainz/tests/integration/test_settings_views.py
+++ b/listenbrainz/tests/integration/test_settings_views.py
@@ -4,7 +4,7 @@ import time
 from brainzutils import cache
 
 import listenbrainz.db.user as db_user
-from listenbrainz.background.background_tasks import claim_task
+from listenbrainz.background.background_tasks import peek_task
 from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -83,8 +83,9 @@ class SettingsViewsTestCase(IntegrationTestCase):
         resp = self.client.post(self.custom_url_for('settings.delete_listens'))
         self.assertEqual(resp.status_code, 200)
 
+        # Peek without claiming so the background_tasks worker can process the delete.
         with self.app.app_context():
-            task = claim_task()
+            task = peek_task()
             self.assertIsNotNone(task)
             self.assertEqual(task.user_id, self.user["id"])
             self.assertEqual(task.task, "delete_listens")

--- a/listenbrainz/tests/integration/test_settings_views.py
+++ b/listenbrainz/tests/integration/test_settings_views.py
@@ -4,7 +4,7 @@ import time
 from brainzutils import cache
 
 import listenbrainz.db.user as db_user
-from listenbrainz.background.background_tasks import get_task
+from listenbrainz.background.background_tasks import claim_task
 from listenbrainz.listenstore.timescale_listenstore import REDIS_USER_LISTEN_COUNT
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -84,7 +84,7 @@ class SettingsViewsTestCase(IntegrationTestCase):
         self.assertEqual(resp.status_code, 200)
 
         with self.app.app_context():
-            task = get_task()
+            task = claim_task()
             self.assertIsNotNone(task)
             self.assertEqual(task.user_id, self.user["id"])
             self.assertEqual(task.task, "delete_listens")

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import listenbrainz.db.user as db_user
 import listenbrainz.webserver.login
-from listenbrainz.background.background_tasks import claim_task
+from listenbrainz.background.background_tasks import peek_task
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.domain.musicbrainz import MusicBrainzService
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -73,7 +73,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assert200(r)
         mock_authorize_mb_user_deleter.assert_called_once_with('132')
         with self.app.app_context():
-            task = claim_task()
+            task = peek_task()
             self.assertIsNotNone(task)
             self.assertEqual(task.user_id, user_id)
             self.assertEqual(task.task, "delete_user")
@@ -98,7 +98,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assert200(r)
         mock_get_user_info.assert_called_with('132')
         with self.app.app_context():
-            task = claim_task()
+            task = peek_task()
             self.assertIsNotNone(task)
             self.assertEqual(task.user_id, user_id)
             self.assertEqual(task.task, "delete_user")

--- a/listenbrainz/webserver/views/test/test_index.py
+++ b/listenbrainz/webserver/views/test/test_index.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 import listenbrainz.db.user as db_user
 import listenbrainz.webserver.login
-from listenbrainz.background.background_tasks import get_task
+from listenbrainz.background.background_tasks import claim_task
 from listenbrainz.db.testing import DatabaseTestCase
 from listenbrainz.domain.musicbrainz import MusicBrainzService
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -73,7 +73,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assert200(r)
         mock_authorize_mb_user_deleter.assert_called_once_with('132')
         with self.app.app_context():
-            task = get_task()
+            task = claim_task()
             self.assertIsNotNone(task)
             self.assertEqual(task.user_id, user_id)
             self.assertEqual(task.task, "delete_user")
@@ -98,7 +98,7 @@ class IndexViewsTestCase(IntegrationTestCase):
         self.assert200(r)
         mock_get_user_info.assert_called_with('132')
         with self.app.app_context():
-            task = get_task()
+            task = claim_task()
             self.assertIsNotNone(task)
             self.assertEqual(task.user_id, user_id)
             self.assertEqual(task.task, "delete_user")

--- a/listenbrainz/webserver/views/test/test_webhook_receiver.py
+++ b/listenbrainz/webserver/views/test/test_webhook_receiver.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from sqlalchemy import text
 
-from listenbrainz.background.background_tasks import claim_task
+from listenbrainz.background.background_tasks import peek_task
 from listenbrainz.db import user as db_user
 
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -267,7 +267,7 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         self.assert200(response)
 
         with self.app.app_context():
-            task = claim_task()
+            task = peek_task()
         self.assertIsNone(task)
 
         payload = {
@@ -291,7 +291,7 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         self.assert200(response)
 
         with self.app.app_context():
-            task = claim_task()
+            task = peek_task()
         self.assertIsNotNone(task)
         self.assertEqual(task.user_id, user_id)
         self.assertEqual(task.task, "delete_user")

--- a/listenbrainz/webserver/views/test/test_webhook_receiver.py
+++ b/listenbrainz/webserver/views/test/test_webhook_receiver.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from sqlalchemy import text
 
-from listenbrainz.background.background_tasks import get_task
+from listenbrainz.background.background_tasks import claim_task
 from listenbrainz.db import user as db_user
 
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -267,7 +267,7 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         self.assert200(response)
 
         with self.app.app_context():
-            task = get_task()
+            task = claim_task()
         self.assertIsNone(task)
 
         payload = {
@@ -291,7 +291,7 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         self.assert200(response)
 
         with self.app.app_context():
-            task = get_task()
+            task = claim_task()
         self.assertIsNotNone(task)
         self.assertEqual(task.user_id, user_id)
         self.assertEqual(task.task, "delete_user")


### PR DESCRIPTION
Replace the plain SELECT with a claim/release pattern using FOR UPDATE SKIP LOCKED so multiple background task workers can run without processing the same task. The claim survives intermediate commits during long-running tasks (e.g. multi-hour file imports).

- claim_task(): CTE locks and marks claimed_at in one quick transaction
- release_task(): clears claimed_at on failure so task is retryable
- remove_task(): deletes on success (unchanged)
- Auto-reclaim after 6 hours for crashed worker recovery
- Exceptions in process_task() now propagate instead of being swallowed

* [ ] I have run the code and manually tested the changes

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

I've used Cursor while writing code based on the plan I've created.

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


1. :beginner: If any action is needed on merge or deployment, list it such as:
   1. Add tests
   2. Run an SQL update script
