### PR TITLE
LB-1604: Add release_group_mbid to mbid_mapping in fetched listens

### DIFF
--- a/docs/users/json.rst
+++ b/docs/users/json.rst
@@ -212,6 +212,10 @@ The following fields may be present in the ``mbid_mapping`` element:
    * - ``release_mbid``
      - string
      - A MusicBrainz Release ID of the canonical release for this recording.
+   * - ``release_group_mbid``
+     - string
+     - The MusicBrainz Release Group ID that ``release_mbid`` belongs to. Useful for
+       grouping listens by album without additional metadata lookups.
    * - ``artist_mbids``
      - array of strings
      - A list of MusicBrainz Artist IDs from the artist credit of the matched recording.
@@ -272,6 +276,7 @@ user-submitted data in ``additional_info`` and the server-resolved data in ``mbi
           "recording_mbid": "30d08f4c-d825-4ae1-b79c-44242cddd7c0",
           "recording_name": "Some Resolve",
           "release_mbid": "e96c2e7b-94fd-4fbe-9c44-1a27d8664825",
+          "release_group_mbid": "1d98b0bc-5832-49d2-a93e-463032631a2f",
           "artist_mbids": [
             "1c70a3fc-fa3c-4be1-8b55-c3192db8a884"
           ],

--- a/listenbrainz/listen.py
+++ b/listenbrainz/listen.py
@@ -132,7 +132,7 @@ class Listen(object):
     def from_timescale(cls, listened_at, user_id, created, recording_msid, track_metadata,
                        recording_mbid=None, recording_name=None, release_mbid=None, artist_mbids=None,
                        ac_names=None, ac_join_phrases=None, user_name=None,
-                       caa_id=None, caa_release_mbid=None, url_rels=None):
+                       caa_id=None, caa_release_mbid=None, url_rels=None, release_group_mbid=None):
         """Factory to make Listen() objects from a timescale dict"""
         track_metadata["additional_info"]["recording_msid"] = recording_msid
         if recording_mbid is not None:
@@ -143,6 +143,9 @@ class Listen(object):
 
             if release_mbid is not None:
                 track_metadata["mbid_mapping"]["release_mbid"] = str(release_mbid)
+
+            if release_group_mbid is not None:
+                track_metadata["mbid_mapping"]["release_group_mbid"] = str(release_group_mbid)
 
             if artist_mbids is not None and ac_names is not None and ac_join_phrases is not None:
                 artists = []

--- a/listenbrainz/listenstore/tests/test_timescalelistenstore.py
+++ b/listenbrainz/listenstore/tests/test_timescalelistenstore.py
@@ -185,6 +185,7 @@ class TestTimescaleListenStore(DatabaseTestCase, TimescaleTestCase):
         self.assertEqual(len(listens), 1)
         self.assertEqual(listens[0].data["mbid_mapping"]["artist_mbids"], ['678d88b2-87b0-403b-b63d-5da7465aecc3'])
         self.assertEqual(listens[0].data["mbid_mapping"]["release_mbid"], '93ac1812-d38d-4125-88e8-8440e3e89072')
+        self.assertEqual(listens[0].data["mbid_mapping"]["release_group_mbid"], '53f80f76-f8af-3558-bfd5-e7221e055c75')
         self.assertEqual(listens[0].data["mbid_mapping"]["recording_mbid"], '2cfad207-3f55-4aec-8120-86cf66e34d59')
 
     def test_get_listen_count_for_user(self):

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -264,6 +264,7 @@ class TimescaleListenStore:
                         , sl.recording_mbid
                         , mbc.recording_data->>'name' AS recording_name
                         , mbc.release_mbid
+                        , mbc.release_data->>'release_group_mbid' AS release_group_mbid
                         , mbc.artist_mbids::TEXT[]
                         , (mbc.release_data->>'caa_id')::bigint AS caa_id
                         , mbc.release_data->>'caa_release_mbid' AS caa_release_mbid
@@ -283,6 +284,7 @@ class TimescaleListenStore:
                         , sl.recording_mbid
                         , recording_data->>'name'
                         , release_mbid
+                        , release_data->>'release_group_mbid'
                         , artist_mbids
                         , artist_data->>'name'
                         , recording_data->>'name'
@@ -358,6 +360,7 @@ class TimescaleListenStore:
                     recording_mbid=result.recording_mbid,
                     recording_name=result.recording_name,
                     release_mbid=result.release_mbid,
+                    release_group_mbid=result.release_group_mbid,
                     artist_mbids=result.artist_mbids,
                     ac_names=result.ac_names,
                     ac_join_phrases=result.ac_join_phrases,
@@ -436,6 +439,7 @@ class TimescaleListenStore:
                          , l.recording_mbid
                          , mbc.recording_data->>'name' AS recording_name
                          , mbc.release_mbid
+                         , mbc.release_data->>'release_group_mbid' AS release_group_mbid
                          , mbc.artist_mbids::TEXT[]
                          , (mbc.release_data->>'caa_id')::bigint AS caa_id
                          , mbc.release_data->>'caa_release_mbid' AS caa_release_mbid
@@ -455,6 +459,7 @@ class TimescaleListenStore:
                          , l.recording_mbid
                          , mbc.recording_data->>'name'
                          , mbc.release_mbid
+                         , mbc.release_data->>'release_group_mbid'
                          , mbc.artist_mbids
                          , mbc.release_data->>'caa_id'
                          , mbc.release_data->>'caa_release_mbid'
@@ -480,6 +485,7 @@ class TimescaleListenStore:
                 recording_mbid=result.recording_mbid,
                 recording_name=result.recording_name,
                 release_mbid=result.release_mbid,
+                release_group_mbid=result.release_group_mbid,
                 artist_mbids=result.artist_mbids,
                 ac_names=result.ac_names,
                 ac_join_phrases=result.ac_join_phrases,
@@ -538,6 +544,7 @@ class TimescaleListenStore:
                          , l.recording_mbid
                          , mbc.recording_data->>'name' AS recording_name
                          , mbc.release_mbid
+                         , mbc.release_data->>'release_group_mbid' AS release_group_mbid
                          , mbc.artist_mbids::TEXT[]
                          , (mbc.release_data->>'caa_id')::bigint AS caa_id
                          , mbc.release_data->>'caa_release_mbid' AS caa_release_mbid
@@ -557,6 +564,7 @@ class TimescaleListenStore:
                          , l.recording_mbid
                          , mbc.recording_data->>'name'
                          , mbc.release_mbid
+                         , mbc.release_data->>'release_group_mbid'
                          , mbc.artist_mbids
                          , mbc.release_data->>'caa_id'
                          , mbc.release_data->>'caa_release_mbid'
@@ -582,6 +590,7 @@ class TimescaleListenStore:
                 recording_mbid=result.recording_mbid,
                 recording_name=result.recording_name,
                 release_mbid=result.release_mbid,
+                release_group_mbid=result.release_group_mbid,
                 artist_mbids=result.artist_mbids,
                 ac_names=result.ac_names,
                 ac_join_phrases=result.ac_join_phrases,


### PR DESCRIPTION
## Problem

`GET /1/user/(user_name)/listens` does not include a `release_group_mbid`, so grouping a user's listens by album requires one extra `GET /1/metadata/recording` call per listen — the exact pain point described in [LB-1604](https://tickets.metabrainz.org/browse/LB-1604).

Fixes [LB-1604](https://tickets.metabrainz.org/browse/LB-1604)

## Solution

The `mapping.mb_metadata_cache` table already stores the release group MBID inside its `release_data` JSONB, so no cache or schema changes are needed - the field just needs to be threaded through the listen-fetch path:

* `timescale_listenstore.py`: all three listen-fetch queries now select `release_data->>'release_group_mbid'` and pass it to `Listen.from_timescale()`.
* `listen.py`: `from_timescale()` adds `release_group_mbid` to `mbid_mapping` when the mapping has one (same pattern as `release_mbid`).
* Docs: added the field to the `mbid_mapping` reference table and the example listen in `json.rst`.
* Tests: `test_fetch_listens_with_mapping` now asserts the new field (the existing fixture already contained a `release_group_mbid`).

The field appears only in the server-resolved `mbid_mapping` block, is read-only, and is omitted when the mapped release has no release group data - fully backward compatible.

### Testing

`test_timescalelistenstore.py` (18 passed, including the new assertion) and `test_api.py` + `test_listen.py` (81 passed) run locally in the Docker test environment.

Screenshots of the local test run:

<img width="1919" height="1018" alt="Screenshot 2026-08-03 035313" src="https://github.com/user-attachments/assets/132f297a-1ca3-41ba-8efb-6f971b4aa89d" />

- [x] I have run the code and manually tested the changes

## AI usage

- [x] I have used AI in this PR (add more details below)
- [x] I used AI tools for communication
- [x] I used AI tools for coding
- [x] I understand all the changes made in this PR

The code in this PR was written with an AI coding assistant (Claude Code) working under my direction. The AI traced the existing `mbid_mapping` data flow (which I had previously documented in #3754) and made the changes following the existing `release_mbid` pattern. I reviewed every change and ran the test suites myself to verify the output.

## Action

None. The data is already present in `mb_metadata_cache`; the field starts appearing in responses on deploy.