### PR TITLE
LB-2019: Allow users to dismiss admin alerts

### DIFF
--- a/frontend/js/src/layout/index.tsx
+++ b/frontend/js/src/layout/index.tsx
@@ -36,7 +36,7 @@ async function showInitialAlerts(initialAlerts: ServerAlert[]) {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(
-      "LocalStorage error, initial alert dismissals may not be remembered",
+      "Browser storage error, initial alert dismissals may not be remembered",
       error
     );
   }

--- a/frontend/js/src/layout/index.tsx
+++ b/frontend/js/src/layout/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Outlet, ScrollRestoration } from "react-router";
 import { toast, ToastContainer, ToastOptions } from "react-toastify";
+import localforage from "localforage";
 
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react";
 import Footer from "../components/Footer";
@@ -20,6 +21,57 @@ const mappingLevelToBootstrapClass = {
   error: "danger",
 };
 
+const dismissedInitialAlertsStore = localforage.createInstance({
+  name: "listenbrainz",
+  driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE],
+  storeName: "dismissed-initial-alerts",
+});
+
+async function showInitialAlerts(initialAlerts: ServerAlert[]) {
+  let dismissedInitialAlertIds = new Set<string>();
+  try {
+    dismissedInitialAlertIds = new Set(
+      await dismissedInitialAlertsStore.keys()
+    );
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "LocalStorage error, initial alert dismissals may not be remembered",
+      error
+    );
+  }
+
+  initialAlerts
+    .filter((alert) => !dismissedInitialAlertIds.has(alert.id))
+    .forEach((alert) => {
+      const levelOrDefault = alert.level ?? "default";
+      const bsClass = mappingLevelToBootstrapClass[levelOrDefault];
+      const options: ToastOptions = {
+        autoClose: false,
+        closeOnClick: false,
+        draggable: false,
+        containerId: "initial-alerts",
+        toastId: alert.id,
+        type: levelOrDefault,
+        className: `alert alert-${bsClass}`,
+        onClose: () => {
+          dismissedInitialAlertsStore.setItem(alert.id, true).catch((error) => {
+            // eslint-disable-next-line no-console
+            console.error(
+              "LocalStorage error, initial alert dismissal may not be remembered",
+              error
+            );
+          });
+        },
+      };
+      const messageWithHTML = (
+        // eslint-disable-next-line react/no-danger -- we control the content of the initial alerts, so this is safe
+        <span dangerouslySetInnerHTML={{ __html: alert.message }} />
+      );
+      toast(messageWithHTML, options);
+    });
+}
+
 export default function Layout({
   children,
   initialAlerts = [],
@@ -32,23 +84,7 @@ export default function Layout({
   withBrainzPlayer?: boolean;
 }) {
   React.useEffect(() => {
-    initialAlerts.forEach((alert) => {
-      const levelOrDefault = alert.level ?? "default";
-      const bsClass = mappingLevelToBootstrapClass[levelOrDefault];
-      const options: ToastOptions = {
-        autoClose: false,
-        closeOnClick: false,
-        containerId: "initial-alerts",
-        toastId: alert.id,
-        type: levelOrDefault,
-        className: `alert alert-${bsClass}`,
-      };
-      const messageWithHTML = (
-        // eslint-disable-next-line react/no-danger -- we control the content of the initial alerts, so this is safe
-        <span dangerouslySetInnerHTML={{ __html: alert.message }} />
-      );
-      toast(messageWithHTML, options);
-    });
+    showInitialAlerts(initialAlerts);
   }, [initialAlerts]);
 
   return (

--- a/frontend/js/tests/layout/Layout.test.tsx
+++ b/frontend/js/tests/layout/Layout.test.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { toast } from "react-toastify";
+
+const mockLocalForageStore = new Map<string, unknown>();
+const mockKeys = jest.fn(() =>
+  Promise.resolve(Array.from(mockLocalForageStore.keys()))
+);
+const mockSetItem = jest.fn((key: string, value: unknown) => {
+  mockLocalForageStore.set(key, value);
+  return Promise.resolve(value);
+});
+
+jest.mock("localforage", () => ({
+  __esModule: true,
+  default: {
+    INDEXEDDB: "INDEXEDDB",
+    LOCALSTORAGE: "LOCALSTORAGE",
+    createInstance: jest.fn(() => ({
+      keys: mockKeys,
+      setItem: mockSetItem,
+    })),
+  },
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+  ToastContainer: () => null,
+}));
+
+jest.mock("react-router", () => ({
+  Outlet: () => null,
+  ScrollRestoration: () => null,
+}));
+
+jest.mock("../../src/components/Footer", () => () => null);
+jest.mock("../../src/components/Navbar", () => () => null);
+jest.mock("../../src/utils/ProtectedRoutes", () => () => null);
+
+let Layout: typeof import("../../src/layout").default;
+
+describe("Layout initial alerts", () => {
+  const initialAlerts = [
+    {
+      id: "test-alert",
+      level: "info" as const,
+      message: "Test alert",
+    },
+  ];
+
+  beforeEach(() => {
+    mockLocalForageStore.clear();
+    jest.clearAllMocks();
+  });
+
+  beforeAll(async () => {
+    const layoutModule = await import("../../src/layout");
+    Layout = layoutModule.default;
+  });
+
+  it("stores dismissed initial alerts and skips them on later renders", async () => {
+    const { unmount } = render(
+      <Layout initialAlerts={initialAlerts} withBrainzPlayer={false} />
+    );
+
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    const mockedToast = toast as unknown as jest.Mock;
+    const toastOptions = mockedToast.mock.calls[0][1];
+    expect(toastOptions.toastId).toBe("test-alert");
+
+    toastOptions.onClose();
+
+    await waitFor(() =>
+      expect(mockLocalForageStore.get("test-alert")).toBe(true)
+    );
+
+    unmount();
+    jest.clearAllMocks();
+    render(<Layout initialAlerts={initialAlerts} withBrainzPlayer={false} />);
+
+    await waitFor(() => expect(mockKeys).toHaveBeenCalledTimes(1));
+    expect(toast).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
#3756 added a way for admins to show a toast/alert/popup/whateveryouwannacallit on the website. Those alerts are dismissable, but next time you load the page they will be back.
This PR adds a way for users to dismiss the alerts, and save that in the browser's localstorage/indexedDB so at next page load the alert in question is not shown.

* [x] I have run the code and manually tested the changes

# AI usage
* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Used Codex to generate the test file for the Layout component, specifically for the alerts testing which required a lot of mocking setup.
