### PR TITLE
Prevent unecessary UserSocialNetwork re-renders

### DIFF
--- a/frontend/js/src/user-feed/NetworkFeed.tsx
+++ b/frontend/js/src/user-feed/NetworkFeed.tsx
@@ -271,7 +271,7 @@ export default function NetworkFeedPage() {
           )}
         </div>
         <div className="col-sm-4">
-          <UserSocialNetwork user={currentUser} />
+          <UserSocialNetwork userName={currentUser.name} />
         </div>
       </div>
     </>

--- a/frontend/js/src/user/Dashboard.tsx
+++ b/frontend/js/src/user/Dashboard.tsx
@@ -509,7 +509,7 @@ export default function Listen() {
             />
           )}
           {user && <ListenCountCard user={user} listenCount={listenCount} />}
-          {user && <UserSocialNetwork user={user} />}
+          {user && <UserSocialNetwork userName={user.name} />}
         </div>
         <div className="col-lg-8 order-lg-1">
           {!listens.length && (

--- a/frontend/js/src/user/components/follow/CompatibilityCard.tsx
+++ b/frontend/js/src/user/components/follow/CompatibilityCard.tsx
@@ -9,7 +9,7 @@ import Card from "../../../components/Card";
 import SimilarityScore from "./SimilarityScore";
 
 export type CompatibilityCardProps = {
-  user: ListenBrainzUser;
+  userName: string;
   similarityScore: number;
   similarArtists: Array<{
     artist_name: string;
@@ -19,7 +19,7 @@ export type CompatibilityCardProps = {
 };
 
 function CompatibilityCard(props: CompatibilityCardProps) {
-  const { user, similarityScore, similarArtists } = props;
+  const { userName, similarityScore, similarArtists } = props;
 
   const firstFiveArtists = similarArtists.slice(0, 5);
   const otherArtists = similarArtists.slice(5, 25);
@@ -85,17 +85,17 @@ function CompatibilityCard(props: CompatibilityCardProps) {
     <Card id="compatibility-card" data-testid="compatibility-card">
       <div className="info-icon" data-tip data-for="info-tooltip">
         <Link
-          to={`/user/${encodeURIComponent(user.name)}/stats/?range=all_time`}
+          to={`/user/${encodeURIComponent(userName)}/stats/?range=all_time`}
           target="_blank"
           rel="noopener noreferrer"
         >
           <FontAwesomeIcon icon={faCircleInfo} />
         </Link>
       </div>
-      <span>Your compatibility with {user.name}:</span>
+      <span>Your compatibility with {userName}:</span>
       <SimilarityScore
         similarityScore={similarityScore}
-        user={user}
+        userName={userName}
         type="compact"
       />
       <hr />

--- a/frontend/js/src/user/components/follow/FollowerFollowingCards.tsx
+++ b/frontend/js/src/user/components/follow/FollowerFollowingCards.tsx
@@ -6,7 +6,7 @@ import UserListModalEntry from "./UserListModalEntry";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 export type FollowerFollowingCardsProps = {
-  user: ListenBrainzUser;
+  userName: string;
   followerList: Array<string>;
   followingList: Array<string>;
   loggedInUserFollowsUser: (user: ListenBrainzUser | SimilarUser) => boolean;
@@ -44,7 +44,7 @@ export default class FollowerFollowingCards extends React.Component<
       updateFollowingList,
       followerList,
       followingList,
-      user,
+      userName,
     } = this.props;
     const { activeMode } = this.state;
     const { currentUser } = this.context;
@@ -59,9 +59,9 @@ export default class FollowerFollowingCards extends React.Component<
             <>
               <hr />
               <div className="follower-following-empty text-center text-muted">
-                {user.name === currentUser?.name
+                {userName === currentUser?.name
                   ? "You don't"
-                  : `${user.name} doesn't`}{" "}
+                  : `${userName} doesn't`}{" "}
                 have any followers.
               </div>
             </>
@@ -71,9 +71,9 @@ export default class FollowerFollowingCards extends React.Component<
           <>
             <hr />
             <div className="follower-following-empty text-center text-muted">
-              {user.name === currentUser?.name
+              {userName === currentUser?.name
                 ? "You aren't"
-                : `${user.name} isn't`}{" "}
+                : `${userName} isn't`}{" "}
               following anyone.
             </div>
           </>

--- a/frontend/js/src/user/components/follow/SimilarUsersModal.tsx
+++ b/frontend/js/src/user/components/follow/SimilarUsersModal.tsx
@@ -5,7 +5,7 @@ import UserListModalEntry from "./UserListModalEntry";
 import GlobalAppContext from "../../../utils/GlobalAppContext";
 
 export type SimilarUsersModalProps = {
-  user: ListenBrainzUser;
+  userName: string;
   similarUsersList: Array<SimilarUser>;
   loggedInUserFollowsUser: (user: ListenBrainzUser | SimilarUser) => boolean;
   updateFollowingList: (
@@ -16,12 +16,13 @@ export type SimilarUsersModalProps = {
 
 function SimilarUsersModal(props: SimilarUsersModalProps) {
   const {
-    user,
+    userName,
     loggedInUserFollowsUser,
     updateFollowingList,
     similarUsersList,
   } = props;
   const { currentUser } = React.useContext(GlobalAppContext);
+  const currentUserName = currentUser?.name;
 
   const renderSimilarUsersList = React.useCallback(() => {
     if (similarUsersList.length === 0) {
@@ -30,7 +31,7 @@ function SimilarUsersModal(props: SimilarUsersModalProps) {
           <hr />
           <div className="similar-users-empty text-center text-muted">
             Users with similar music tastes to{" "}
-            {user.name === currentUser?.name ? "you" : user.name} will appear
+            {userName === currentUserName ? "you" : userName} will appear
             here.
           </div>
         </>
@@ -53,8 +54,8 @@ function SimilarUsersModal(props: SimilarUsersModalProps) {
     );
   }, [
     similarUsersList,
-    user,
-    currentUser,
+    userName,
+    currentUserName,
     loggedInUserFollowsUser,
     updateFollowingList,
   ]);

--- a/frontend/js/src/user/components/follow/SimilarityScore.tsx
+++ b/frontend/js/src/user/components/follow/SimilarityScore.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 export type SimilarityScoreProps = {
   type: "regular" | "compact";
   similarityScore: number;
-  user?: ListenBrainzUser;
+  userName?: string;
 };
 
 const getclassName = (similarityScore: number): string => {
@@ -19,7 +19,7 @@ const getclassName = (similarityScore: number): string => {
 };
 
 function SimilarityScore(props: SimilarityScoreProps) {
-  const { user, type, similarityScore } = props;
+  const { userName, type, similarityScore } = props;
 
   // We transform the similarity score from a scale 0-1 to 0-100
   const percentage = Number((similarityScore * 100).toFixed());
@@ -48,7 +48,7 @@ function SimilarityScore(props: SimilarityScoreProps) {
       </div>
       {type === "regular" ? (
         <p className="text-muted">
-          Your compatibility with {user?.name} is {percentage}%
+          Your compatibility with {userName} is {percentage}%
         </p>
       ) : (
         <p className="small text-muted">{percentage}%</p>

--- a/frontend/js/src/user/components/follow/UserListModalEntry.tsx
+++ b/frontend/js/src/user/components/follow/UserListModalEntry.tsx
@@ -27,7 +27,7 @@ function UserListModalEntry(props: UserListModalEntryProps) {
         {isUserLoggedIn && mode === "similar-users" && (
           <SimilarityScore
             similarityScore={(user as SimilarUser).similarityScore}
-            user={user}
+            userName={user.name}
             type="compact"
           />
         )}

--- a/frontend/js/src/user/components/follow/UserSocialNetwork.tsx
+++ b/frontend/js/src/user/components/follow/UserSocialNetwork.tsx
@@ -10,11 +10,11 @@ import { ToastMsg } from "../../../notifications/Notifications";
 import FlairsExplanationButton from "../../../common/flairs/FlairsExplanationButton";
 
 export type UserSocialNetworkProps = {
-  user: ListenBrainzUser;
+  userName: string;
 };
 
 function UserSocialNetwork(props: UserSocialNetworkProps) {
-  const { user: profileUser } = props;
+  const { userName } = props;
   const { currentUser, APIService } = React.useContext(GlobalAppContext);
 
   const [followerList, setFollowerList] = React.useState<Array<string>>([]);
@@ -60,7 +60,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
     } = APIService;
 
     // Get followers
-    getFollowersOfUser(profileUser.name)
+    getFollowersOfUser(userName)
       .then((response: { followers: string[] }) => {
         setFollowerList(response.followers || []);
       })
@@ -79,7 +79,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
       });
 
     // Get following
-    getFollowingForUser(profileUser.name)
+    getFollowingForUser(userName)
       .then((response: { following: string[] }) => {
         setFollowingList(response.following || []);
       })
@@ -89,7 +89,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
         } else {
           toast.error(
             <ToastMsg
-              title={`Error while fetching ${profileUser?.name}'s following`}
+              title={`Error while fetching ${userName}'s following`}
               message={err.toString()}
             />,
             { toastId: "fetch-following-error" }
@@ -98,7 +98,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
       });
 
     // Get similar users
-    getSimilarUsersForUser(profileUser.name)
+    getSimilarUsersForUser(userName)
       .then(
         (response: {
           payload: Array<{ user_name: string; similarity: number }>;
@@ -148,9 +148,9 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
     }
 
     // Get similarity and similar artists (only if logged in and different user)
-    if (currentUser?.name && currentUser.name !== profileUser.name) {
+    if (currentUser?.name && currentUser.name !== userName) {
       // Get similarity
-      getSimilarityBetweenUsers(currentUser.name, profileUser.name)
+      getSimilarityBetweenUsers(currentUser.name, userName)
         .then((response: { payload: { similarity: number } }) => {
           setSimilarityScore(response.payload.similarity);
         })
@@ -175,7 +175,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
 
       // Get similar artists
       Promise.all([
-        getUserEntity(profileUser.name, "artist", "all_time", 0, 100),
+        getUserEntity(userName, "artist", "all_time", 0, 100),
         getUserEntity(currentUser.name, "artist", "all_time", 0, 100),
       ])
         .then(([userResponse, currentUserResponse]) => {
@@ -201,10 +201,10 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
           }
         });
     }
-  }, [profileUser, currentUser, APIService, showUserNotFoundToast]);
+  }, [userName, currentUser?.name, APIService, showUserNotFoundToast]);
 
   const isAnotherUser =
-    Boolean(currentUser?.name) && currentUser.name !== profileUser?.name;
+    Boolean(currentUser?.name) && currentUser.name !== userName;
 
   const loggedInUserFollowsUser = (user: ListenBrainzUser): boolean => {
     if (isNil(currentUser) || isEmpty(currentUser)) {
@@ -232,7 +232,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
 
     // update the users following list (for followers/following pane)
     const newFollowingList = [...followingList];
-    if (profileUser.name === currentUser.name) {
+    if (userName === currentUser.name) {
       const profileUserIndex = newFollowingList.indexOf(user.name);
       if (action === "follow" && profileUserIndex === -1) {
         newFollowingList.push(user.name);
@@ -250,7 +250,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
     <>
       {isAnotherUser && (
         <CompatibilityCard
-          user={profileUser}
+          userName={userName}
           similarityScore={similarityScore}
           similarArtists={similarArtists}
         />
@@ -259,7 +259,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
         <div className="col-6 col-lg-12 d-none d-sm-block">
           <Card>
             <FollowerFollowingCards
-              user={profileUser}
+              userName={userName}
               followerList={followerList}
               followingList={followingList}
               loggedInUserFollowsUser={loggedInUserFollowsUser}
@@ -273,7 +273,7 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
         <div className="col-6 col-lg-12 d-none d-sm-block">
           <Card className="card-user-sn">
             <SimilarUsersModal
-              user={profileUser}
+              userName={userName}
               similarUsersList={similarUsersList}
               loggedInUserFollowsUser={loggedInUserFollowsUser}
               updateFollowingList={updateFollowingList}
@@ -285,4 +285,4 @@ function UserSocialNetwork(props: UserSocialNetworkProps) {
   );
 }
 
-export default UserSocialNetwork;
+export default React.memo(UserSocialNetwork);

--- a/frontend/js/tests/user/follow/FollowerFollowingModal.test.tsx
+++ b/frontend/js/tests/user/follow/FollowerFollowingModal.test.tsx
@@ -14,7 +14,7 @@ import { ReactQueryWrapper } from "../../test-react-query";
 import { textContentMatcher } from "../../test-utils/rtl-test-utils";
 
 const defaultProps: FollowerFollowingCardsProps = {
-  user: { name: "foobar" },
+  userName: "foobar",
   followerList: ["foo"],
   followingList: ["bar"],
   loggedInUserFollowsUser: () => true,

--- a/frontend/js/tests/user/follow/SimilarUsersModal.test.tsx
+++ b/frontend/js/tests/user/follow/SimilarUsersModal.test.tsx
@@ -10,7 +10,7 @@ import RecordingFeedbackManager from "../../../src/utils/RecordingFeedbackManage
 import { ReactQueryWrapper } from "../../test-react-query";
 
 const props = {
-  user: { name: "shivam-kapila" },
+  userName: "shivam-kapila",
   similarUsersList: [{ name: "mr_monkey", similarityScore: 0.567 }],
   loggedInUserFollowsUser: () => true,
   updateFollowingList: () => {},

--- a/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
+++ b/frontend/js/tests/user/follow/UserSocialNetwork.test.tsx
@@ -42,7 +42,7 @@ jest.mock("react-toastify", () => ({
 
 const { loggedInUser, ...otherProps } = userSocialNetworkProps;
 const props = {
-  ...otherProps,
+  userName: otherProps.user.name,
 };
 
 const globalContext: GlobalAppContextT = {
@@ -148,7 +148,7 @@ describe("<UserSocialNetwork />", () => {
 
   it("renders CompatibilityCard when viewing another user's profile", async () => {
     const differentUserProps = {
-      user: { id: 2, name: "differentuser" },
+      userName: "differentuser",
     };
 
     renderWithProviders(
@@ -163,7 +163,7 @@ describe("<UserSocialNetwork />", () => {
 
   it("does not render CompatibilityCard when viewing own profile", async () => {
     const ownProfileProps = {
-      user: { id: 1, name: loggedInUser.name },
+      userName: loggedInUser.name,
     };
 
     renderWithProviders(
@@ -202,8 +202,8 @@ describe("<UserSocialNetwork />", () => {
 
     // Wait for component to mount and make API calls
     await waitFor(() => {
-      expect(getFollowersOfUserSpy).toHaveBeenCalledWith(props.user.name);
-      expect(getFollowingForUserSpy).toHaveBeenCalledWith(props.user.name);
+      expect(getFollowersOfUserSpy).toHaveBeenCalledWith(props.userName);
+      expect(getFollowingForUserSpy).toHaveBeenCalledWith(props.userName);
     });
 
     // Verify the modal component receives the data (check if it's rendered)
@@ -237,7 +237,7 @@ describe("<UserSocialNetwork />", () => {
 
     // Wait for API call to be made
     await waitFor(() => {
-      expect(getSimilarUsersForUserSpy).toHaveBeenCalledWith(props.user.name);
+      expect(getSimilarUsersForUserSpy).toHaveBeenCalledWith(props.userName);
     });
 
     // Verify the similar users modal is rendered
@@ -335,7 +335,7 @@ describe("<UserSocialNetwork />", () => {
 
   it("does not fetch similarity data when viewing own profile", async () => {
     const ownProfileProps = {
-      user: { id: 1, name: loggedInUser.name },
+      userName: loggedInUser.name,
     };
 
     renderWithProviders(
@@ -363,7 +363,7 @@ describe("<UserSocialNetwork />", () => {
     );
 
     const differentUserProps = {
-      user: { id: 2, name: "differentuser" },
+      userName: "differentuser",
     };
 
     renderWithProviders(
@@ -389,7 +389,7 @@ describe("<UserSocialNetwork />", () => {
   it("re-fetches data when profileUser changes", async () => {
     const { rerender } = renderWithProviders(
       <QueryClientProvider client={queryClient}>
-        <UserSocialNetwork user={{ id: 1, name: "user1" }} />
+        <UserSocialNetwork userName="user1" />
       </QueryClientProvider>,
       globalContext
     );
@@ -403,7 +403,7 @@ describe("<UserSocialNetwork />", () => {
     // Change the user prop
     rerender(
       <QueryClientProvider client={queryClient}>
-        <UserSocialNetwork user={{ id: 2, name: "user2" }} />
+        <UserSocialNetwork userName="user2" />
       </QueryClientProvider>
     );
 
@@ -441,7 +441,7 @@ describe("<UserSocialNetwork />", () => {
   );
 
   renderWithProviders(
-    <UserSocialNetwork user={{ name: "nonexistent_user" }} />,
+    <UserSocialNetwork userName="nonexistent_user" />,
     globalContext
   );
 

--- a/frontend/js/tests/user/stats/SimilarityScore.test.tsx
+++ b/frontend/js/tests/user/stats/SimilarityScore.test.tsx
@@ -6,7 +6,7 @@ import SimilarityScore, {
 
 const defaultProps: SimilarityScoreProps = {
   similarityScore: 0.239745792, // This will be rounded to 24%
-  user: { auth_token: "baz", name: "test" },
+  userName: "test",
   type: "regular",
 };
 


### PR DESCRIPTION
# Problem

I noticed an annoying thing in my console network tab, we are doing a lot of unnecessary API calls on the Dashboard page.
Currently each time a user paginates to a new page of listens on their Dashboard, API calls are made to multiple endpoints as the UserSocialNetwork component rerenders.
Every page change does 4 unnecessary API calls to fetch the same data
The cause is the `user` object dependency which changes identity even if the data inside it does not. Good ol' javascript comparison gotcha I didn't think about...

# Solution
Passing down the username only (the only piece of data required from the user object for all these components), we avoid those re-renders as the username string does not change adn the string comparison is simpler

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Used Codex as a glorified search-and-replace after giving it a list of components to make the same change to
