### PR TITLE
ci: version bumps and zizmor-powered hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -1,4 +1,5 @@
 name: ListenBrainz Build Production Image
+permissions: {}
 
 on:
   push:

--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -28,7 +28,7 @@ jobs:
       if: github.event.pull_request.draft == false
 
       steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/build-prod-image.yml
+++ b/.github/workflows/build-prod-image.yml
@@ -29,6 +29,8 @@ jobs:
 
       steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Login to Docker Hub
         run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,4 +1,5 @@
 name: Build and publish image to Docker Hub
+permissions: {}
 
 on:
   release:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
 
     - name: Docker Setup Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       
     - name: Docker Login
-      uses: docker/login-action@v2
+      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
         
     - name: Build and push Docker images
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         build-args: GIT_COMMIT_SHA=${{ github.ref_name }}
         cache-from: metabrainz/listenbrainz:cache

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,5 @@
 name: ListenBrainz Frontend Tests
+permissions: {}
 
 on:
   push:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
@@ -39,7 +39,7 @@ jobs:
     # We do not use this to install node but only to register problem matchers
     # so that eslint annotations work.
     - name: Setup Node.js environment to enable annotations
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 
     - name: Build frontend containers
       run: ./test.sh fe -b

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -22,12 +22,12 @@ jobs:
 
       steps:
       # Run only if we are deploying a branch or tag from this repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # empty strings evaluate to 0
         if: ${{ github.event.inputs.pr == 0}}
         
       # Run only if we are deploying a PR (may be in a forked repo)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ github.event.inputs.pr != 0}}
         with:
           ref: ${{ format('refs/pull/{0}/head', github.event.inputs.pr) }}

--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -1,6 +1,7 @@
 # This workflow can be used to push an image off a branch to Docker Hub.
 # This is useful to deploy changes to LB beta or test for testing.
 name: Push development image
+permissions: {}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -25,12 +25,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # empty strings evaluate to 0
         if: ${{ github.event.inputs.pr == 0}}
+        with:
+          persist-credentials: false
         
       # Run only if we are deploying a PR (may be in a forked repo)
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ github.event.inputs.pr != 0}}
         with:
           ref: ${{ format('refs/pull/{0}/head', github.event.inputs.pr) }}
+          persist-credentials: false
 
 
       - name: Login to Docker Hub

--- a/.github/workflows/push-dev-image.yml
+++ b/.github/workflows/push-dev-image.yml
@@ -41,8 +41,12 @@ jobs:
         run: |
           docker build \
             --target listenbrainz-prod \
-            --tag metabrainz/listenbrainz:"${{ github.event.inputs.tag }}" \
+            --tag metabrainz/listenbrainz:"${GITHUB_EVENT_INPUTS_TAG}" \
             --build-arg GIT_COMMIT_SHA="${{ github.sha }}" .
+        env:
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}
 
       - name: Push development image
-        run: docker push metabrainz/listenbrainz:"${{ github.event.inputs.tag }}"
+        run: docker push metabrainz/listenbrainz:"${GITHUB_EVENT_INPUTS_TAG}"
+        env:
+          GITHUB_EVENT_INPUTS_TAG: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,5 @@
 name: Release Drafter
+permissions: {}
 
 on:
   push:
@@ -9,6 +10,10 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed for drafting releases per [1]
+      pull-requests: read # Needed for drafting releases per [1]
+      # [1] https://github.com/release-drafter/release-drafter/tree/master#usage
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-zizmor.yml
+++ b/.github/workflows/run-zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -1,5 +1,5 @@
 name: ListenBrainz Spark Tests
-
+permissions: {}
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Create configuration file
       run: cp listenbrainz/config.py.sample listenbrainz/config.py

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Create configuration file
       run: cp listenbrainz/config.py.sample listenbrainz/config.py

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,5 @@
 name: ListenBrainz Server Tests
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
TL;DR: Replicates metabrainz/musicbrainz-server#3777 and metabrainz/musicbrainz-server#3782, but for LB

# Problem

GitHub Actions and their misconfigurations are often a target for threat actors due to a number of security pitfalls, some of which GitHub is aware of and provides best practice guidance for, others are inherent to the architecture of GitHub Actions.

In addition, most if not all of our action `uses` pointed at outdated versions. (A significant portion of the annotations on any given workflow run were due to Node runtime deprecations, for example.)

# Solution

In each commit, this PR introduces a new set of improvements to our GitHub Actions configurations:

- Bump major versions of actions where available (among other things, this fixes the deprecation warnings described above)
- Apply auto-fixes identified by [zizmor](https://zizmor.sh/), a powerful static analysis tool for GitHub Actions (most of the fixes are action version pins, but one disables credential persistence; the latter can be explicitly added back if we figure out we really need it)
- Remediates another set of zizmor findings by disabling all permissions by default at the workflow level (if we find we need them for specific jobs, we can add them back at the per-job level)
- Adds a new workflow designed to run zizmor and report back findings
- Adds a Dependabot config for GitHub Actions only (since versions are now pinned, it's good to keep them up to date, [albeit with a cooldown period](https://docs.zizmor.sh/audits/#dependabot-cooldown))

# AI usage

* [x] I did not use any AI
* [ ] I have used AI in this PR ~~(add more details below)~~

# Further action

It's possible that zeroing out most permissions by default may be too restrictive. I found one instance where a workflow had certain required permissions (namely, in the release drafter) and added those, but that may not be all that's needed to keep some workflows functioning.

The zizmor-based fixes here are based on the default ["persona"](https://docs.zizmor.sh/usage/#using-personas). There are more findings in this repo emitted under stricter personas that are probably worth at least glancing at if not also remediating, but I wanted to at least give default-persona changes a go to see if, e.g., we need to add back credential persistence or job-level permissions before going stricter.
