### PR TITLE
Make webhooks idempotent

### DIFF
--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -311,6 +311,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         uid = random.randint(2000, 1 << 31)
         testuser = db_user.get_or_create(self.db_conn, uid, "user_%d" % uid)
         self.logstore.set_empty_values_for_user(testuser["id"])
+        self.logstore.set_empty_values_for_user(testuser["id"])
         data = self._get_count_and_timestamps(testuser["id"])
         self.assertEqual(data["count"], 0)
         self.assertEqual(data["min_listened_at"], None)

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -54,8 +54,13 @@ class TimescaleListenStore:
 
     def set_empty_values_for_user(self, user_id: int):
         """When a user is created, set the timestamp keys and insert an entry in the listen count
-         table so that we can avoid the expensive lookup for a brand new user."""
-        query = """INSERT INTO listen_user_metadata VALUES (:user_id, 0, NULL, NULL, NOW())"""
+         table so that we can avoid the expensive lookup for a brand new user. If the user already
+         has an entry, leave it unchanged."""
+        query = """
+            INSERT INTO listen_user_metadata (user_id, count, min_listened_at, max_listened_at, created)
+                 VALUES (:user_id, 0, NULL, NULL, NOW())
+            ON CONFLICT (user_id) DO NOTHING
+        """
         ts_conn.execute(sqlalchemy.text(query), {"user_id": user_id})
         ts_conn.commit()
 

--- a/listenbrainz/webserver/views/test/test_webhook_receiver.py
+++ b/listenbrainz/webserver/views/test/test_webhook_receiver.py
@@ -4,6 +4,8 @@ import json
 import uuid
 from unittest import mock
 
+from sqlalchemy import text
+
 from listenbrainz.background.background_tasks import get_task
 from listenbrainz.db import user as db_user
 
@@ -63,6 +65,10 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         }
 
         response, delivery_id = self._send_webhook("user.created", payload)
+        self.assert200(response)
+        self.assertEqual(response.json["status"], "success")
+
+        response, _ = self._send_webhook("user.created", payload, delivery_id=delivery_id)
         self.assert200(response)
         self.assertEqual(response.json["status"], "success")
 
@@ -210,7 +216,10 @@ class WebhookReceiverTestCase(IntegrationTestCase):
             "old": {"name": "oldusername"},
             "new": {"name": "newusername"}
         }
-        response, _ = self._send_webhook("user.updated", update_payload)
+        response, delivery_id = self._send_webhook("user.updated", update_payload)
+        self.assert200(response)
+
+        response, _ = self._send_webhook("user.updated", update_payload, delivery_id=delivery_id)
         self.assert200(response)
 
         user = db_user.get_by_mb_row_id(self.db_conn, 456, fetch_email=True)
@@ -275,7 +284,10 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         user_id = user["id"]
 
         delete_payload = {"user_id": 789}
-        response, _ = self._send_webhook("user.deleted", delete_payload)
+        response, delivery_id = self._send_webhook("user.deleted", delete_payload)
+        self.assert200(response)
+
+        response, _ = self._send_webhook("user.deleted", delete_payload, delivery_id=delivery_id)
         self.assert200(response)
 
         with self.app.app_context():
@@ -283,3 +295,9 @@ class WebhookReceiverTestCase(IntegrationTestCase):
         self.assertIsNotNone(task)
         self.assertEqual(task.user_id, user_id)
         self.assertEqual(task.task, "delete_user")
+
+        result = self.db_conn.execute(
+            text("SELECT count(*) FROM background_tasks WHERE user_id = :user_id AND task = 'delete_user'"),
+            {"user_id": user_id},
+        )
+        self.assertEqual(result.scalar_one(), 1)


### PR DESCRIPTION
Handle redelivery of already delivered webhook well to avoid crashes.