### PR TITLE
perf: parallelize feed event queries and fix entity page connection pooling

### DIFF
--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -191,7 +191,7 @@ def artist_entity(artist_mbid: str):
         top_release_group_color = None
 
     try:
-        top_recording_color = popularity.get_top_recordings_for_artist(db_conn, ts_conn, artist_mbid, 1)[0]["release_color"]
+        top_recording_color = popular_recordings[0]["release_color"]
     except IndexError:
         top_recording_color = None
 
@@ -383,48 +383,45 @@ def recording_entity(recording_mbid: str):
     if not is_valid_uuid(recording_mbid):
         return jsonify({"error": "Provided recording mbid is invalid: %s" % recording_mbid}), 400
 
-    with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
-            psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_PGBOUNCER_URI"]) as ts_conn, \
-            mb_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as mb_curs, \
-            ts_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as ts_curs:
-        recording_data = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, [recording_mbid])
-    if recording_data is None or len(recording_data) == 0 or recording_data[0].get("recording_mbid") is None:
-        return jsonify({"error": f"Recording {recording_mbid} not found in the metadata cache"}), 404
-
-    recording_data = recording_data[0]
-
+    mb_conn = psycopg2.connect(current_app.config["MB_DATABASE_URI"])
     try:
-        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
-                mb_conn.cursor(cursor_factory=DictCursor) as mb_curs, \
-                ts_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as ts_curs:
+        with mb_conn.cursor(cursor_factory=DictCursor) as mb_curs, \
+                ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
+            recording_data = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, [recording_mbid])
+        if recording_data is None or len(recording_data) == 0 or recording_data[0].get("recording_mbid") is None:
+            return jsonify({"error": f"Recording {recording_mbid} not found in the metadata cache"}), 404
 
-            similar_recordings = similarity.get_recordings(
-                mb_curs,
-                ts_curs,
-                [recording_mbid],
-                "session_based_days_7500_session_300_contribution_5_threshold_15_limit_50_skip_30_top_n_listeners_1000",
-                18
-            )
-            similar_recording_mbids = [recording["recording_mbid"] for recording in similar_recordings]
-            similar_recordings_data = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, similar_recording_mbids)
-    except Exception:
-        current_app.logger.error("Error loading similar recordings:", exc_info=True)
-        similar_recordings_data = []
+        recording_data = recording_data[0]
 
-    try:
-        with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
-                mb_conn.cursor(cursor_factory=DictCursor) as mb_curs:
-            release_groups_data = load_release_groups_for_recordings(mb_curs, [recording_mbid])
-            release_groups_data = list(release_groups_data.values())
-    except Exception:
-        current_app.logger.error("Error loading release groups for recording:", exc_info=True)
-        release_groups_data = []
+        try:
+            with mb_conn.cursor(cursor_factory=DictCursor) as mb_curs, \
+                    ts_conn.connection.cursor(cursor_factory=DictCursor) as ts_curs:
+                similar_recordings = similarity.get_recordings(
+                    mb_curs,
+                    ts_curs,
+                    [recording_mbid],
+                    "session_based_days_7500_session_300_contribution_5_threshold_15_limit_50_skip_30_top_n_listeners_1000",
+                    18
+                )
+                similar_recording_mbids = [recording["recording_mbid"] for recording in similar_recordings]
+                similar_recordings_data = load_recordings_from_mbids_with_redirects(mb_curs, ts_curs, similar_recording_mbids)
+        except Exception:
+            current_app.logger.error("Error loading similar recordings:", exc_info=True)
+            similar_recordings_data = []
+
+        try:
+            with mb_conn.cursor(cursor_factory=DictCursor) as mb_curs:
+                release_groups_data = load_release_groups_for_recordings(mb_curs, [recording_mbid])
+                release_groups_data = list(release_groups_data.values())
+        except Exception:
+            current_app.logger.error("Error loading release groups for recording:", exc_info=True)
+            release_groups_data = []
+    finally:
+        mb_conn.close()
 
     release_group_mbids = [rg["mbid"] for rg in release_groups_data]
     try:
-        with psycopg2.connect(current_app.config["SQLALCHEMY_TIMESCALE_PGBOUNCER_URI"]) as ts_conn, \
-                ts_conn.cursor(cursor_factory=DictCursor) as ts_curs:
-            popularity_data, _ = popularity.get_counts(ts_curs, "release_group", release_group_mbids)
+        popularity_data, _ = popularity.get_counts(ts_conn, "release_group", release_group_mbids)
     except Exception:
         current_app.logger.error("Error loading popularity data for release groups:", exc_info=True)
         popularity_data = []

--- a/listenbrainz/webserver/views/user_timeline_event_api.py
+++ b/listenbrainz/webserver/views/user_timeline_event_api.py
@@ -17,6 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Iterable
 
@@ -794,69 +795,42 @@ def get_feed_events_for_user(
     max_ts: int,
     count: int,
 ) -> List[APITimelineEvent]:
-    """Gets all user events in the feed."""
+    """Gets all user events in the feed, fetching all event types concurrently."""
 
     users_for_events = followed_users + [user]
-    follow_events = get_follow_events(
-        users_for_events=users_for_events,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
+    min_ts = min_ts or 0
+    max_ts = max_ts or int(time.time())
 
-    recording_recommendation_events = get_recording_recommendation_events(
-        users_for_events=users_for_events,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
+    app = current_app._get_current_object()
 
-    personal_recording_recommendation_events = get_personal_recording_recommendation_events(
-        user=user,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
+    def in_context(fn, **kwargs):
+        def run():
+            with app.app_context():
+                return fn(**kwargs)
+        return run
 
-    thanks_events = get_thanks_events(
-        user=user,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
+    tasks = {
+        "follow": in_context(get_follow_events, users_for_events=users_for_events, min_ts=min_ts, max_ts=max_ts, count=count),
+        "rec_rec": in_context(get_recording_recommendation_events, users_for_events=users_for_events, min_ts=min_ts, max_ts=max_ts, count=count),
+        "personal": in_context(get_personal_recording_recommendation_events, user=user, min_ts=min_ts, max_ts=max_ts, count=count),
+        "thanks": in_context(get_thanks_events, user=user, min_ts=min_ts, max_ts=max_ts, count=count),
+        "cb_review": in_context(get_cb_review_events, users_for_events=users_for_events, min_ts=min_ts, max_ts=max_ts, count=count),
+        "notification": in_context(get_notification_events, user=user, min_ts=min_ts, max_ts=max_ts, count=count),
+        "pin": in_context(get_recording_pin_events, users_for_events=users_for_events, min_ts=min_ts, max_ts=max_ts, count=count),
+    }
 
-    cb_review_events = get_cb_review_events(
-        users_for_events=users_for_events,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
-
-    notification_events = get_notification_events(
-        user=user,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
-
-    recording_pin_events = get_recording_pin_events(
-        users_for_events=users_for_events,
-        min_ts=min_ts or 0,
-        max_ts=max_ts or int(time.time()),
-        count=count,
-    )
+    all_events = []
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        futures = {executor.submit(fn): name for name, fn in tasks.items()}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                all_events.extend(future.result())
+            except Exception:
+                current_app.logger.error("Error fetching %s feed events:", name, exc_info=True)
 
     # TODO: add playlist event and like event
-    all_events = sorted(
-        follow_events
-        + recording_recommendation_events
-        + recording_pin_events
-        + cb_review_events
-        + notification_events
-        + personal_recording_recommendation_events
-        + thanks_events,
-        key=lambda event: -event.created,
-    )
+    all_events.sort(key=lambda event: -event.created)
 
     hidden_event_ids = db_user_timeline_event.get_hidden_timeline_event_ids(
         db_conn, user["id"], count


### PR DESCRIPTION
# Problem

Two unrelated issues were both wasting WSGI threads and DB connections:

1. The `/user/<user>/feed/events` endpoint runs 7 independent DB queries back to back inside `get_feed_events_for_user`. Each query waits for the previous one to finish even though none of them depend on each other. The thread is held for the sum of all 7 instead of the slowest one.

2. The recording entity page (`/track/<mbid>/`) was opening 5 raw `psycopg2.connect()` calls per request -- 3 separate connections to the MusicBrainz DB and 2 to TimescaleDB -- all bypassing the SQLAlchemy connection pool. Each one is a fresh TCP handshake that gets discarded after a single use.

# Solution

**Feed endpoint:** Replaced the sequential calls in `get_feed_events_for_user` with a `ThreadPoolExecutor`. All 7 event type queries now run concurrently. Each thread gets its own Flask app context so `db_conn`/`ts_conn` resolve correctly against the pool. Failures in individual sub-queries are caught per thread and log an error rather than crashing the whole feed response.

**Entity page connections:**
- `recording_entity`: consolidated from 5 raw connections to 1 shared MB connection + the pooled `ts_conn` for all TimescaleDB work. The popularity counts call now uses `ts_conn` directly, matching the pattern already used in `album_entity`.
- `artist_entity`: removed a redundant `get_top_recordings_for_artist(count=1)` call that was only used to get the top recording's color. That value is already in `popular_recordings[0]` which was fetched earlier in the same request with `count=10`.

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I have used AI in this PR (add more details below)

- [x] I used AI tools for coding
- [x] I understand all the changes made in this PR

Used Claude Code to assist with investigation, implementation, and analysis throughout this PR. All changes were reviewed and validated against the codebase.