### PR TITLE
Revert CritiqueBrainz OAuth scope change

### DIFF
--- a/listenbrainz/domain/critiquebrainz.py
+++ b/listenbrainz/domain/critiquebrainz.py
@@ -7,7 +7,7 @@ from data.model.external_service import ExternalServiceType
 from listenbrainz.db.model.review import CBReviewMetadata
 from listenbrainz.domain.brainz_service import BaseBrainzService
 
-CRITIQUEBRAINZ_SCOPES = ["critiquebrainz:review"]
+CRITIQUEBRAINZ_SCOPES = ["review"]
 
 OAUTH_AUTHORIZE_URL = "https://critiquebrainz.org/oauth/authorize"
 OAUTH_TOKEN_URL = "https://critiquebrainz.org/ws/1/oauth/token"


### PR DESCRIPTION
Mistake introduced in 3c4bea4 , these scopes are for the CritiqueBrainz OAuth (unprefixed) and not for the MetaBrainz OAuth (prefixed).

This currently results in an error when users log into CB from the LB website:
<img width="781" height="362" alt="image" src="https://github.com/user-attachments/assets/0d2b4c8d-40ca-47d6-a03b-b865dde973dc" />

Manually changing the scope from `critiquebrainz:review` to `review` in the URL confirms that was the problem:

<img width="1198" height="465" alt="image" src="https://github.com/user-attachments/assets/8cd24427-e9f9-40a8-b8b9-da1d54791c52" />
 
(Excuse my french.)