### PR TITLE
Dumps Improvements - Retention and Memory Usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,8 @@ FROM listenbrainz-base AS listenbrainz-prod
 
 # Create directories for cron logs and dumps
 # /mnt/dumps: Temporary working space for dumps
-# /mnt/backup: All dumps
-# /mnt/ftp: Subset of all dumps that are uploaded to
+# /mnt/backup: Non-full public dump backups
+# /mnt/ftp: Temporary dump staging and small FTP-retention markers
 RUN mkdir /logs /mnt/dumps /mnt/backup /mnt/ftp
 
 COPY ./docker/run-lb-command /usr/local/bin

--- a/admin/config.sh.ctmpl
+++ b/admin/config.sh.ctmpl
@@ -7,15 +7,17 @@ DUMP_THREADS="{{template "KEY" "dump_threads"}}"
 DUMP_BASE_DIR="{{template "KEY" "base_dir"}}"
 PRIVATE_DUMP_BASE_DIR="{{template "KEY" "private_base_dir"}}"
 
-# Where to back things up to, who should own the backup files, and what mode
-# those files should have.
-# The backups include a full database export
+# Where to back up non-full public dumps, who should own the backup files, and
+# what mode those files should have. Public full dumps are uploaded to the
+# remote FTP host and then removed locally.
 BACKUP_DIR="{{template "KEY" "backup_dir"}}"
 BACKUP_USER="{{template "KEY" "user"}}"
 BACKUP_GROUP="{{template "KEY" "group"}}"
 BACKUP_DIR_MODE=700
 BACKUP_FILE_MODE=600
 
+# Private full database dumps are never uploaded to FTP and remain on this
+# private backup volume.
 PRIVATE_BACKUP_DIR="{{template "KEY" "private_backup_dir"}}"
 
 # Same but for the files that need to copied to the FTP server,

--- a/admin/config.sh.sample
+++ b/admin/config.sh.sample
@@ -4,15 +4,17 @@ DUMP_THREADS=4
 DUMP_BASE_DIR='/mnt/dumps'
 PRIVATE_DUMP_BASE_DIR='/private/dumps'
 
-# Where to back things up to, who should own the backup files, and what mode
-# those files should have.
-# The backups include a full database export, and all replication data.
+# Where to back up non-full public dumps, who should own the backup files, and
+# what mode those files should have. Public full dumps are uploaded to the
+# remote FTP host and then removed locally.
 BACKUP_DIR=/mnt/backup
 BACKUP_USER=root
 BACKUP_GROUP=root
 BACKUP_DIR_MODE=700
 BACKUP_FILE_MODE=600
 
+# Private full database dumps are never uploaded to FTP and remain on this
+# private backup volume.
 PRIVATE_BACKUP_DIR=/private/backup
 
 # Same but for the files that need to copied to the FTP server,

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -182,18 +182,23 @@ echo "Dump created with timestamp $DUMP_TIMESTAMP"
 DUMP_DIR=$(dirname "$DUMP_ID_FILE")
 DUMP_NAME=$(basename "$DUMP_DIR")
 
-# Backup dumps to the backup volume
-echo "Creating Backup directories..."
-mkdir -m "$BACKUP_DIR_MODE" -p \
-    "$BACKUP_DIR/$SUB_DIR" \
-    "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
-echo "Backup directories created!"
+# Full dumps are already published to the remote FTP server and are too large
+# to keep a second public copy on the backup volume. Other dump types retain
+# their existing local backup.
+if [ "$DUMP_TYPE" != "full" ]; then
+    echo "Creating Backup directories..."
+    mkdir -m "$BACKUP_DIR_MODE" -p \
+        "$BACKUP_DIR/$SUB_DIR" \
+        "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME"
+    echo "Backup directories created!"
 
-# Copy the files into the backup directory
-echo "Begin copying dumps to backup directory..."
-retry rsync -a "$DUMP_DIR/" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME/"
-chmod "$BACKUP_FILE_MODE" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME/"*
-echo "Dumps copied to backup directory!"
+    echo "Begin copying dumps to backup directory..."
+    retry rsync -a "$DUMP_DIR/" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME/"
+    chmod "$BACKUP_FILE_MODE" "$BACKUP_DIR/$SUB_DIR/$DUMP_NAME/"*
+    echo "Dumps copied to backup directory!"
+else
+    echo "Skipping the redundant public full dump backup."
+fi
 
 HAS_EMPTY_PRIVATE_DIRS_OR_FILES=$(find "$PRIVATE_DUMP_INTERMEDIATE_DIR" -empty)
 if [ -z "$HAS_EMPTY_PRIVATE_DIRS_OR_FILES" ]; then
@@ -234,17 +239,23 @@ mkdir  -m "$FTP_DIR_MODE" -p \
     "$FTP_DIR/$SUB_DIR" \
     "$FTP_CURRENT_DUMP_DIR"
 
-# make sure all dump files are owned by the correct user
-# and set appropriate mode for files to be uploaded to
-# the FTP server
-retry rsync -a "$DUMP_DIR/" "$FTP_CURRENT_DUMP_DIR/"
+# Make sure all dump files are owned by the correct user and set appropriate
+# mode for files to be uploaded to the FTP server. Move full-dump files into
+# staging instead of retaining another complete copy in the working directory.
+if [ "$DUMP_TYPE" == "full" ]; then
+    retry rsync -a --remove-source-files "$DUMP_DIR/" "$FTP_CURRENT_DUMP_DIR/"
+    rm -rf -- "$DUMP_DIR"
+else
+    retry rsync -a "$DUMP_DIR/" "$FTP_CURRENT_DUMP_DIR/"
+fi
 echo "Fixing FTP permissions"
 chmod "$FTP_DIR_MODE" "$FTP_CURRENT_DUMP_DIR"
 chmod "$FTP_FILE_MODE" "$FTP_CURRENT_DUMP_DIR/"*
 
-# create an explicit rsync filter for the new private dump in the
-# ftp folder
-touch "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
+# Create a fresh rsync filter for this dump. A directory reused after a retry
+# may contain a retention-marker filter, which must not hide the new payload.
+rm -f -- "$FTP_CURRENT_DUMP_DIR/.ftp-retention-marker"
+: > "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
 add_rsync_include_rule \
     "$FTP_CURRENT_DUMP_DIR" \
@@ -276,11 +287,20 @@ echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 cat "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
 
-/usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
-/usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
+if [ "$DUMP_TYPE" == "full" ]; then
+    # Full FTP retention is applied by rsync-dump-files.sh only after every
+    # pending payload has uploaded successfully. Remove public full dumps left
+    # on the legacy backup volume now that it is no longer used for them.
+    /usr/local/bin/python manage.py dump delete_old_dumps \
+        --remove-all-full-dumps \
+        "$BACKUP_DIR/$SUB_DIR"
+else
+    /usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
+    /usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
+fi
 /usr/local/bin/python manage.py dump delete_old_dumps "$PRIVATE_BACKUP_DIR/$SUB_DIR"
 
 # rsync to ftp folder taking care of the rules
-./admin/rsync-dump-files.sh "$DUMP_TYPE"
+./admin/rsync-dump-files.sh "$DUMP_TYPE" "$DUMP_NAME"
 
-echo "Dumps created, backed up and uploaded to the FTP server!"
+echo "Dumps created and uploaded to the FTP server; applicable backups completed!"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -226,6 +226,14 @@ if [ -n "$PRIVATE_DUMP_INTERMEDIATE_DIR" ]; then
         exit 1
     fi
 
+    read -r PRIVATE_DUMP_TIMESTAMP PRIVATE_DUMP_ID PRIVATE_DUMP_TYPE < "$PRIVATE_DUMP_ID_FILE"
+    if [ "$PRIVATE_DUMP_TIMESTAMP" != "$DUMP_TIMESTAMP" ] || \
+        [ "$PRIVATE_DUMP_ID" != "$DUMP_ID" ] || \
+        [ "$PRIVATE_DUMP_TYPE" != "$DUMP_TYPE" ]; then
+        echo "Public and private dump metadata do not match, exiting."
+        exit 1
+    fi
+
     PRIVATE_DUMP_DIR=$(dirname "$PRIVATE_DUMP_ID_FILE")
     PRIVATE_DUMP_NAME=$(basename "$PRIVATE_DUMP_DIR")
 
@@ -316,8 +324,8 @@ fi
 /usr/local/bin/python manage.py dump delete_old_dumps "$PRIVATE_BACKUP_DIR/$SUB_DIR"
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    # Public full dumps are no longer backed up locally, so remove any that are
-    # left over on the backup volume from when they were.
+    # Public full dumps are no longer backed up locally. Override the normal
+    # retention count (two) with zero to remove any legacy full dump backups.
     /usr/local/bin/python manage.py dump delete_old_dumps --keep full=0 "$BACKUP_DIR/$SUB_DIR"
 else
     /usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -310,11 +310,26 @@ if [ "$DUMP_TYPE" == "full" ]; then
     /usr/local/bin/python manage.py dump delete_old_dumps \
         --remove-all-full-dumps \
         "$BACKUP_DIR/$SUB_DIR"
+elif [ "$DUMP_TYPE" == "db" ]; then
+    # The FTP and backup fullexport directories also contain full dumps. A db
+    # run must not expire full payloads which may still be pending upload.
+    /usr/local/bin/python manage.py dump delete_old_dumps \
+        --only-db-dumps \
+        "$FTP_DIR/$SUB_DIR"
+    /usr/local/bin/python manage.py dump delete_old_dumps \
+        --only-db-dumps \
+        "$BACKUP_DIR/$SUB_DIR"
 else
     /usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
     /usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
 fi
-/usr/local/bin/python manage.py dump delete_old_dumps "$PRIVATE_BACKUP_DIR/$SUB_DIR"
+if [ "$DUMP_TYPE" == "db" ]; then
+    /usr/local/bin/python manage.py dump delete_old_dumps \
+        --only-db-dumps \
+        "$PRIVATE_BACKUP_DIR/$SUB_DIR"
+else
+    /usr/local/bin/python manage.py dump delete_old_dumps "$PRIVATE_BACKUP_DIR/$SUB_DIR"
+fi
 
 # rsync to ftp folder taking care of the rules
 ./admin/rsync-dump-files.sh "$DUMP_TYPE" "$DUMP_NAME"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -20,7 +20,7 @@
 
 # usage
 # the first argument to this script is the dump type, it can be either
-# full, incremental or feedback. the remaining arguments are forwarded
+# full, db, incremental or feedback. the remaining arguments are forwarded
 # the python dump_manager script. this can be useful in scenarios where
 # we want to pass in the --dump-id manually for recreating a failed dump.
 
@@ -32,9 +32,10 @@ cd "$LB_SERVER_ROOT" || exit 1
 source "admin/config.sh"
 source "admin/functions.sh"
 
-# This variable contains the name of a directory that is deleted when the script
-# exits, so we sanitise it here in case it was included in the environment.
+# These variables contain the names of directories that are deleted when the script
+# exits, so we sanitise them here in case they were included in the environment.
 DUMP_INTERMEDIATE_DIR=""
+PRIVATE_DUMP_INTERMEDIATE_DIR=""
 
 if [ "$DEPLOY_ENV" == "prod" ] && \
    { [ "$CONTAINER_NAME" == "listenbrainz-cron-prod" ] || [ "$CONTAINER_NAME" == "listenbrainz-full-dumps-cron-prod" ]; }
@@ -100,6 +101,9 @@ shift
 
 if [ "$DUMP_TYPE" == "full" ]; then
     SUB_DIR="fullexport"
+elif [ "$DUMP_TYPE" == "db" ]; then
+    # database dumps are published alongside the full listen dumps
+    SUB_DIR="fullexport"
 elif [ "$DUMP_TYPE" == "incremental" ]; then
     SUB_DIR="incremental"
 elif [ "$DUMP_TYPE" == "feedback" ]; then
@@ -109,7 +113,7 @@ elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
 elif [ "$DUMP_TYPE" == "sample" ]; then
     SUB_DIR="sample"
 else
-    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'incremental', 'feedback', 'mbcanonical' or 'sample'"
+    echo "ERROR: Dump Type $DUMP_TYPE is invalid. Dump type must be one of 'full', 'db', 'incremental', 'feedback', 'mbcanonical' or 'sample'"
     exit
 fi
 
@@ -126,16 +130,24 @@ mkdir -p "$DUMP_INTERMEDIATE_DIR"
 
 DUMP_TEMP_DIR="$DUMP_BASE_DIR"
 
-PRIVATE_DUMP_INTERMEDIATE_DIR="$PRIVATE_DUMP_BASE_DIR/$SUB_DIR.$$"
-echo "PRIVATE_DUMP_BASE_DIR is $PRIVATE_DUMP_BASE_DIR"
-echo "creating PRIVATE_DUMP_INTERMEDIATE_DIR $PRIVATE_DUMP_INTERMEDIATE_DIR"
-mkdir -p "$PRIVATE_DUMP_INTERMEDIATE_DIR"
+# only the db dumps create private dumps
+if [ "$DUMP_TYPE" == "db" ]; then
+    PRIVATE_DUMP_INTERMEDIATE_DIR="$PRIVATE_DUMP_BASE_DIR/$SUB_DIR.$$"
+    echo "PRIVATE_DUMP_BASE_DIR is $PRIVATE_DUMP_BASE_DIR"
+    echo "creating PRIVATE_DUMP_INTERMEDIATE_DIR $PRIVATE_DUMP_INTERMEDIATE_DIR"
+    mkdir -p "$PRIVATE_DUMP_INTERMEDIATE_DIR"
 
-PRIVATE_DUMP_TEMP_DIR="$PRIVATE_DUMP_BASE_DIR"
+    PRIVATE_DUMP_TEMP_DIR="$PRIVATE_DUMP_BASE_DIR"
+fi
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    if ! /usr/local/bin/python manage.py dump create_full -l "$DUMP_INTERMEDIATE_DIR" -lp "$PRIVATE_DUMP_INTERMEDIATE_DIR" -lt "$DUMP_TEMP_DIR" -lpt "$PRIVATE_DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
+    if ! /usr/local/bin/python manage.py dump create_full -l "$DUMP_INTERMEDIATE_DIR" -lt "$DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
         echo "Full dump failed, exiting!"
+        exit 1
+    fi
+elif [ "$DUMP_TYPE" == "db" ]; then
+    if ! /usr/local/bin/python manage.py dump create_db_dump -l "$DUMP_INTERMEDIATE_DIR" -lp "$PRIVATE_DUMP_INTERMEDIATE_DIR" -lt "$DUMP_TEMP_DIR" -lpt "$PRIVATE_DUMP_TEMP_DIR" -t "$DUMP_THREADS" "$@"; then
+        echo "Database dump failed, exiting!"
         exit 1
     fi
 elif [ "$DUMP_TYPE" == "incremental" ]; then
@@ -182,9 +194,9 @@ echo "Dump created with timestamp $DUMP_TIMESTAMP"
 DUMP_DIR=$(dirname "$DUMP_ID_FILE")
 DUMP_NAME=$(basename "$DUMP_DIR")
 
-# Full dumps are already published to the remote FTP server and are too large
-# to keep a second public copy on the backup volume. Other dump types retain
-# their existing local backup.
+# Full listen dumps are already published to the remote FTP server and are too
+# large to keep a second public copy on the backup volume. Other dump types,
+# including the db dumps, retain their existing local backup.
 if [ "$DUMP_TYPE" != "full" ]; then
     echo "Creating Backup directories..."
     mkdir -m "$BACKUP_DIR_MODE" -p \
@@ -200,9 +212,13 @@ else
     echo "Skipping the redundant public full dump backup."
 fi
 
-HAS_EMPTY_PRIVATE_DIRS_OR_FILES=$(find "$PRIVATE_DUMP_INTERMEDIATE_DIR" -empty)
-if [ -z "$HAS_EMPTY_PRIVATE_DIRS_OR_FILES" ]; then
-    # private dumps directory is not empty
+if [ -n "$PRIVATE_DUMP_INTERMEDIATE_DIR" ]; then
+    HAS_EMPTY_PRIVATE_DIRS_OR_FILES=$(find "$PRIVATE_DUMP_INTERMEDIATE_DIR" -empty)
+    if [ -n "$HAS_EMPTY_PRIVATE_DIRS_OR_FILES" ]; then
+        echo "Empty private files or dirs found, exiting."
+        echo "$HAS_EMPTY_PRIVATE_DIRS_OR_FILES"
+        exit 1
+    fi
 
     PRIVATE_DUMP_ID_FILE=$(find "$PRIVATE_DUMP_INTERMEDIATE_DIR" -type f -name 'DUMP_ID.txt')
     if [ -z "$PRIVATE_DUMP_ID_FILE" ]; then
@@ -288,9 +304,9 @@ cat "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    # Full FTP retention is applied by rsync-dump-files.sh only after every
-    # pending payload has uploaded successfully. Remove public full dumps left
-    # on the legacy backup volume now that it is no longer used for them.
+    # Full listen dump FTP retention is applied by rsync-dump-files.sh only after
+    # every pending payload has uploaded successfully. Remove public full dumps
+    # left on the legacy backup volume now that it is no longer used for them.
     /usr/local/bin/python manage.py dump delete_old_dumps \
         --remove-all-full-dumps \
         "$BACKUP_DIR/$SUB_DIR"

--- a/admin/create-dumps.sh
+++ b/admin/create-dumps.sh
@@ -226,8 +226,6 @@ if [ -n "$PRIVATE_DUMP_INTERMEDIATE_DIR" ]; then
         exit 1
     fi
 
-    read -r PRIVATE_DUMP_TIMESTAMP PRIVATE_DUMP_ID PRIVATE_DUMP_TYPE < "$PRIVATE_DUMP_ID_FILE"
-    echo "Dump created with timestamp $PRIVATE_DUMP_TIMESTAMP"
     PRIVATE_DUMP_DIR=$(dirname "$PRIVATE_DUMP_ID_FILE")
     PRIVATE_DUMP_NAME=$(basename "$PRIVATE_DUMP_DIR")
 
@@ -302,36 +300,27 @@ EXCLUDE_RULE="exclude *"
 echo "$EXCLUDE_RULE" >> "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 cat "$FTP_CURRENT_DUMP_DIR/.rsync-filter"
 
+# Publish the dump and expire whatever has aged out on the FTP server. The
+# server's retention is applied from a listing of the server itself, so nothing
+# here has to stand in for dumps that are published but not kept locally.
+./admin/rsync-dump-files.sh "$DUMP_TYPE" "$DUMP_NAME" "$FTP_CURRENT_DUMP_DIR"
 
 if [ "$DUMP_TYPE" == "full" ]; then
-    # Full listen dump FTP retention is applied by rsync-dump-files.sh only after
-    # every pending payload has uploaded successfully. Remove public full dumps
-    # left on the legacy backup volume now that it is no longer used for them.
-    /usr/local/bin/python manage.py dump delete_old_dumps \
-        --remove-all-full-dumps \
-        "$BACKUP_DIR/$SUB_DIR"
-elif [ "$DUMP_TYPE" == "db" ]; then
-    # The FTP and backup fullexport directories also contain full dumps. A db
-    # run must not expire full payloads which may still be pending upload.
-    /usr/local/bin/python manage.py dump delete_old_dumps \
-        --only-db-dumps \
-        "$FTP_DIR/$SUB_DIR"
-    /usr/local/bin/python manage.py dump delete_old_dumps \
-        --only-db-dumps \
-        "$BACKUP_DIR/$SUB_DIR"
-else
-    /usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
-    /usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
-fi
-if [ "$DUMP_TYPE" == "db" ]; then
-    /usr/local/bin/python manage.py dump delete_old_dumps \
-        --only-db-dumps \
-        "$PRIVATE_BACKUP_DIR/$SUB_DIR"
-else
-    /usr/local/bin/python manage.py dump delete_old_dumps "$PRIVATE_BACKUP_DIR/$SUB_DIR"
+    # A published full listen dump is far too large to keep a local copy of too.
+    echo "Removing the local copy of the published full dump..."
+    rm -rf -- "$FTP_CURRENT_DUMP_DIR"
 fi
 
-# rsync to ftp folder taking care of the rules
-./admin/rsync-dump-files.sh "$DUMP_TYPE" "$DUMP_NAME"
+# Apply local retention now that the new dump has been published.
+/usr/local/bin/python manage.py dump delete_old_dumps "$FTP_DIR/$SUB_DIR"
+/usr/local/bin/python manage.py dump delete_old_dumps "$PRIVATE_BACKUP_DIR/$SUB_DIR"
+
+if [ "$DUMP_TYPE" == "full" ]; then
+    # Public full dumps are no longer backed up locally, so remove any that are
+    # left over on the backup volume from when they were.
+    /usr/local/bin/python manage.py dump delete_old_dumps --keep full=0 "$BACKUP_DIR/$SUB_DIR"
+else
+    /usr/local/bin/python manage.py dump delete_old_dumps "$BACKUP_DIR/$SUB_DIR"
+fi
 
 echo "Dumps created and uploaded to the FTP server; applicable backups completed!"

--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -18,93 +18,54 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+# usage
+#   rsync-dump-files.sh <dump type> <dump name> <source dir>
+#
+# Publishes one dump directory to the FTP host and then expires the dumps which
+# have fallen outside their retention window.
+#
+# The remote host, not this machine, is the source of truth for what has been
+# published, so nothing here mirrors a local directory. Uploading only ever adds
+# the one named dump, and expiry is driven by a listing of the remote host. That
+# is what lets full listen dumps be deleted locally right after upload without
+# any local bookkeeping to stand in for them.
+#
+# Set DUMP_DRY_RUN=1 to log the remote deletions without performing them.
+
 unset SSH_AUTH_SOCK
 
 LB_SERVER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
-cd "$LB_SERVER_ROOT"
+cd "$LB_SERVER_ROOT" || exit 1
 
 source admin/config.sh
 source admin/functions.sh
 
 DUMP_TYPE=$1
 DUMP_NAME=$2
-DESTINATION="brainz@$RSYNC_FULLEXPORT_HOST:./"
-RSYNC_FILTER_OPTIONS=(-FF)
-RSYNC_DELETE_OPTIONS=(--delete)
+SOURCE_DIR=$3
 
-function build_rsync_filter_options {
-    RSYNC_FILTER_OPTIONS=(-FF)
+# Names are interpolated into remote paths that get deleted, so only well-formed
+# dump directory names are accepted. Must be kept in step with the DUMP_KINDS
+# table in listenbrainz/dumps/cleanup.py.
+DUMP_NAME_PATTERN='^(listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-(full|db|incremental)'
+DUMP_NAME_PATTERN+='|listenbrainz-(feedback|sample)-[0-9]{8}-[0-9]{6}-full'
+DUMP_NAME_PATTERN+='|musicbrainz-canonical-dump-[0-9]{8}-[0-9]{6})$'
 
-    # Only the fullexport dir contains full listen dump marker directories.
-    if [ "$DUMP_TYPE" != "full" ] && [ "$DUMP_TYPE" != "db" ]; then
-        return
-    fi
-
-    # Command-line protect rules are passed to the receiving rsync process.
-    # They preserve payloads for retained marker directories while
-    # --delete/--delete-after removes remote directories whose local markers
-    # expired. The db dump sync uses the same rules so that it never deletes
-    # the full listen dump payloads it has no local copy of.
-    shopt -s nullglob
-    for RETAINED_DUMP_DIR in "$SOURCE_DIR"/listenbrainz-dump-*-full; do
-        RETAINED_DUMP_NAME=$(basename "$RETAINED_DUMP_DIR")
-        if [ -f "$RETAINED_DUMP_DIR/.ftp-retention-marker" ] && \
-           [[ "$RETAINED_DUMP_NAME" =~ ^listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-full$ ]]
-        then
-            RSYNC_FILTER_OPTIONS+=(--filter="protect /$RETAINED_DUMP_NAME/***")
-        fi
-    done
-    shopt -u nullglob
-}
-
-function sync_source {
-    build_rsync_filter_options
-    retry rsync \
-        --archive \
-        "${RSYNC_DELETE_OPTIONS[@]}" \
-        "${RSYNC_FILTER_OPTIONS[@]}" \
-        --rsh "ssh -i $SSH_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_FULLEXPORT_PORT" \
-        --verbose \
-        "$SOURCE_DIR/" \
-        "$DESTINATION"
-}
-
-if [ "$DUMP_TYPE" == "full" ]; then
-    if [[ ! "$DUMP_NAME" =~ ^listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-full$ ]]; then
-        echo "Invalid or missing full dump name '$DUMP_NAME', exiting!"
+case "$DUMP_TYPE" in
+    # database dumps are published alongside the full listen dumps
+    full|db)     SSH_KEY=$RSYNC_FULLEXPORT_KEY ;;
+    incremental) SSH_KEY=$RSYNC_INCREMENTAL_KEY ;;
+    feedback)    SSH_KEY=$RSYNC_SPARK_KEY ;;
+    mbcanonical) SSH_KEY=$RSYNC_MBCANONICAL_KEY ;;
+    sample)      SSH_KEY=$RSYNC_SAMPLE_KEY ;;
+    *)
+        echo "Dump type '$DUMP_TYPE' must be one of full, db, incremental, feedback, mbcanonical or sample, exiting!"
         exit 1
-    fi
-    # Full dump directories without payloads are retained locally as markers.
-    # Mirroring the parent directory lets --delete enforce the FTP retention
-    # constant without retaining the large dump files locally.
-    SOURCE_DIR=$RSYNC_FULLEXPORT_DIR
-    SSH_KEY=$RSYNC_FULLEXPORT_KEY
-    # Expire old remote dumps only after the new payload transfer succeeds.
-    RSYNC_DELETE_OPTIONS=(--delete-after)
-    if [ ! -d "$SOURCE_DIR/$DUMP_NAME" ]; then
-        echo "Full dump source directory '$SOURCE_DIR/$DUMP_NAME' does not exist, exiting!"
-        exit 1
-    fi
-elif [ "$DUMP_TYPE" == "db" ]; then
-    # Database dumps are published alongside the full listen dumps and use the
-    # same rsync credentials, but their payloads are small enough to be retained
-    # locally, like incremental dumps.
-    SOURCE_DIR=$RSYNC_FULLEXPORT_DIR
-    SSH_KEY=$RSYNC_FULLEXPORT_KEY
-elif [ "$DUMP_TYPE" == "incremental" ]; then
-    SOURCE_DIR=$RSYNC_INCREMENTAL_DIR
-    SSH_KEY=$RSYNC_INCREMENTAL_KEY
-elif [ "$DUMP_TYPE" == "feedback" ]; then
-    SOURCE_DIR=$RSYNC_SPARK_DIR
-    SSH_KEY=$RSYNC_SPARK_KEY
-elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
-    SOURCE_DIR=$RSYNC_MBCANONICAL_DIR
-    SSH_KEY=$RSYNC_MBCANONICAL_KEY
-elif [ "$DUMP_TYPE" == "sample" ]; then
-    SOURCE_DIR=$RSYNC_SAMPLE_DIR
-    SSH_KEY=$RSYNC_SAMPLE_KEY
-else
-    echo "Could not determine which directory (full, db, incremental, feedback, mbcanonical, sample) to copy over, exiting!"
+        ;;
+esac
+
+if [[ ! "$DUMP_NAME" =~ $DUMP_NAME_PATTERN ]]; then
+    echo "Invalid or missing dump name '$DUMP_NAME', exiting!"
     exit 1
 fi
 
@@ -113,45 +74,108 @@ if [ ! -d "$SOURCE_DIR" ]; then
     exit 1
 fi
 
-if ! sync_source; then
-    echo "Failed to upload $DUMP_TYPE dump; local files have been preserved."
+if [ ! -f "$SOURCE_DIR/.rsync-filter" ]; then
+    echo "Rsync filter '$SOURCE_DIR/.rsync-filter' does not exist, refusing to publish!"
     exit 1
 fi
 
-if [ "$DUMP_TYPE" == "full" ]; then
-    # Keep only tiny directory/filter markers after a successful transfer. The
-    # exclude rule protects retained remote payloads from deletion on the next
-    # run, while removal of older marker directories allows rsync to expire the
-    # corresponding remote dumps.
-    shopt -s nullglob
-    for LOCAL_DUMP_DIR in "$SOURCE_DIR"/listenbrainz-dump-*-full; do
-        LOCAL_DUMP_NAME=$(basename "$LOCAL_DUMP_DIR")
-        if [ ! -d "$LOCAL_DUMP_DIR" ] || [ -L "$LOCAL_DUMP_DIR" ] || \
-           [[ ! "$LOCAL_DUMP_NAME" =~ ^listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-full$ ]]
-        then
-            echo "Ignoring unexpected directory '$LOCAL_DUMP_DIR' during local cleanup."
-            continue
+DESTINATION="brainz@$RSYNC_FULLEXPORT_HOST:./"
+RSYNC_RSH="ssh -i $SSH_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_FULLEXPORT_PORT"
+
+EMPTY_DIR=$(mktemp -d)
+trap 'rm -rf -- "$EMPTY_DIR"' EXIT
+
+function publish_dump {
+    retry rsync \
+        --archive \
+        --verbose \
+        -FF \
+        --rsh "$RSYNC_RSH" \
+        "$SOURCE_DIR/" \
+        "$DESTINATION$DUMP_NAME/"
+}
+
+# Print the name of every directory published on the remote host.
+function list_remote_dumps {
+    rsync --list-only --rsh "$RSYNC_RSH" "$DESTINATION" | awk '/^d/ && $5 != "." { print $5 }'
+}
+
+# Delete one published dump from the remote host. The include rules name the
+# single directory to remove and everything else is excluded, which protects it
+# from --delete; the source is an empty directory, so nothing is transferred.
+function expire_remote_dump {
+    local dump_name=$1
+    local dry_run_option=()
+
+    if [ -n "$DUMP_DRY_RUN" ]; then
+        dry_run_option=(--dry-run)
+        echo "Dry run: would remove '$dump_name' from the FTP server."
+    else
+        echo "Removing '$dump_name' from the FTP server..."
+    fi
+
+    retry rsync \
+        --recursive \
+        --delete \
+        --verbose \
+        "${dry_run_option[@]}" \
+        --rsh "$RSYNC_RSH" \
+        --include "/$dump_name" \
+        --include "/$dump_name/***" \
+        --exclude '*' \
+        "$EMPTY_DIR/" \
+        "$DESTINATION"
+}
+
+# Expire the published dumps which have fallen outside their retention window.
+# The retention policy itself lives in the dump manager; this only needs to know
+# how to list and how to delete.
+function apply_remote_retention {
+    local remote_dumps expired dump_name
+
+    if ! remote_dumps=$(list_remote_dumps); then
+        echo "Could not list the dumps on the FTP server, not expiring anything!"
+        return 1
+    fi
+
+    # An empty listing means the listing failed in a way rsync did not report,
+    # since the dump just uploaded should be in it. Do not act on it.
+    if [ -z "$remote_dumps" ]; then
+        echo "The FTP server listing is empty, not expiring anything!"
+        return 1
+    fi
+
+    if ! expired=$(printf '%s\n' "$remote_dumps" | /usr/local/bin/python manage.py dump list_expired_dumps); then
+        echo "Could not work out which dumps have expired, not expiring anything!"
+        return 1
+    fi
+
+    if [ -z "$expired" ]; then
+        echo "No dumps have expired on the FTP server."
+        return 0
+    fi
+
+    while read -r dump_name; do
+        if [[ ! "$dump_name" =~ $DUMP_NAME_PATTERN ]]; then
+            echo "Refusing to remove unexpected remote directory '$dump_name'!"
+            return 1
         fi
+        if ! expire_remote_dump "$dump_name"; then
+            echo "Failed to remove '$dump_name' from the FTP server!"
+            return 1
+        fi
+    done <<< "$expired"
+}
 
-        find "$LOCAL_DUMP_DIR" -mindepth 1 -delete
-        touch "$LOCAL_DUMP_DIR/.ftp-retention-marker"
-        printf 'exclude *\n' > "$LOCAL_DUMP_DIR/.rsync-filter"
-    done
-    shopt -u nullglob
-
-    # Every payload is now safe on the remote host, so it is safe to expire
-    # markers beyond the retention constant. A second metadata-only
-    # rsync applies those expirations remotely.
-    if ! /usr/local/bin/python manage.py dump delete_old_dumps "$SOURCE_DIR"
-    then
-        echo "Full dumps uploaded, but local retention-marker cleanup failed."
-        exit 1
-    fi
-
-    if ! sync_source; then
-        echo "Full dumps uploaded, but remote retention cleanup failed."
-        exit 1
-    fi
-
-    echo "Full dumps uploaded successfully; local payloads removed and FTP retention applied."
+if ! publish_dump; then
+    echo "Failed to upload $DUMP_TYPE dump '$DUMP_NAME'; local files have been preserved."
+    exit 1
 fi
+echo "Uploaded $DUMP_TYPE dump '$DUMP_NAME' to the FTP server."
+
+if ! apply_remote_retention; then
+    echo "$DUMP_TYPE dump '$DUMP_NAME' was uploaded, but FTP retention failed."
+    exit 1
+fi
+
+echo "$DUMP_TYPE dump '$DUMP_NAME' uploaded and FTP retention applied."

--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -27,20 +27,71 @@ source admin/config.sh
 source admin/functions.sh
 
 DUMP_TYPE=$1
+DUMP_NAME=$2
+DESTINATION="brainz@$RSYNC_FULLEXPORT_HOST:./"
+RSYNC_FILTER_OPTIONS=(-FF)
+RSYNC_DELETE_OPTIONS=(--delete)
 
-if [ $DUMP_TYPE == "full" ]; then
+function build_rsync_filter_options {
+    RSYNC_FILTER_OPTIONS=(-FF)
+
+    if [ "$DUMP_TYPE" != "full" ]; then
+        return
+    fi
+
+    # Command-line protect rules are passed to the receiving rsync process.
+    # They preserve payloads for retained marker directories while
+    # --delete-after removes remote directories whose local markers expired.
+    shopt -s nullglob
+    for RETAINED_DUMP_DIR in "$SOURCE_DIR"/listenbrainz-dump-*-full; do
+        RETAINED_DUMP_NAME=$(basename "$RETAINED_DUMP_DIR")
+        if [ -f "$RETAINED_DUMP_DIR/.ftp-retention-marker" ] && \
+           [[ "$RETAINED_DUMP_NAME" =~ ^listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-full$ ]]
+        then
+            RSYNC_FILTER_OPTIONS+=(--filter="protect /$RETAINED_DUMP_NAME/***")
+        fi
+    done
+    shopt -u nullglob
+}
+
+function sync_source {
+    build_rsync_filter_options
+    retry rsync \
+        --archive \
+        "${RSYNC_DELETE_OPTIONS[@]}" \
+        "${RSYNC_FILTER_OPTIONS[@]}" \
+        --rsh "ssh -i $SSH_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_FULLEXPORT_PORT" \
+        --verbose \
+        "$SOURCE_DIR/" \
+        "$DESTINATION"
+}
+
+if [ "$DUMP_TYPE" == "full" ]; then
+    if [[ ! "$DUMP_NAME" =~ ^listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-full$ ]]; then
+        echo "Invalid or missing full dump name '$DUMP_NAME', exiting!"
+        exit 1
+    fi
+    # Full dump directories without payloads are retained locally as markers.
+    # Mirroring the parent directory lets --delete enforce the FTP retention
+    # constant without retaining the large dump files locally.
     SOURCE_DIR=$RSYNC_FULLEXPORT_DIR
     SSH_KEY=$RSYNC_FULLEXPORT_KEY
-elif [ $DUMP_TYPE == "incremental" ]; then
+    # Expire old remote dumps only after the new payload transfer succeeds.
+    RSYNC_DELETE_OPTIONS=(--delete-after)
+    if [ ! -d "$SOURCE_DIR/$DUMP_NAME" ]; then
+        echo "Full dump source directory '$SOURCE_DIR/$DUMP_NAME' does not exist, exiting!"
+        exit 1
+    fi
+elif [ "$DUMP_TYPE" == "incremental" ]; then
     SOURCE_DIR=$RSYNC_INCREMENTAL_DIR
     SSH_KEY=$RSYNC_INCREMENTAL_KEY
-elif [ $DUMP_TYPE == "feedback" ]; then
+elif [ "$DUMP_TYPE" == "feedback" ]; then
     SOURCE_DIR=$RSYNC_SPARK_DIR
     SSH_KEY=$RSYNC_SPARK_KEY
-elif [ $DUMP_TYPE == "mbcanonical" ]; then
+elif [ "$DUMP_TYPE" == "mbcanonical" ]; then
     SOURCE_DIR=$RSYNC_MBCANONICAL_DIR
     SSH_KEY=$RSYNC_MBCANONICAL_KEY
-elif [ $DUMP_TYPE == "sample" ]; then
+elif [ "$DUMP_TYPE" == "sample" ]; then
     SOURCE_DIR=$RSYNC_SAMPLE_DIR
     SSH_KEY=$RSYNC_SAMPLE_KEY
 else
@@ -48,11 +99,50 @@ else
     exit 1
 fi
 
-retry rsync \
-    --archive \
-    --delete \
-    -FF \
-    --rsh "ssh -i $SSH_KEY -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p $RSYNC_FULLEXPORT_PORT" \
-    --verbose \
-    $SOURCE_DIR/ \
-    brainz@$RSYNC_FULLEXPORT_HOST:./
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Dump source directory '$SOURCE_DIR' does not exist, exiting!"
+    exit 1
+fi
+
+if ! sync_source; then
+    echo "Failed to upload $DUMP_TYPE dump; local files have been preserved."
+    exit 1
+fi
+
+if [ "$DUMP_TYPE" == "full" ]; then
+    # Keep only tiny directory/filter markers after a successful transfer. The
+    # exclude rule protects retained remote payloads from deletion on the next
+    # run, while removal of older marker directories allows rsync to expire the
+    # corresponding remote dumps.
+    shopt -s nullglob
+    for LOCAL_DUMP_DIR in "$SOURCE_DIR"/listenbrainz-dump-*-full; do
+        LOCAL_DUMP_NAME=$(basename "$LOCAL_DUMP_DIR")
+        if [ ! -d "$LOCAL_DUMP_DIR" ] || [ -L "$LOCAL_DUMP_DIR" ] || \
+           [[ ! "$LOCAL_DUMP_NAME" =~ ^listenbrainz-dump-[0-9]+-[0-9]{8}-[0-9]{6}-full$ ]]
+        then
+            echo "Ignoring unexpected directory '$LOCAL_DUMP_DIR' during local cleanup."
+            continue
+        fi
+
+        find "$LOCAL_DUMP_DIR" -mindepth 1 -delete
+        touch "$LOCAL_DUMP_DIR/.ftp-retention-marker"
+        printf 'exclude *\n' > "$LOCAL_DUMP_DIR/.rsync-filter"
+    done
+    shopt -u nullglob
+
+    # Every payload is now safe on the remote host, so it is safe to expire
+    # markers beyond the retention constant. A second metadata-only
+    # rsync applies those expirations remotely.
+    if ! /usr/local/bin/python manage.py dump delete_old_dumps "$SOURCE_DIR"
+    then
+        echo "Full dumps uploaded, but local retention-marker cleanup failed."
+        exit 1
+    fi
+
+    if ! sync_source; then
+        echo "Full dumps uploaded, but remote retention cleanup failed."
+        exit 1
+    fi
+
+    echo "Full dumps uploaded successfully; local payloads removed and FTP retention applied."
+fi

--- a/admin/rsync-dump-files.sh
+++ b/admin/rsync-dump-files.sh
@@ -35,13 +35,16 @@ RSYNC_DELETE_OPTIONS=(--delete)
 function build_rsync_filter_options {
     RSYNC_FILTER_OPTIONS=(-FF)
 
-    if [ "$DUMP_TYPE" != "full" ]; then
+    # Only the fullexport dir contains full listen dump marker directories.
+    if [ "$DUMP_TYPE" != "full" ] && [ "$DUMP_TYPE" != "db" ]; then
         return
     fi
 
     # Command-line protect rules are passed to the receiving rsync process.
     # They preserve payloads for retained marker directories while
-    # --delete-after removes remote directories whose local markers expired.
+    # --delete/--delete-after removes remote directories whose local markers
+    # expired. The db dump sync uses the same rules so that it never deletes
+    # the full listen dump payloads it has no local copy of.
     shopt -s nullglob
     for RETAINED_DUMP_DIR in "$SOURCE_DIR"/listenbrainz-dump-*-full; do
         RETAINED_DUMP_NAME=$(basename "$RETAINED_DUMP_DIR")
@@ -82,6 +85,12 @@ if [ "$DUMP_TYPE" == "full" ]; then
         echo "Full dump source directory '$SOURCE_DIR/$DUMP_NAME' does not exist, exiting!"
         exit 1
     fi
+elif [ "$DUMP_TYPE" == "db" ]; then
+    # Database dumps are published alongside the full listen dumps and use the
+    # same rsync credentials, but their payloads are small enough to be retained
+    # locally, like incremental dumps.
+    SOURCE_DIR=$RSYNC_FULLEXPORT_DIR
+    SSH_KEY=$RSYNC_FULLEXPORT_KEY
 elif [ "$DUMP_TYPE" == "incremental" ]; then
     SOURCE_DIR=$RSYNC_INCREMENTAL_DIR
     SSH_KEY=$RSYNC_INCREMENTAL_KEY
@@ -95,7 +104,7 @@ elif [ "$DUMP_TYPE" == "sample" ]; then
     SOURCE_DIR=$RSYNC_SAMPLE_DIR
     SSH_KEY=$RSYNC_SAMPLE_KEY
 else
-    echo "Could not determine which directory (full, incremental, feedback, mbcanonical, sample) to copy over, exiting!"
+    echo "Could not determine which directory (full, db, incremental, feedback, mbcanonical, sample) to copy over, exiting!"
     exit 1
 fi
 

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -27,4 +27,4 @@ CREATE TYPE user_data_export_type_type AS ENUM ('export_all_user_data');
 
 CREATE TYPE user_data_import_service_type AS ENUM ('spotify', 'applemusic', 'listenbrainz', 'librefm', 'maloja', 'panoscrobbler', 'audioscrobbler', 'spinitron');
 
-CREATE TYPE data_dump_type_type AS ENUM ('incremental', 'full');
+CREATE TYPE data_dump_type_type AS ENUM ('incremental', 'full', 'db');

--- a/admin/sql/updates/2026-07-24-add-db-dump-type.sql
+++ b/admin/sql/updates/2026-07-24-add-db-dump-type.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TYPE data_dump_type_type ADD VALUE IF NOT EXISTS 'db';
+
+COMMIT;

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -39,7 +39,10 @@ MAILTO=""
 # Request user fresh releases daily
 0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --threshold 10 >> /logs/fresh_releases.log 2>&1
 
-# Full dumps run in a separate cron container using full-dumps-crontab.
+## Trigger a public/private database dump on 1st and 15th of every month, do not block to wait for the lock. This runs
+## an hour before the full listens dump so that the two dumps do not hammer the databases at the same time. The full
+## listens and stats dumps are created by a separate cron job in the full dumps cron container.
+0 3 1,15 * * root flock -x -n /var/lock/lb-db-dumps.lock /code/listenbrainz/admin/create-dumps.sh db >> /logs/db_dumps.log 2>&1
 
 # run job to update msids with mapped mbids daily
 0 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py update-msid-tables >> /logs/msid-updater.log 2>&1

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -39,10 +39,10 @@ MAILTO=""
 # Request user fresh releases daily
 0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --threshold 10 >> /logs/fresh_releases.log 2>&1
 
-## Trigger a public/private database dump on 1st and 15th of every month, do not block to wait for the lock. This runs
-## an hour before the full listens dump so that the two dumps do not hammer the databases at the same time. The full
-## listens and stats dumps are created by a separate cron job in the full dumps cron container.
-0 3 1,15 * * root flock -x -n /var/lock/lb-db-dumps.lock /code/listenbrainz/admin/create-dumps.sh db >> /logs/db_dumps.log 2>&1
+## Trigger a public/private database dump on 2nd and 16th of every month, do not block to wait for the lock. The full
+## listens and stats dumps run on the previous day in the full dumps cron container so that the jobs do not hammer the
+## databases at the same time despite running on separate hosts.
+0 3 2,16 * * root flock -x -n /var/lock/lb-db-dumps.lock /code/listenbrainz/admin/create-dumps.sh db >> /logs/db_dumps.log 2>&1
 
 # run job to update msids with mapped mbids daily
 0 6 * * * root /usr/local/bin/python /code/listenbrainz/manage.py update-msid-tables >> /logs/msid-updater.log 2>&1

--- a/docker/services/cron/crontab
+++ b/docker/services/cron/crontab
@@ -40,8 +40,8 @@ MAILTO=""
 0 3 * * * root /usr/local/bin/python /code/listenbrainz/manage.py spark request_fresh_releases --threshold 10 >> /logs/fresh_releases.log 2>&1
 
 ## Trigger a public/private database dump on 2nd and 16th of every month, do not block to wait for the lock. The full
-## listens and stats dumps run on the previous day in the full dumps cron container so that the jobs do not hammer the
-## databases at the same time despite running on separate hosts.
+## listens and stats dumps run on the previous day in the full dumps cron container (see 'full-dumps-crontab') so that
+## the jobs do not hammer the databases at the same time despite running on separate hosts.
 0 3 2,16 * * root flock -x -n /var/lock/lb-db-dumps.lock /code/listenbrainz/admin/create-dumps.sh db >> /logs/db_dumps.log 2>&1
 
 # run job to update msids with mapped mbids daily

--- a/docker/services/cron/full-dumps-crontab
+++ b/docker/services/cron/full-dumps-crontab
@@ -2,5 +2,5 @@ MAILTO=""
 
 ## Trigger a full listens and stats dump on 1st and 15th of every month, in the middle of the night, do not block to
 ## wait for lock. The public and private database dumps are created by a separate cron job on the following day in the
-## regular cron container so that the jobs do not hammer the databases at the same time.
+## regular cron container (see 'crontab') so that the jobs do not hammer the databases at the same time.
 0 4 1,15 * * root flock -x -n /var/lock/lb-full-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/full_dumps.log 2>&1

--- a/docker/services/cron/full-dumps-crontab
+++ b/docker/services/cron/full-dumps-crontab
@@ -1,4 +1,6 @@
 MAILTO=""
 
-## Trigger a full dump on 1st and 15th of every month, in the middle of the night, do not block to wait for lock.
+## Trigger a full listens and stats dump on 1st and 15th of every month, in the middle of the night, do not block to
+## wait for lock. The public and private database dumps are created by a separate cron job an hour earlier in the
+## regular cron container.
 0 4 1,15 * * root flock -x -n /var/lock/lb-full-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/full_dumps.log 2>&1

--- a/docker/services/cron/full-dumps-crontab
+++ b/docker/services/cron/full-dumps-crontab
@@ -1,6 +1,6 @@
 MAILTO=""
 
 ## Trigger a full listens and stats dump on 1st and 15th of every month, in the middle of the night, do not block to
-## wait for lock. The public and private database dumps are created by a separate cron job an hour earlier in the
-## regular cron container.
+## wait for lock. The public and private database dumps are created by a separate cron job on the following day in the
+## regular cron container so that the jobs do not hammer the databases at the same time.
 0 4 1,15 * * root flock -x -n /var/lock/lb-full-dumps.lock /code/listenbrainz/admin/create-dumps.sh full >> /logs/full_dumps.log 2>&1

--- a/docs/maintainers/dumps.rst
+++ b/docs/maintainers/dumps.rst
@@ -63,8 +63,9 @@ Manually triggering dumps
 If you want to re-run a dump after it fails, or manually trigger a dump then you can run the dump script manually. A few
 things need to be kept in mind while doing this, the :ref:`developers/commands:create_full` and
 :ref:`developers/commands:create_db_dump` commands invoked to do the dumps accept a :option:`--dump-id` parameter to number
-the dump. If no id specified, the script will look in the database for the last id, add 1 to it and use it for the dump.
-Note that a dump id belongs to one dump type, so a db dump can only be re-run with the id of an existing db dump.
+the dump. If no id is specified, the script will look in the database for the last id, add 1 to it and use it for the dump.
+A supplied dump id must belong to an existing dump of the same type: a db dump cannot be re-run with the id of a full
+dump, or vice versa.
 
 .. code:: sql
 

--- a/docs/maintainers/dumps.rst
+++ b/docs/maintainers/dumps.rst
@@ -23,6 +23,15 @@ cron container by running :code:`docker exec -it listenbrainz-cron-prod bash`.
 This file is large, so use :command:`tail` instead of :command:`cat` to view the logs. For example:
 :code:`tail -n 500 /logs/full_dumps.log` will list the last 500 lines of the full dumps log file.
 
+Full dump retention
+^^^^^^^^^^^^^^^^^^^
+Public full dump payloads are removed from local FTP staging after a successful rsync. Small marker directories remain
+so that later rsync runs preserve the newest full dumps on the FTP server and remove only versions beyond the retention
+limit. :data:`listenbrainz.dumps.cleanup.NUMBER_OF_FULL_DUMPS_TO_KEEP` controls that limit and is currently ``2``.
+Private full database dumps are kept on the private backup volume and are never uploaded to FTP. Retention cleanup runs
+only after every pending public payload uploads successfully, so failed uploads remain locally available for retry.
+Public full dumps left on the legacy backup volume are removed during the next full-dump run.
+
 From the log file, you should probably be able to see whether the error occurred in python part of the code or bash
 script. If you see a python stack trace, it is likely that sentry recorded the error too. The `sentry view <https://sentry.metabrainz.org/organizations/metabrainz/issues/?project=15>`_
 sometimes offers more details so searching sentry for this error can be helpful.

--- a/docs/maintainers/dumps.rst
+++ b/docs/maintainers/dumps.rst
@@ -9,28 +9,47 @@ is usually responsible for bringing dump failures to the notice of maintainers. 
 cron jobs and is scheduled to run a few hours after the regular dump times. If dumps are not working but no email was
 received by the maintainers, it is possible that the cron jobs are not setup properly.
 
+Twice monthly dumps
+^^^^^^^^^^^^^^^^^^^
+The twice monthly dumps are created by two independent cron jobs, both publishing into the :file:`fullexport` directory
+on the FTP server:
+
+* the **db** dump job creates the public and private postgres and timescale dumps into a
+  :file:`listenbrainz-dump-<id>-<timestamp>-db` directory.
+* the **full** dump job creates the listens, spark and statistics dumps into a
+  :file:`listenbrainz-dump-<id>-<timestamp>-full` directory.
+
+The db dump runs an hour before the full dump so that the two jobs do not read from the databases at the same time.
+Both dump types get their own id in the :code:`data_dump` table, so their ids and timestamps do not match each other.
+
 Logs
 ^^^^
-Looking at the logs is a good starting point to debug dump failures. Incremental, feedback, and canonical dump jobs
-run in the :code:`listenbrainz-cron-prod` container. Full dump jobs run in the
+Looking at the logs is a good starting point to debug dump failures. Database, incremental, feedback, and canonical dump
+jobs run in the :code:`listenbrainz-cron-prod` container. Full dump jobs run in the
 :code:`listenbrainz-full-dumps-cron-prod` container. The output of dump-related jobs is redirected in the crontab files
 under :file:`docker/services/cron/`.
 
 For full dumps, inspect :file:`/logs/full_dumps.log` inside the full-dumps cron container:
 :code:`docker exec -it listenbrainz-full-dumps-cron-prod bash`. For other dump jobs, open a bash shell in the regular
-cron container by running :code:`docker exec -it listenbrainz-cron-prod bash`.
+cron container by running :code:`docker exec -it listenbrainz-cron-prod bash`. The db dump job logs to
+:file:`/logs/db_dumps.log` there.
 
 This file is large, so use :command:`tail` instead of :command:`cat` to view the logs. For example:
 :code:`tail -n 500 /logs/full_dumps.log` will list the last 500 lines of the full dumps log file.
 
 Full dump retention
 ^^^^^^^^^^^^^^^^^^^
-Public full dump payloads are removed from local FTP staging after a successful rsync. Small marker directories remain
+Full listens dump payloads are removed from local FTP staging after a successful rsync. Small marker directories remain
 so that later rsync runs preserve the newest full dumps on the FTP server and remove only versions beyond the retention
 limit. :data:`listenbrainz.dumps.cleanup.NUMBER_OF_FULL_DUMPS_TO_KEEP` controls that limit and is currently ``2``.
-Private full database dumps are kept on the private backup volume and are never uploaded to FTP. Retention cleanup runs
-only after every pending public payload uploads successfully, so failed uploads remain locally available for retry.
-Public full dumps left on the legacy backup volume are removed during the next full-dump run.
+Retention cleanup runs only after every pending public payload uploads successfully, so failed uploads remain locally
+available for retry. Public full dumps left on the legacy backup volume are removed during the next full-dump run.
+
+Db dumps are much smaller, so they are handled like the incremental dumps instead: the public dumps stay in the FTP
+staging directory and are also copied to the backup volume, and the private dumps are kept on the private backup volume
+and are never uploaded to FTP. :data:`listenbrainz.dumps.cleanup.NUMBER_OF_DB_DUMPS_TO_KEEP` controls how many of them
+are retained in each of those locations. Because both dump types share the :file:`fullexport` directory, the db dump
+rsync protects the retained full dump payloads on the FTP server from deletion.
 
 From the log file, you should probably be able to see whether the error occurred in python part of the code or bash
 script. If you see a python stack trace, it is likely that sentry recorded the error too. The `sentry view <https://sentry.metabrainz.org/organizations/metabrainz/issues/?project=15>`_
@@ -41,9 +60,10 @@ Manually triggering dumps
 .. program:: ./develop.sh manage dump create_full
 
 If you want to re-run a dump after it fails, or manually trigger a dump then you can run the dump script manually. A few
-things need to be kept in mind while doing this, the :ref:`developers/commands:create_full` invoked to do the dump
-accepts a :option:`--dump-id` parameter to number the dump. If no id specified, the script will look in the database for
-the last id, add 1 to it and use it for the dump.
+things need to be kept in mind while doing this, the :ref:`developers/commands:create_full` and
+:ref:`developers/commands:create_db_dump` commands invoked to do the dumps accept a :option:`--dump-id` parameter to number
+the dump. If no id specified, the script will look in the database for the last id, add 1 to it and use it for the dump.
+Note that a dump id belongs to one dump type, so a db dump can only be re-run with the id of an existing db dump.
 
 .. code:: sql
 

--- a/docs/maintainers/dumps.rst
+++ b/docs/maintainers/dumps.rst
@@ -19,7 +19,8 @@ on the FTP server:
 * the **full** dump job creates the listens, spark and statistics dumps into a
   :file:`listenbrainz-dump-<id>-<timestamp>-full` directory.
 
-The db dump runs an hour before the full dump so that the two jobs do not read from the databases at the same time.
+The full dump runs on the 1st and 15th of each month, and the db dump runs on the 2nd and 16th. The jobs run on separate
+hosts, so scheduling them on different days prevents them from reading heavily from the databases at the same time.
 Both dump types get their own id in the :code:`data_dump` table, so their ids and timestamps do not match each other.
 
 Logs

--- a/docs/users/listenbrainz-dumps.rst
+++ b/docs/users/listenbrainz-dumps.rst
@@ -28,6 +28,11 @@ A ListenBrainz data dump consists of three archives:
 
 #. ``listenbrainz-listens-dump-spark.tar.zst``
 
+The database dumps and the listens dumps are created by separate jobs, so they are published in two directories per
+dump cycle. The ``listenbrainz-public-dump.tar.zst`` archive is in the directory whose name ends in ``-db`` and the
+listens archives are in the directory whose name ends in ``-full``. Their ids and timestamps do not match each other,
+so always pick the newest directory of each kind.
+
 
 listenbrainz-public-dump.tar.zst
 -------------------------------

--- a/listenbrainz/dumps/check.py
+++ b/listenbrainz/dumps/check.py
@@ -14,10 +14,11 @@ INCREMENTAL_MAX_AGE = 26  # hours
 FEEDBACK_MAX_AGE = 8  # days
 
 
-def _fetch_latest_file_info_from_ftp_dir(directory: str, has_id: bool):
+def _fetch_latest_file_info_from_ftp_dir(directory: str, has_id: bool, suffix: str | None = None):
     """
         Given a base FTP dir and whether the dump name contains an id, browses the MB FTP server to fetch
-        the latest dump directory name and return it
+        the latest dump directory name and return it. The fullexport dir contains both listens dumps and
+        database dumps, so a suffix can be specified to only consider dumps of one type.
     """
 
     latest_dump_id: Optional[int] = None
@@ -25,7 +26,7 @@ def _fetch_latest_file_info_from_ftp_dir(directory: str, has_id: bool):
 
     def process_line(file):
         nonlocal latest_dump_id, latest_dt
-        if file:
+        if file and (suffix is None or file.endswith(suffix)):
             if has_id:
                 dump_id, dt = _parse_ftp_name_with_id(file)
             else:
@@ -81,37 +82,48 @@ def check_ftp_dump_ages():
 
     msg = ""
     try:
-        dump_id, dt = _fetch_latest_file_info_from_ftp_dir('/pub/musicbrainz/listenbrainz/fullexport', True)
+        dump_id, dt = _fetch_latest_file_info_from_ftp_dir('/pub/musicbrainz/listenbrainz/fullexport', True, '-full')
         age = datetime.now() - dt
         if age > timedelta(days=FULLEXPORT_MAX_AGE):
-            msg = "Full dump %d is more than %d days old: %s\n" % (dump_id, FULLEXPORT_MAX_AGE, str(age))
+            msg += "Full dump %d is more than %d days old: %s\n" % (dump_id, FULLEXPORT_MAX_AGE, str(age))
             print(msg, end="")
         else:
             print("Full dump %s is %s old, good!" % (dump_id, str(age)))
     except Exception as err:
-        msg = "Cannot fetch full dump age: %s\n\n%s" % (str(err), traceback.format_exc())
+        msg += "Cannot fetch full dump age: %s\n\n%s" % (str(err), traceback.format_exc())
+
+    try:
+        dump_id, dt = _fetch_latest_file_info_from_ftp_dir('/pub/musicbrainz/listenbrainz/fullexport', True, '-db')
+        age = datetime.now() - dt
+        if age > timedelta(days=FULLEXPORT_MAX_AGE):
+            msg += "Database dump %d is more than %d days old: %s\n" % (dump_id, FULLEXPORT_MAX_AGE, str(age))
+            print(msg, end="")
+        else:
+            print("Database dump %s is %s old, good!" % (dump_id, str(age)))
+    except Exception as err:
+        msg += "Cannot fetch database dump age: %s\n\n%s" % (str(err), traceback.format_exc())
 
     try:
         dump_id, dt = _fetch_latest_file_info_from_ftp_dir('/pub/musicbrainz/listenbrainz/incremental', True)
         age = datetime.now() - dt
         if age > timedelta(hours=INCREMENTAL_MAX_AGE):
-            msg = "Incremental dump %s is more than %s hours old: %s\n" % (dump_id, INCREMENTAL_MAX_AGE, str(age))
+            msg += "Incremental dump %s is more than %s hours old: %s\n" % (dump_id, INCREMENTAL_MAX_AGE, str(age))
             print(msg, end="")
         else:
             print("Incremental dump %s is %s old, good!" % (dump_id, str(age)))
     except Exception as err:
-        msg = "Cannot fetch incremental dump age: %s\n\n%s" % (str(err), traceback.format_exc())
+        msg += "Cannot fetch incremental dump age: %s\n\n%s" % (str(err), traceback.format_exc())
 
     try:
         dump_id, dt = _fetch_latest_file_info_from_ftp_dir('/pub/musicbrainz/listenbrainz/spark', False)
         age = datetime.now() - dt
         if age > timedelta(days=FEEDBACK_MAX_AGE):
-            msg = "Feedback dump %s is more than %s days old: %s\n" % (dump_id, FEEDBACK_MAX_AGE, str(age))
+            msg += "Feedback dump %s is more than %s days old: %s\n" % (dump_id, FEEDBACK_MAX_AGE, str(age))
             print(msg, end="")
         else:
             print("Feedback dump %s is %s old, good!" % (dump_id, str(age)))
     except Exception as err:
-        msg = "Cannot fetch feedback dump age: %s\n\n%s" % (str(err), traceback.format_exc())
+        msg += "Cannot fetch feedback dump age: %s\n\n%s" % (str(err), traceback.format_exc())
 
     app = create_app()
     with app.app_context():

--- a/listenbrainz/dumps/check.py
+++ b/listenbrainz/dumps/check.py
@@ -26,6 +26,7 @@ def _fetch_latest_file_info_from_ftp_dir(directory: str, has_id: bool, suffix: s
 
     def process_line(file):
         nonlocal latest_dump_id, latest_dt
+        file = file.rstrip("/")
         if file and (suffix is None or file.endswith(suffix)):
             if has_id:
                 dump_id, dt = _parse_ftp_name_with_id(file)

--- a/listenbrainz/dumps/cleanup.py
+++ b/listenbrainz/dumps/cleanup.py
@@ -3,6 +3,7 @@ import re
 import shutil
 
 NUMBER_OF_FULL_DUMPS_TO_KEEP = 2
+NUMBER_OF_DB_DUMPS_TO_KEEP = 2
 NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP = 30
 NUMBER_OF_FEEDBACK_DUMPS_TO_KEEP = 2
 NUMBER_OF_CANONICAL_DUMPS_TO_KEEP = 2
@@ -35,6 +36,15 @@ def _cleanup_dumps(location, remove_all_full_dumps=False):
     # Clean up full dumps
     full_dumps_to_keep = 0 if remove_all_full_dumps else NUMBER_OF_FULL_DUMPS_TO_KEEP
     _cleanup_full_dumps(location, full_dumps_to_keep)
+
+    # Clean up database dumps
+    db_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-db')
+    dump_files = [x for x in os.listdir(location) if db_dump_re.match(x)]
+    db_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
+    if not db_dumps:
+        print('No database dumps present in specified directory!')
+    else:
+        remove_dumps(location, db_dumps, NUMBER_OF_DB_DUMPS_TO_KEEP)
 
     # Clean up incremental dumps
     incremental_dump_re = re.compile(

--- a/listenbrainz/dumps/cleanup.py
+++ b/listenbrainz/dumps/cleanup.py
@@ -19,12 +19,23 @@ def _cleanup_full_dumps(location, dumps_to_keep):
         remove_dumps(location, full_dumps, dumps_to_keep)
 
 
-def _cleanup_dumps(location, remove_all_full_dumps=False):
+def _cleanup_db_dumps(location):
+    db_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-db')
+    dump_files = [x for x in os.listdir(location) if db_dump_re.match(x)]
+    db_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
+    if not db_dumps:
+        print('No database dumps present in specified directory!')
+    else:
+        remove_dumps(location, db_dumps, NUMBER_OF_DB_DUMPS_TO_KEEP)
+
+
+def _cleanup_dumps(location, remove_all_full_dumps=False, only_db_dumps=False):
     """Delete old dumps according to each dump type's retention constant.
 
     Args:
         location (str): the dir which needs to be cleaned up
         remove_all_full_dumps (bool): remove all full dumps instead of applying normal retention
+        only_db_dumps (bool): apply database dump retention without touching other dump types
 
     Returns:
         (int, int): the number of dumps remaining, the number of dumps deleted
@@ -33,18 +44,16 @@ def _cleanup_dumps(location, remove_all_full_dumps=False):
         print(f'Location {location} does not exist!')
         return
 
+    if only_db_dumps:
+        _cleanup_db_dumps(location)
+        return
+
     # Clean up full dumps
     full_dumps_to_keep = 0 if remove_all_full_dumps else NUMBER_OF_FULL_DUMPS_TO_KEEP
     _cleanup_full_dumps(location, full_dumps_to_keep)
 
     # Clean up database dumps
-    db_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-db')
-    dump_files = [x for x in os.listdir(location) if db_dump_re.match(x)]
-    db_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
-    if not db_dumps:
-        print('No database dumps present in specified directory!')
-    else:
-        remove_dumps(location, db_dumps, NUMBER_OF_DB_DUMPS_TO_KEEP)
+    _cleanup_db_dumps(location)
 
     # Clean up incremental dumps
     incremental_dump_re = re.compile(

--- a/listenbrainz/dumps/cleanup.py
+++ b/listenbrainz/dumps/cleanup.py
@@ -8,11 +8,22 @@ NUMBER_OF_FEEDBACK_DUMPS_TO_KEEP = 2
 NUMBER_OF_CANONICAL_DUMPS_TO_KEEP = 2
 
 
-def _cleanup_dumps(location):
-    """ Delete old dumps while keeping the latest two dumps in the specified directory
+def _cleanup_full_dumps(location, dumps_to_keep):
+    full_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-full')
+    dump_files = [x for x in os.listdir(location) if full_dump_re.match(x)]
+    full_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
+    if not full_dumps:
+        print('No full dumps present in specified directory!')
+    else:
+        remove_dumps(location, full_dumps, dumps_to_keep)
+
+
+def _cleanup_dumps(location, remove_all_full_dumps=False):
+    """Delete old dumps according to each dump type's retention constant.
 
     Args:
         location (str): the dir which needs to be cleaned up
+        remove_all_full_dumps (bool): remove all full dumps instead of applying normal retention
 
     Returns:
         (int, int): the number of dumps remaining, the number of dumps deleted
@@ -22,13 +33,8 @@ def _cleanup_dumps(location):
         return
 
     # Clean up full dumps
-    full_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-full')
-    dump_files = [x for x in os.listdir(location) if full_dump_re.match(x)]
-    full_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
-    if not full_dumps:
-        print('No full dumps present in specified directory!')
-    else:
-        remove_dumps(location, full_dumps, NUMBER_OF_FULL_DUMPS_TO_KEEP)
+    full_dumps_to_keep = 0 if remove_all_full_dumps else NUMBER_OF_FULL_DUMPS_TO_KEEP
+    _cleanup_full_dumps(location, full_dumps_to_keep)
 
     # Clean up incremental dumps
     incremental_dump_re = re.compile(

--- a/listenbrainz/dumps/cleanup.py
+++ b/listenbrainz/dumps/cleanup.py
@@ -1,122 +1,144 @@
 import os
 import re
 import shutil
+import sys
+from dataclasses import dataclass
 
 NUMBER_OF_FULL_DUMPS_TO_KEEP = 2
 NUMBER_OF_DB_DUMPS_TO_KEEP = 2
 NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP = 30
 NUMBER_OF_FEEDBACK_DUMPS_TO_KEEP = 2
 NUMBER_OF_CANONICAL_DUMPS_TO_KEEP = 2
+NUMBER_OF_SAMPLE_DUMPS_TO_KEEP = 2
 
 
-def _cleanup_full_dumps(location, dumps_to_keep):
-    full_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-full')
-    dump_files = [x for x in os.listdir(location) if full_dump_re.match(x)]
-    full_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
-    if not full_dumps:
-        print('No full dumps present in specified directory!')
-    else:
-        remove_dumps(location, full_dumps, dumps_to_keep)
+@dataclass(frozen=True)
+class DumpKind:
+    """ The retention policy for one type of dump.
+
+    The pattern must match a complete dump directory name and capture, in order,
+    the numeric fields which sort dumps of this kind from oldest to newest.
+    """
+    name: str
+    pattern: re.Pattern
+    keep: int
+
+    def sort_key(self, dump_name):
+        return tuple(int(field) for field in self.pattern.fullmatch(dump_name).groups())
 
 
-def _cleanup_db_dumps(location):
-    db_dump_re = re.compile('listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-db')
-    dump_files = [x for x in os.listdir(location) if db_dump_re.match(x)]
-    db_dumps = [x for x in sorted(dump_files, key=get_dump_id, reverse=True)]
-    if not db_dumps:
-        print('No database dumps present in specified directory!')
-    else:
-        remove_dumps(location, db_dumps, NUMBER_OF_DB_DUMPS_TO_KEEP)
+DUMP_KINDS = (
+    DumpKind(
+        'full',
+        re.compile(r'listenbrainz-dump-(\d+)-\d{8}-\d{6}-full'),
+        NUMBER_OF_FULL_DUMPS_TO_KEEP,
+    ),
+    DumpKind(
+        'db',
+        re.compile(r'listenbrainz-dump-(\d+)-\d{8}-\d{6}-db'),
+        NUMBER_OF_DB_DUMPS_TO_KEEP,
+    ),
+    DumpKind(
+        'incremental',
+        re.compile(r'listenbrainz-dump-(\d+)-\d{8}-\d{6}-incremental'),
+        NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP,
+    ),
+    DumpKind(
+        'feedback',
+        re.compile(r'listenbrainz-feedback-(\d{8})-(\d{6})-full'),
+        NUMBER_OF_FEEDBACK_DUMPS_TO_KEEP,
+    ),
+    DumpKind(
+        'sample',
+        re.compile(r'listenbrainz-sample-(\d{8})-(\d{6})-full'),
+        NUMBER_OF_SAMPLE_DUMPS_TO_KEEP,
+    ),
+    DumpKind(
+        'canonical',
+        re.compile(r'musicbrainz-canonical-dump-(\d{8})-(\d{6})'),
+        NUMBER_OF_CANONICAL_DUMPS_TO_KEEP,
+    ),
+)
 
 
-def _cleanup_dumps(location, remove_all_full_dumps=False, only_db_dumps=False):
-    """Delete old dumps according to each dump type's retention constant.
+def parse_keep_overrides(overrides):
+    """ Parse `KIND=COUNT` retention overrides into a dict.
+
+    Args:
+        overrides (Iterable[str]): overrides in `KIND=COUNT` form, e.g. `full=0`
+
+    Raises:
+        ValueError: if a kind is unknown or a count is not a non-negative integer
+    """
+    known_kinds = {kind.name for kind in DUMP_KINDS}
+    parsed = {}
+    for override in overrides:
+        kind, separator, count = override.partition('=')
+        if not separator or kind not in known_kinds or not count.isdigit():
+            raise ValueError(
+                f"invalid retention override '{override}', expected KIND=COUNT where KIND is one of "
+                f"{', '.join(sorted(known_kinds))} and COUNT is a non-negative integer"
+            )
+        parsed[kind] = int(count)
+    return parsed
+
+
+def select_expired_dumps(dump_names, keep_overrides=None):
+    """ Select the dumps which have fallen outside their kind's retention window.
+
+    This is the single definition of the retention policy. It works on names
+    alone so that the same policy can be applied to a local directory and to a
+    listing of the remote FTP host. Names which do not belong to a known dump
+    kind are ignored.
+
+    Args:
+        dump_names (Iterable[str]): dump directory names
+        keep_overrides (dict): number of dumps to keep, by kind name, overriding the defaults
+
+    Returns:
+        list[str]: the names of the dumps which should be deleted, newest first
+    """
+    keep_overrides = keep_overrides or {}
+    dump_names = list(dump_names)
+    expired = []
+
+    for kind in DUMP_KINDS:
+        keep = keep_overrides.get(kind.name, kind.keep)
+        dumps = sorted(
+            (name for name in dump_names if kind.pattern.fullmatch(name)),
+            key=kind.sort_key,
+            reverse=True,
+        )
+        if not dumps:
+            print(f'No {kind.name} dumps present!', file=sys.stderr)
+            continue
+
+        for name in dumps[:keep]:
+            print(f'Keeping {name}...', file=sys.stderr)
+        expired.extend(dumps[keep:])
+
+    return expired
+
+
+def _cleanup_dumps(location, keep_overrides=None):
+    """ Delete the dumps in a local directory which have fallen outside their kind's retention window.
 
     Args:
         location (str): the dir which needs to be cleaned up
-        remove_all_full_dumps (bool): remove all full dumps instead of applying normal retention
-        only_db_dumps (bool): apply database dump retention without touching other dump types
+        keep_overrides (dict): number of dumps to keep, by kind name, overriding the defaults
 
     Returns:
-        (int, int): the number of dumps remaining, the number of dumps deleted
+        (int, int): the number of entries remaining in the directory, the number of dumps deleted
     """
     if not os.path.exists(location):
-        print(f'Location {location} does not exist!')
-        return
+        print(f'Location {location} does not exist!', file=sys.stderr)
+        return 0, 0
 
-    if only_db_dumps:
-        _cleanup_db_dumps(location)
-        return
+    entries = os.listdir(location)
+    expired = select_expired_dumps(entries, keep_overrides)
+    for name in expired:
+        print(f'Removing {name}...', file=sys.stderr)
+        shutil.rmtree(os.path.join(location, name))
 
-    # Clean up full dumps
-    full_dumps_to_keep = 0 if remove_all_full_dumps else NUMBER_OF_FULL_DUMPS_TO_KEEP
-    _cleanup_full_dumps(location, full_dumps_to_keep)
-
-    # Clean up database dumps
-    _cleanup_db_dumps(location)
-
-    # Clean up incremental dumps
-    incremental_dump_re = re.compile(
-        'listenbrainz-dump-[0-9]*-[0-9]*-[0-9]*-incremental')
-    dump_files = [x for x in os.listdir(
-        location) if incremental_dump_re.match(x)]
-    incremental_dumps = [x for x in sorted(
-        dump_files, key=get_dump_id, reverse=True)]
-    if not incremental_dumps:
-        print('No incremental dumps present in specified directory!')
-    else:
-        remove_dumps(location, incremental_dumps,
-                     NUMBER_OF_INCREMENTAL_DUMPS_TO_KEEP)
-
-    # Clean up spark / feedback dumps
-    spark_dump_re = re.compile(
-        'listenbrainz-feedback-[0-9]*-[0-9]*-full')
-    dump_files = [x for x in os.listdir(
-        location) if spark_dump_re.match(x)]
-    spark_dumps = [x for x in sorted(
-        dump_files, key=get_dump_ts, reverse=True)]
-    if not spark_dumps:
-        print('No spark feedback dumps present in specified directory!')
-    else:
-        remove_dumps(location, spark_dumps,
-                     NUMBER_OF_FEEDBACK_DUMPS_TO_KEEP)
-
-    # Clean up canonical dumps
-    mbcanonical_dump_re = re.compile(
-        'musicbrainz-canonical-dump-[0-9]*-[0-9]*')
-    dump_files = [x for x in os.listdir(
-        location) if mbcanonical_dump_re.match(x)]
-    mbcanonical_dumps = [x for x in sorted(
-        dump_files, key=lambda dump_name: dump_name.split('-')[3] + dump_name.split('-')[4], reverse=True)]
-    if not mbcanonical_dumps:
-        print('No canonical dumps present in specified directory!')
-    else:
-        remove_dumps(location, mbcanonical_dumps,
-                     NUMBER_OF_CANONICAL_DUMPS_TO_KEEP)
-
-
-def remove_dumps(location, dumps, remaining_count):
-    keep = dumps[0:remaining_count]
-    keep_count = 0
-    for dump in keep:
-        print('Keeping %s...' % dump)
-        keep_count += 1
-
-    remove = dumps[remaining_count:]
-    remove_count = 0
-    for dump in remove:
-        print('Removing %s...' % dump)
-        shutil.rmtree(os.path.join(location, dump))
-        remove_count += 1
-
-    print('Deleted %d old exports, kept %d exports!' %
-          (remove_count, keep_count))
-    return keep_count, remove_count
-
-
-def get_dump_id(dump_name):
-    return int(dump_name.split('-')[2])
-
-
-def get_dump_ts(dump_name):
-    return dump_name.split('-')[2] + dump_name.split('-')[3]
+    print(f'Deleted {len(expired)} old exports from {location}!', file=sys.stderr)
+    return len(entries) - len(expired), len(expired)

--- a/listenbrainz/dumps/manager.py
+++ b/listenbrainz/dumps/manager.py
@@ -32,7 +32,7 @@ from listenbrainz.db.dump_entry import get_latest_incremental_dump, add_dump_ent
     get_previous_incremental_dump
 from listenbrainz.dumps import DUMP_DEFAULT_THREAD_COUNT
 from listenbrainz.dumps.check import check_ftp_dump_ages
-from listenbrainz.dumps.cleanup import _cleanup_dumps
+from listenbrainz.dumps.cleanup import _cleanup_dumps, parse_keep_overrides, select_expired_dumps
 from listenbrainz.dumps.exporter import create_statistics_dump, dump_feedback_for_spark, dump_database, \
     create_sample_dump
 from listenbrainz.dumps.importer import import_postgres_dump
@@ -465,16 +465,40 @@ def import_dump(private_archive, private_timescale_archive,
             import_sample_data(sample_archive, threads)
 
 
+def _parse_keep_overrides(overrides):
+    try:
+        return parse_keep_overrides(overrides)
+    except ValueError as err:
+        raise click.BadParameter(str(err), param_hint='--keep')
+
+
+keep_option = click.option(
+    '--keep', 'keep_overrides', multiple=True, metavar='KIND=COUNT',
+    help='Keep COUNT dumps of kind KIND instead of the default, e.g. --keep full=0. May be repeated.'
+)
+
+
 @cli.command(name="delete_old_dumps")
 @click.argument('location', type=str)
-@click.option('--remove-all-full-dumps', is_flag=True, default=False)
-@click.option('--only-db-dumps', is_flag=True, default=False)
-def delete_old_dumps(location, remove_all_full_dumps, only_db_dumps):
-    _cleanup_dumps(
-        location,
-        remove_all_full_dumps=remove_all_full_dumps,
-        only_db_dumps=only_db_dumps,
-    )
+@keep_option
+def delete_old_dumps(location, keep_overrides):
+    """ Delete the dumps in LOCATION which have fallen outside their kind's retention window. """
+    _cleanup_dumps(location, _parse_keep_overrides(keep_overrides))
+
+
+@cli.command(name="list_expired_dumps")
+@keep_option
+def list_expired_dumps(keep_overrides):
+    """ Read dump directory names on stdin and print the expired ones to stdout.
+
+    The retention policy lives here so that the shell scripts which own the rsync
+    credentials do not need to know it: they list the remote host, pipe the listing
+    through this command and delete whatever it names. Diagnostics are written to
+    stderr so that stdout stays machine readable.
+    """
+    dump_names = [line.strip() for line in sys.stdin if line.strip()]
+    for name in select_expired_dumps(dump_names, _parse_keep_overrides(keep_overrides)):
+        click.echo(name)
 
 
 @cli.command(name="check_dump_ages")

--- a/listenbrainz/dumps/manager.py
+++ b/listenbrainz/dumps/manager.py
@@ -413,8 +413,9 @@ def import_dump(private_archive, private_timescale_archive,
 
 @cli.command(name="delete_old_dumps")
 @click.argument('location', type=str)
-def delete_old_dumps(location):
-    _cleanup_dumps(location)
+@click.option('--remove-all-full-dumps', is_flag=True, default=False)
+def delete_old_dumps(location, remove_all_full_dumps):
+    _cleanup_dumps(location, remove_all_full_dumps=remove_all_full_dumps)
 
 
 @cli.command(name="check_dump_ages")

--- a/listenbrainz/dumps/manager.py
+++ b/listenbrainz/dumps/manager.py
@@ -468,8 +468,13 @@ def import_dump(private_archive, private_timescale_archive,
 @cli.command(name="delete_old_dumps")
 @click.argument('location', type=str)
 @click.option('--remove-all-full-dumps', is_flag=True, default=False)
-def delete_old_dumps(location, remove_all_full_dumps):
-    _cleanup_dumps(location, remove_all_full_dumps=remove_all_full_dumps)
+@click.option('--only-db-dumps', is_flag=True, default=False)
+def delete_old_dumps(location, remove_all_full_dumps, only_db_dumps):
+    _cleanup_dumps(
+        location,
+        remove_all_full_dumps=remove_all_full_dumps,
+        only_db_dumps=only_db_dumps,
+    )
 
 
 @cli.command(name="check_dump_ages")

--- a/listenbrainz/dumps/manager.py
+++ b/listenbrainz/dumps/manager.py
@@ -101,8 +101,6 @@ def create_mbcanonical(location, use_lb_conn):
 @cli.command(name="create_full")
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'),
               help="path to the directory where the dump should be made")
-@click.option('--location-private', '-lp', default=None,
-              help="path to the directory where the private dumps should be made")
 @click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT,
               help="the number of threads to be used while compression")
 @click.option('--dump-id', type=int, default=None,
@@ -111,33 +109,19 @@ def create_mbcanonical(location, use_lb_conn):
               help="If True, make a listens dump")
 @click.option('--spark/--no-spark', 'do_spark_dump', type=bool, default=True,
               help="If True, make a spark listens dump")
-@click.option('--db/--no-db', 'do_db_dump', type=bool, default=True,
-              help="If True, make a public/private postgres dump")
-@click.option('--timescale/--no-timescale', 'do_timescale_dump', type=bool, default=True,
-              help="If True, make a public/private timescale dump")
 @click.option('--stats/--no-stats', 'do_stats_dump', type=bool, default=True,
               help="If True, make a couchdb stats dump")
 @click.option("--location-temp", "-lt", default=None,
               help="path to directory to use for creating necessary temporary files during dumps.")
-@click.option("--location-private-temp", "-lpt", default=None,
-              help="path to directory to use for creating necessary temporary files during private dumps.")
-def create_full(location: str, location_private: str, threads: int, dump_id: int, do_listen_dump: bool,
-                do_spark_dump: bool, do_db_dump: bool, do_timescale_dump: bool, do_stats_dump: bool,
-                location_temp: str = None, location_private_temp: str = None):
-    """ Create a ListenBrainz data dump which includes a private dump, a statistics dump
-        and a dump of the actual listens from the listenstore.
+def create_full(location: str, threads: int, dump_id: int, do_listen_dump: bool, do_spark_dump: bool,
+                do_stats_dump: bool, location_temp: str = None):
+    """ Create a ListenBrainz full data dump which includes a dump of the actual listens from the
+        listenstore, a spark formatted listens dump and a statistics dump.
+
+        The public and private database dumps are created separately by the create_db_dump command.
     """
     app = create_app(bypass_pgbouncer=True)
     with app.app_context():
-        if not location_private and (do_db_dump or do_timescale_dump):
-            current_app.logger.error("No location specified for creating private database and timescale dumps")
-            sys.exit(-1)
-        if location_private and os.path.normpath(location_private) == os.path.normpath(location):
-            current_app.logger.error("Location specified for public and private dumps cannot be same")
-            sys.exit(-1)
-        if location_private and PurePath(location_private).is_relative_to(PurePath(location)):
-            current_app.logger.error("Private dumps location cannot be a subdirectory of public dumps location")
-            sys.exit(-1)
         ls = DumpListenStore(app)
         if dump_id is None:
             latest_inc_dump = get_latest_incremental_dump()
@@ -158,28 +142,7 @@ def create_full(location: str, location_private: str, threads: int, dump_id: int
         dump_path = os.path.join(location, dump_name)
         create_path(dump_path)
 
-        private_dump_path = None
-        if location_private:
-            private_dump_path = os.path.join(location_private, dump_name)
-            create_path(private_dump_path)
-
-        locations = {
-            "public": dump_path,
-            "private": private_dump_path,
-            "public_temp": location_temp,
-            "private_temp": location_private_temp,
-        }
-
         expected_num_dumps = 0
-        expected_num_private_dumps = 0
-        if do_db_dump:
-            dump_database("postgres", locations, end_time, threads)
-            expected_num_dumps += 1
-            expected_num_private_dumps += 1
-        if do_timescale_dump:
-            dump_database("timescale", locations, end_time, threads)
-            expected_num_dumps += 1
-            expected_num_private_dumps += 1
         if do_listen_dump:
             ls.dump_listens(
                 dump_path, dump_id=dump_id, start_time=start_time,
@@ -200,37 +163,128 @@ def create_full(location: str, location_private: str, threads: int, dump_id: int
 
         try:
             write_hashes(dump_path)
-            if private_dump_path:
-                write_hashes(private_dump_path)
         except IOError as e:
             current_app.logger.error('Unable to create hash files! Error: %s', str(e), exc_info=True)
             sys.exit(-1)
 
         try:
-            # 6 types of dumps, archive, md5, sha256 for each
+            # archive, md5, sha256 for each expected dump archive
             expected_num_dump_files = expected_num_dumps * 3
-            expected_num_private_dumps = expected_num_private_dumps * 3
             if not sanity_check_dumps(dump_path, expected_num_dump_files):
-                return sys.exit(-1)
-            if private_dump_path and not sanity_check_dumps(private_dump_path, expected_num_private_dumps):
                 return sys.exit(-1)
         except OSError:
             sys.exit(-1)
 
         current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
-        if private_dump_path:
-            current_app.logger.info('Private dumps created and hashes written at %s' % private_dump_path)
 
         # Write the DUMP_ID file so that the FTP sync scripts can be more robust
         with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
             f.write("%s %s full\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
-        if private_dump_path:
-            # Write the DUMP_ID file so that the backup sync scripts can be more robust
-            with open(os.path.join(private_dump_path, "DUMP_ID.txt"), "w") as f:
-                f.write("%s %s full\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
         if do_spark_dump:
             ls.cleanup_listen_delete_metadata()
+
+
+@cli.command(name="create_db_dump")
+@click.option('--location', '-l', default=os.path.join(os.getcwd(), 'listenbrainz-export'),
+              help="path to the directory where the public dumps should be made")
+@click.option('--location-private', '-lp', default=None,
+              help="path to the directory where the private dumps should be made")
+@click.option('--threads', '-t', type=int, default=DUMP_DEFAULT_THREAD_COUNT,
+              help="the number of threads to be used while compression")
+@click.option('--dump-id', type=int, default=None,
+              help="the ID of the ListenBrainz data dump")
+@click.option('--postgres/--no-postgres', 'do_db_dump', type=bool, default=True,
+              help="If True, make a public/private postgres dump")
+@click.option('--timescale/--no-timescale', 'do_timescale_dump', type=bool, default=True,
+              help="If True, make a public/private timescale dump")
+@click.option("--location-temp", "-lt", default=None,
+              help="path to directory to use for creating necessary temporary files during dumps.")
+@click.option("--location-private-temp", "-lpt", default=None,
+              help="path to directory to use for creating necessary temporary files during private dumps.")
+def create_db_dump(location: str, location_private: str, threads: int, dump_id: int, do_db_dump: bool,
+                   do_timescale_dump: bool, location_temp: str = None, location_private_temp: str = None):
+    """ Create a dump of the public and private data in the postgres and timescale databases.
+
+        The listens, spark and statistics dumps are created separately by the create_full command.
+    """
+    app = create_app(bypass_pgbouncer=True)
+    with app.app_context():
+        if not do_db_dump and not do_timescale_dump:
+            current_app.logger.error("Nothing to dump, both postgres and timescale dumps are disabled")
+            sys.exit(-1)
+        if not location_private:
+            current_app.logger.error("No location specified for creating private database and timescale dumps")
+            sys.exit(-1)
+        if os.path.normpath(location_private) == os.path.normpath(location):
+            current_app.logger.error("Location specified for public and private dumps cannot be same")
+            sys.exit(-1)
+        if PurePath(location_private).is_relative_to(PurePath(location)):
+            current_app.logger.error("Private dumps location cannot be a subdirectory of public dumps location")
+            sys.exit(-1)
+
+        if dump_id is None:
+            end_time = datetime.now(tz=timezone.utc)
+            dump_id = add_dump_entry(end_time, "db")
+        else:
+            dump_entry = get_dump_entry(dump_id, "db")
+            if dump_entry is None:
+                current_app.logger.error("No db dump with ID %d found", dump_id)
+                sys.exit(-1)
+            end_time = dump_entry['created']
+
+        dump_name = f'listenbrainz-dump-{dump_id}-{end_time.strftime("%Y%m%d-%H%M%S")}-db'
+        dump_path = os.path.join(location, dump_name)
+        create_path(dump_path)
+
+        private_dump_path = os.path.join(location_private, dump_name)
+        create_path(private_dump_path)
+
+        locations = {
+            "public": dump_path,
+            "private": private_dump_path,
+            "public_temp": location_temp,
+            "private_temp": location_private_temp,
+        }
+
+        expected_num_dumps = 0
+        expected_num_private_dumps = 0
+        if do_db_dump:
+            dump_database("postgres", locations, end_time, threads)
+            expected_num_dumps += 1
+            expected_num_private_dumps += 1
+        if do_timescale_dump:
+            dump_database("timescale", locations, end_time, threads)
+            expected_num_dumps += 1
+            expected_num_private_dumps += 1
+
+        try:
+            write_hashes(dump_path)
+            write_hashes(private_dump_path)
+        except IOError as e:
+            current_app.logger.error('Unable to create hash files! Error: %s', str(e), exc_info=True)
+            sys.exit(-1)
+
+        try:
+            # archive, md5, sha256 for each expected dump archive
+            expected_num_dump_files = expected_num_dumps * 3
+            expected_num_private_dump_files = expected_num_private_dumps * 3
+            if not sanity_check_dumps(dump_path, expected_num_dump_files):
+                return sys.exit(-1)
+            if not sanity_check_dumps(private_dump_path, expected_num_private_dump_files):
+                return sys.exit(-1)
+        except OSError:
+            sys.exit(-1)
+
+        current_app.logger.info('Dumps created and hashes written at %s' % dump_path)
+        current_app.logger.info('Private dumps created and hashes written at %s' % private_dump_path)
+
+        # Write the DUMP_ID file so that the FTP sync scripts can be more robust
+        with open(os.path.join(dump_path, "DUMP_ID.txt"), "w") as f:
+            f.write("%s %s db\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
+        # Write the DUMP_ID file so that the backup sync scripts can be more robust
+        with open(os.path.join(private_dump_path, "DUMP_ID.txt"), "w") as f:
+            f.write("%s %s db\n" % (end_time.strftime('%Y%m%d-%H%M%S'), dump_id))
 
 
 @cli.command(name="create_incremental")

--- a/listenbrainz/dumps/tests/test_dump_check.py
+++ b/listenbrainz/dumps/tests/test_dump_check.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from listenbrainz.dumps.check import _fetch_latest_file_info_from_ftp_dir
+
+
+@patch("listenbrainz.dumps.check.FTP")
+def test_fetch_latest_dump_normalizes_trailing_slash(mock_ftp):
+    dump_names = [
+        "listenbrainz-dump-122-20260615-030000-full",
+        "listenbrainz-dump-123-20260701-030000-full/",
+        "listenbrainz-dump-124-20260701-040000-db/",
+    ]
+    mock_ftp.return_value.retrlines.side_effect = (
+        lambda command, callback: [callback(name) for name in dump_names]
+    )
+
+    dump_id, created = _fetch_latest_file_info_from_ftp_dir(
+        "/pub/musicbrainz/listenbrainz/fullexport",
+        True,
+        "-full",
+    )
+
+    assert dump_id == 123
+    assert created == datetime(2026, 7, 1, 3, 0)

--- a/listenbrainz/dumps/tests/test_dump_manager.py
+++ b/listenbrainz/dumps/tests/test_dump_manager.py
@@ -57,13 +57,28 @@ def test_cleanup_full_dump_retention_uses_constant(tmp_path):
     assert 'listenbrainz-dump-4-20180312-000004-full' in remaining
 
 
+def test_cleanup_db_dump_retention_uses_constant(tmp_path):
+    for dump_id in range(1, 5):
+        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-db').mkdir()
+
+    _cleanup_dumps(str(tmp_path))
+
+    remaining = {path.name for path in tmp_path.iterdir()}
+    assert 'listenbrainz-dump-1-20180312-000001-db' not in remaining
+    assert 'listenbrainz-dump-2-20180312-000002-db' not in remaining
+    assert 'listenbrainz-dump-3-20180312-000003-db' in remaining
+    assert 'listenbrainz-dump-4-20180312-000004-db' in remaining
+
+
 def test_cleanup_legacy_full_dump_backups(tmp_path):
     for dump_id in range(1, 3):
         (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()
+    (tmp_path / 'listenbrainz-dump-3-20180312-000003-db').mkdir()
 
     _cleanup_dumps(str(tmp_path), remove_all_full_dumps=True)
 
-    assert not list(tmp_path.iterdir())
+    # only the full dumps are removed, db dumps are still backed up on this volume
+    assert [path.name for path in tmp_path.iterdir()] == ['listenbrainz-dump-3-20180312-000003-db']
 
 
 class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
@@ -152,13 +167,31 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
 
         self.assertIn('not-a-dump', newdirs)
 
-    def test_create_full_db(self):
+    def test_create_full(self):
 
         listens = generate_data(1, self.user_name, 1500000000, 5)
         self.listenstore.insert(listens)
 
         # create a full dump
-        self.runner.invoke(dump_manager.create_full, [
+        self.runner.invoke(dump_manager.create_full, ['--location', self.tempdir])
+        self.assertEqual(len(os.listdir(self.tempdir)), 1)
+        dump_name = os.listdir(self.tempdir)[0]
+        self.assertTrue(dump_name.endswith("-full"))
+
+        # make sure that the dump contains a listens dump, a spark dump and a statistics dump
+        archive_count = 0
+        for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
+                archive_count += 1
+        self.assertEqual(archive_count, 3)
+
+        # the database dumps are created by a separate command
+        self.assertEqual(len(os.listdir(self.tempdir_private)), 0)
+
+    def test_create_db_dump(self):
+
+        # create a db dump
+        self.runner.invoke(dump_manager.create_db_dump, [
             '--location',
             self.tempdir,
             '--location-private',
@@ -166,16 +199,17 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         ])
         self.assertEqual(len(os.listdir(self.tempdir)), 1)
         dump_name = os.listdir(self.tempdir)[0]
+        self.assertTrue(dump_name.endswith("-db"))
 
-        # make sure that the dump contains a full listens dump, a public and private dump (postgres),
-        # a public and private dump (timescale) and a spark dump.
-        # dumps should contain the 7 archives
+        # make sure that the dump contains a public dump (postgres) and a public dump (timescale)
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
-        self.assertEqual(archive_count, 5)
+        self.assertEqual(archive_count, 2)
 
+        # and a private dump (postgres) and a private dump (timescale)
+        self.assertEqual(os.listdir(self.tempdir_private), [dump_name])
         private_archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir_private, dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
@@ -190,8 +224,6 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         result = self.runner.invoke(dump_manager.create_full, [
             '--location',
             self.tempdir,
-            '--location-private',
-            self.tempdir_private,
             '--dump-id',
             1000
         ])
@@ -204,6 +236,53 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         result = self.runner.invoke(dump_manager.create_full, [
             '--location',
             self.tempdir,
+            '--dump-id',
+            dump_id
+        ])
+        self.assertEqual(len(os.listdir(self.tempdir)), 1)
+        dump_name = os.listdir(self.tempdir)[0]
+        created_dump_id = int(dump_name.split('-')[2])
+        self.assertEqual(dump_id, created_dump_id)
+
+        # dump should contain the listens, spark and statistics archives
+        archive_count = 0
+        for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
+            if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
+                archive_count += 1
+        self.assertEqual(archive_count, 3)
+
+    def test_create_db_dump_with_id(self):
+        # if the dump ID does not exist, it should exit with a -1
+        result = self.runner.invoke(dump_manager.create_db_dump, [
+            '--location',
+            self.tempdir,
+            '--location-private',
+            self.tempdir_private,
+            '--dump-id',
+            1000
+        ])
+        self.assertEqual(result.exit_code, -1)
+        # make sure no directory was created either
+        self.assertEqual(len(os.listdir(self.tempdir)), 0)
+
+        # a full dump with the same id should not be usable for a db dump either
+        dump_id = add_dump_entry(datetime.now(tz=timezone.utc), "full")
+        result = self.runner.invoke(dump_manager.create_db_dump, [
+            '--location',
+            self.tempdir,
+            '--location-private',
+            self.tempdir_private,
+            '--dump-id',
+            dump_id
+        ])
+        self.assertEqual(result.exit_code, -1)
+        self.assertEqual(len(os.listdir(self.tempdir)), 0)
+
+        # now, add a dump entry to the database and create a dump with that specific dump id
+        dump_id = add_dump_entry(datetime.now(tz=timezone.utc), "db")
+        result = self.runner.invoke(dump_manager.create_db_dump, [
+            '--location',
+            self.tempdir,
             '--location-private',
             self.tempdir_private,
             '--dump-id',
@@ -214,25 +293,25 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         created_dump_id = int(dump_name.split('-')[2])
         self.assertEqual(dump_id, created_dump_id)
 
-        dump_name = os.listdir(self.tempdir_private)[0]
-        created_private_dump_id = int(dump_name.split('-')[2])
+        private_dump_name = os.listdir(self.tempdir_private)[0]
+        created_private_dump_id = int(private_dump_name.split('-')[2])
         self.assertEqual(dump_id, created_private_dump_id)
 
-        # dumps should contain the 7 archives
+        # dumps should contain the public and private postgres and timescale archives
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
-        self.assertEqual(archive_count, 5)
+        self.assertEqual(archive_count, 2)
 
         private_archive_count = 0
-        for file_name in os.listdir(os.path.join(self.tempdir_private, dump_name)):
+        for file_name in os.listdir(os.path.join(self.tempdir_private, private_dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 private_archive_count += 1
         self.assertEqual(private_archive_count, 2)
 
-    def test_full_dump_exits_private_location(self):
-        result = self.runner.invoke(dump_manager.create_full, [
+    def test_db_dump_exits_private_location(self):
+        result = self.runner.invoke(dump_manager.create_db_dump, [
             '--location',
             self.tempdir
         ])
@@ -240,7 +319,7 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertIn("No location specified for creating private database and timescale dumps", self._caplog.text)
 
         self._caplog.clear()
-        result = self.runner.invoke(dump_manager.create_full, [
+        result = self.runner.invoke(dump_manager.create_db_dump, [
             '--location',
             self.tempdir,
             '--location-private',
@@ -250,7 +329,7 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         self.assertIn("Location specified for public and private dumps cannot be same", self._caplog.text)
 
         self._caplog.clear()
-        result = self.runner.invoke(dump_manager.create_full, [
+        result = self.runner.invoke(dump_manager.create_db_dump, [
             '--location',
             self.tempdir,
             '--location-private',
@@ -258,16 +337,6 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         ])
         self.assertEqual(result.exit_code, -1)
         self.assertIn("Private dumps location cannot be a subdirectory of public dumps location", self._caplog.text)
-
-        self._caplog.clear()
-        # no location for private dupms is required if no private dumps are being made
-        result = self.runner.invoke(dump_manager.create_full, [
-            '--location',
-            self.tempdir,
-            '--no-db',
-            '--no-timescale'
-        ], catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)
 
     def test_create_incremental(self):
         # create a incremental dump, this won't work because the incremental dump does
@@ -325,8 +394,7 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
 
         # passing a created value for start timestamp makes it work fine
         self.runner.invoke(dump_manager.create_full, [
-            "--location", self.tempdir,
-            "--no-db", "--no-timescale", "--no-stats"
+            "--location", self.tempdir, "--no-stats"
         ], catch_exceptions=False)
 
         self.assertEqual(len(os.listdir(self.tempdir)), 1)

--- a/listenbrainz/dumps/tests/test_dump_manager.py
+++ b/listenbrainz/dumps/tests/test_dump_manager.py
@@ -123,6 +123,7 @@ def test_select_expired_dumps_ignores_unrecognised_names():
         'listenbrainz-dump-5-2018031-000005-full',
     ]
 
+    # Of the three recognised full dumps, retain the newest two and expire only the oldest.
     assert select_expired_dumps(dump_names) == ['listenbrainz-dump-1-20180312-000001-full']
 
 
@@ -133,6 +134,7 @@ def test_select_expired_dumps_sorts_full_dumps_by_id_not_name():
         'listenbrainz-dump-11-20180314-000011-full',
     ]
 
+    # Default full-dump retention is two, so only the oldest numeric ID expires.
     assert select_expired_dumps(dump_names) == ['listenbrainz-dump-9-20180312-000009-full']
 
 
@@ -272,14 +274,14 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         dump_name = os.listdir(self.tempdir)[0]
         self.assertTrue(dump_name.endswith("-db"))
 
-        # make sure that the dump contains a public dump (postgres) and a public dump (timescale)
+        # make sure that the dump contains a public postgres dump and a public timescale dump
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 2)
 
-        # and a private dump (postgres) and a private dump (timescale)
+        # and a private postgres dump and a private timescale dump
         self.assertEqual(os.listdir(self.tempdir_private), [dump_name])
         private_archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir_private, dump_name)):
@@ -368,13 +370,14 @@ class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
         created_private_dump_id = int(private_dump_name.split('-')[2])
         self.assertEqual(dump_id, created_private_dump_id)
 
-        # dumps should contain the public and private postgres and timescale archives
+        # the public dump should contain the postgres and timescale archives
         archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir, dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):
                 archive_count += 1
         self.assertEqual(archive_count, 2)
 
+        # the private dump should contain the postgres and timescale archives
         private_archive_count = 0
         for file_name in os.listdir(os.path.join(self.tempdir_private, private_dump_name)):
             if file_name.endswith(".tar.zst") or file_name.endswith(".tar"):

--- a/listenbrainz/dumps/tests/test_dump_manager.py
+++ b/listenbrainz/dumps/tests/test_dump_manager.py
@@ -44,6 +44,28 @@ from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app, timescale_connection
 
 
+def test_cleanup_full_dump_retention_uses_constant(tmp_path):
+    for dump_id in range(1, 5):
+        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()
+
+    _cleanup_dumps(str(tmp_path))
+
+    remaining = {path.name for path in tmp_path.iterdir()}
+    assert 'listenbrainz-dump-1-20180312-000001-full' not in remaining
+    assert 'listenbrainz-dump-2-20180312-000002-full' not in remaining
+    assert 'listenbrainz-dump-3-20180312-000003-full' in remaining
+    assert 'listenbrainz-dump-4-20180312-000004-full' in remaining
+
+
+def test_cleanup_legacy_full_dump_backups(tmp_path):
+    for dump_id in range(1, 3):
+        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()
+
+    _cleanup_dumps(str(tmp_path), remove_all_full_dumps=True)
+
+    assert not list(tmp_path.iterdir())
+
+
 class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):
 
     def setUp(self):

--- a/listenbrainz/dumps/tests/test_dump_manager.py
+++ b/listenbrainz/dumps/tests/test_dump_manager.py
@@ -19,9 +19,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA"
 
+import io
 import os
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import time
@@ -38,7 +40,7 @@ from listenbrainz.db.dump_entry import add_dump_entry, get_dump_entries, get_dum
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.db.model.recommendation_feedback import RecommendationFeedbackSubmit
 from listenbrainz.db.testing import DatabaseTestCase, TimescaleTestCase
-from listenbrainz.dumps.cleanup import _cleanup_dumps
+from listenbrainz.dumps.cleanup import _cleanup_dumps, select_expired_dumps
 from listenbrainz.listenstore.tests.util import generate_data
 from listenbrainz.utils import create_path
 from listenbrainz.webserver import create_app, timescale_connection
@@ -70,24 +72,17 @@ def test_cleanup_db_dump_retention_uses_constant(tmp_path):
     assert 'listenbrainz-dump-4-20180312-000004-db' in remaining
 
 
-def test_cleanup_only_db_dumps_preserves_pending_full_dumps(tmp_path):
-    for dump_id in range(1, 5):
-        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()
-        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-db').mkdir()
+def test_cleanup_sample_dump_retention_uses_constant(tmp_path):
+    for minute in range(1, 5):
+        (tmp_path / f'listenbrainz-sample-20180312-00000{minute}-full').mkdir()
 
-    result = CliRunner().invoke(
-        dump_manager.cli,
-        ["delete_old_dumps", "--only-db-dumps", str(tmp_path)],
-    )
+    _cleanup_dumps(str(tmp_path))
 
-    assert result.exit_code == 0
     remaining = {path.name for path in tmp_path.iterdir()}
-    for dump_id in range(1, 5):
-        assert f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full' in remaining
-    assert 'listenbrainz-dump-1-20180312-000001-db' not in remaining
-    assert 'listenbrainz-dump-2-20180312-000002-db' not in remaining
-    assert 'listenbrainz-dump-3-20180312-000003-db' in remaining
-    assert 'listenbrainz-dump-4-20180312-000004-db' in remaining
+    assert 'listenbrainz-sample-20180312-000001-full' not in remaining
+    assert 'listenbrainz-sample-20180312-000002-full' not in remaining
+    assert 'listenbrainz-sample-20180312-000003-full' in remaining
+    assert 'listenbrainz-sample-20180312-000004-full' in remaining
 
 
 def test_cleanup_legacy_full_dump_backups(tmp_path):
@@ -95,10 +90,66 @@ def test_cleanup_legacy_full_dump_backups(tmp_path):
         (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()
     (tmp_path / 'listenbrainz-dump-3-20180312-000003-db').mkdir()
 
-    _cleanup_dumps(str(tmp_path), remove_all_full_dumps=True)
+    result = CliRunner().invoke(
+        dump_manager.cli,
+        ["delete_old_dumps", "--keep", "full=0", str(tmp_path)],
+    )
 
+    assert result.exit_code == 0
     # only the full dumps are removed, db dumps are still backed up on this volume
     assert [path.name for path in tmp_path.iterdir()] == ['listenbrainz-dump-3-20180312-000003-db']
+
+
+def test_cleanup_rejects_unknown_keep_override(tmp_path):
+    (tmp_path / 'listenbrainz-dump-1-20180312-000001-full').mkdir()
+
+    result = CliRunner().invoke(
+        dump_manager.cli,
+        ["delete_old_dumps", "--keep", "listens=0", str(tmp_path)],
+    )
+
+    assert result.exit_code != 0
+    assert [path.name for path in tmp_path.iterdir()] == ['listenbrainz-dump-1-20180312-000001-full']
+
+
+def test_select_expired_dumps_ignores_unrecognised_names():
+    dump_names = [
+        'listenbrainz-dump-1-20180312-000001-full',
+        'listenbrainz-dump-2-20180312-000002-full',
+        'listenbrainz-dump-3-20180312-000003-full',
+        # neither a dump nor a prefix of one that may be deleted
+        'not-a-dump',
+        'listenbrainz-dump-4-20180312-000004-full.tmp',
+        'listenbrainz-dump-5-2018031-000005-full',
+    ]
+
+    assert select_expired_dumps(dump_names) == ['listenbrainz-dump-1-20180312-000001-full']
+
+
+def test_select_expired_dumps_sorts_full_dumps_by_id_not_name():
+    dump_names = [
+        'listenbrainz-dump-9-20180312-000009-full',
+        'listenbrainz-dump-10-20180313-000010-full',
+        'listenbrainz-dump-11-20180314-000011-full',
+    ]
+
+    assert select_expired_dumps(dump_names) == ['listenbrainz-dump-9-20180312-000009-full']
+
+
+def test_list_expired_dumps_prints_expired_names_only(monkeypatch, capsys):
+    dump_names = [
+        'listenbrainz-dump-1-20180312-000001-db',
+        'listenbrainz-dump-2-20180312-000002-db',
+        'listenbrainz-dump-3-20180312-000003-db',
+        'not-a-dump',
+    ]
+    monkeypatch.setattr(sys, 'stdin', io.StringIO("\n".join(dump_names) + "\n"))
+
+    dump_manager.list_expired_dumps.callback(keep_overrides=())
+
+    # the shell scripts parse stdout, so only expired names may appear there
+    stdout, _ = capsys.readouterr()
+    assert stdout.split() == ['listenbrainz-dump-1-20180312-000001-db']
 
 
 class DumpManagerTestCase(DatabaseTestCase, TimescaleTestCase):

--- a/listenbrainz/dumps/tests/test_dump_manager.py
+++ b/listenbrainz/dumps/tests/test_dump_manager.py
@@ -70,6 +70,26 @@ def test_cleanup_db_dump_retention_uses_constant(tmp_path):
     assert 'listenbrainz-dump-4-20180312-000004-db' in remaining
 
 
+def test_cleanup_only_db_dumps_preserves_pending_full_dumps(tmp_path):
+    for dump_id in range(1, 5):
+        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()
+        (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-db').mkdir()
+
+    result = CliRunner().invoke(
+        dump_manager.cli,
+        ["delete_old_dumps", "--only-db-dumps", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    remaining = {path.name for path in tmp_path.iterdir()}
+    for dump_id in range(1, 5):
+        assert f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full' in remaining
+    assert 'listenbrainz-dump-1-20180312-000001-db' not in remaining
+    assert 'listenbrainz-dump-2-20180312-000002-db' not in remaining
+    assert 'listenbrainz-dump-3-20180312-000003-db' in remaining
+    assert 'listenbrainz-dump-4-20180312-000004-db' in remaining
+
+
 def test_cleanup_legacy_full_dump_backups(tmp_path):
     for dump_id in range(1, 3):
         (tmp_path / f'listenbrainz-dump-{dump_id}-20180312-00000{dump_id}-full').mkdir()

--- a/listenbrainz/listenstore/dump_listenstore.py
+++ b/listenbrainz/listenstore/dump_listenstore.py
@@ -336,86 +336,89 @@ class DumpListenStore:
         listen_count = 0
         current_listened_at = None
         conn = timescale.engine.raw_connection()
-        with (conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as curs):
-            curs.execute(query, args)
-            while True:
-                t0 = time.monotonic()
-                written = 0
-                approx_size = 0
-                data = {
-                    'listened_at': [],
-                    'created': [],
-                    'user_id': [],
-                    'recording_msid': [],
-                    'artist_name': [],
-                    'artist_credit_id': [],
-                    'release_name': [],
-                    'release_mbid': [],
-                    'recording_name': [],
-                    'recording_mbid': [],
-                    'artist_credit_mbids': []
-                }
+        try:
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as curs:
+                curs.execute(query, args)
                 while True:
-                    result = curs.fetchone()
-                    if not result:
+                    t0 = time.monotonic()
+                    written = 0
+                    approx_size = 0
+                    data = {
+                        'listened_at': [],
+                        'created': [],
+                        'user_id': [],
+                        'recording_msid': [],
+                        'artist_name': [],
+                        'artist_credit_id': [],
+                        'release_name': [],
+                        'release_mbid': [],
+                        'recording_name': [],
+                        'recording_mbid': [],
+                        'artist_credit_mbids': []
+                    }
+                    while True:
+                        result = curs.fetchone()
+                        if not result:
+                            break
+
+                        # Either take the original listen metadata or the mapping metadata
+                        if result["artist_credit_id"] is None:
+                            data["artist_name"].append(result["l_artist_name"])
+                            data["release_name"].append(result["l_release_name"])
+                            data["recording_name"].append(result["l_recording_name"])
+                            data["artist_credit_id"].append(None)
+                            data["artist_credit_mbids"].append(result["l_artist_credit_mbids"])
+                            data["release_mbid"].append(result["l_release_mbid"])
+                            data["recording_mbid"].append(result["l_recording_mbid"])
+                            approx_size += len(result["l_artist_name"]) + len(result["l_recording_name"]) \
+                                + len(result["l_release_name"] or "0") + len(result["l_recording_mbid"] or "0") \
+                                + len(result["l_release_mbid"] or "0") + len(str(result["l_artist_credit_mbids"] or 0))
+                        else:
+                            data["artist_name"].append(result["m_artist_name"])
+                            data["release_name"].append(result["m_release_name"])
+                            data["recording_name"].append(result["m_recording_name"])
+                            data["artist_credit_id"].append(result["artist_credit_id"])
+                            data["artist_credit_mbids"].append(result["m_artist_credit_mbids"])
+                            data["release_mbid"].append(result["m_release_mbid"])
+                            data["recording_mbid"].append(result["m_recording_mbid"])
+                            approx_size += len(result["m_artist_name"]) + len(result["m_recording_name"]) \
+                                + len(result["m_release_name"] or "0") + len(result["m_recording_mbid"] or "0") \
+                                + len(result["m_release_mbid"] or "0") + len(str(result["m_artist_credit_mbids"] or 0)) \
+                                + len(str(result["artist_credit_id"]))
+
+                        current_listened_at = result["listened_at"]
+                        data["listened_at"].append(current_listened_at)
+                        data["created"].append(result["created"])
+                        data["user_id"].append(result["user_id"])
+                        data["recording_msid"].append(result["recording_msid"])
+                        approx_size += len(str(result["listened_at"])) + len(str(result["created"])) \
+                                       + len(str(result["user_id"])) + len(result["recording_msid"])
+
+                        written += 1
+                        listen_count += 1
+                        if approx_size > PARQUET_TARGET_SIZE:
+                            break
+
+                    if written == 0:
                         break
 
-                    # Either take the original listen metadata or the mapping metadata
-                    if result["artist_credit_id"] is None:
-                        data["artist_name"].append(result["l_artist_name"])
-                        data["release_name"].append(result["l_release_name"])
-                        data["recording_name"].append(result["l_recording_name"])
-                        data["artist_credit_id"].append(None)
-                        data["artist_credit_mbids"].append(result["l_artist_credit_mbids"])
-                        data["release_mbid"].append(result["l_release_mbid"])
-                        data["recording_mbid"].append(result["l_recording_mbid"])
-                        approx_size += len(result["l_artist_name"]) + len(result["l_recording_name"]) \
-                            + len(result["l_release_name"] or "0") + len(result["l_recording_mbid"] or "0") \
-                            + len(result["l_release_mbid"] or "0") + len(str(result["l_artist_credit_mbids"] or 0))
-                    else:
-                        data["artist_name"].append(result["m_artist_name"])
-                        data["release_name"].append(result["m_release_name"])
-                        data["recording_name"].append(result["m_recording_name"])
-                        data["artist_credit_id"].append(result["artist_credit_id"])
-                        data["artist_credit_mbids"].append(result["m_artist_credit_mbids"])
-                        data["release_mbid"].append(result["m_release_mbid"])
-                        data["recording_mbid"].append(result["m_recording_mbid"])
-                        approx_size += len(result["m_artist_name"]) + len(result["m_recording_name"]) \
-                            + len(result["m_release_name"] or "0") + len(result["m_recording_mbid"] or "0") \
-                            + len(result["m_release_mbid"] or "0") + len(str(result["m_artist_credit_mbids"] or 0)) \
-                            + len(str(result["artist_credit_id"]))
+                    filename = os.path.join(temp_dir, "%d.parquet" % parquet_file_id)
 
-                    current_listened_at = result["listened_at"]
-                    data["listened_at"].append(current_listened_at)
-                    data["created"].append(result["created"])
-                    data["user_id"].append(result["user_id"])
-                    data["recording_msid"].append(result["recording_msid"])
-                    approx_size += len(str(result["listened_at"])) + len(str(result["created"])) \
-                                   + len(str(result["user_id"])) + len(result["recording_msid"])
+                    # Create a pandas dataframe, then write that to a parquet files
+                    df = pd.DataFrame(data, dtype=object)
+                    table = pa.Table.from_pandas(df, schema=SPARK_LISTENS_SCHEMA, preserve_index=False)
+                    pq.write_table(table, filename, flavor="spark", compression="zstd")
+                    file_size = os.path.getsize(filename)
+                    tar_file.add(filename, arcname=os.path.join(archive_dir, "%d.parquet" % parquet_file_id))
+                    os.unlink(filename)
+                    parquet_file_id += 1
 
-                    written += 1
-                    listen_count += 1
-                    if approx_size > PARQUET_TARGET_SIZE:
-                        break
-
-                if written == 0:
-                    break
-
-                filename = os.path.join(temp_dir, "%d.parquet" % parquet_file_id)
-
-                # Create a pandas dataframe, then write that to a parquet files
-                df = pd.DataFrame(data, dtype=object)
-                table = pa.Table.from_pandas(df, schema=SPARK_LISTENS_SCHEMA, preserve_index=False)
-                pq.write_table(table, filename, flavor="spark", compression="zstd")
-                file_size = os.path.getsize(filename)
-                tar_file.add(filename, arcname=os.path.join(archive_dir, "%d.parquet" % parquet_file_id))
-                os.unlink(filename)
-                parquet_file_id += 1
-
-                self.log.info("%d listens dumped for %s at %.2f listens/s (%sMB)",
-                              listen_count, current_listened_at.strftime("%Y-%m-%d"),
-                              written / (time.monotonic() - t0),
-                              str(round(file_size / (1024 * 1024), 3)))
+                    self.log.info("%d listens dumped for %s at %.2f listens/s (%sMB)",
+                                  listen_count, current_listened_at.strftime("%Y-%m-%d"),
+                                  written / (time.monotonic() - t0),
+                                  str(round(file_size / (1024 * 1024), 3)))
+        finally:
+            conn.close()
 
         return parquet_file_id
 
@@ -457,15 +460,24 @@ class DumpListenStore:
         parquet_index = 0
         with uncompressed_dump(location, archive_name, metadata, temp_location=temp_location) as (tar, temp_dir, archive_path):
 
-            for year in range(start_time.year, end_time.year + 1):
-                if year == start_time.year:
+            # iterate one month at a time (rather than one year) so that each write_parquet_files
+            # call buffers only a month of listens in memory and holds its database transaction
+            # open for only a month's worth of processing. dumping a full year at once buffers the
+            # entire year's joined result set client-side and OOMs the process.
+            start_year, start_month = start_time.year, start_time.month
+            end_year, end_month = end_time.year, end_time.month
+            year, month = start_year, start_month
+            while (year, month) <= (end_year, end_month):
+                if year == start_year and month == start_month:
                     start = start_time
                 else:
-                    start = datetime(year=year, day=1, month=1)
-                if year == end_time.year:
+                    start = datetime(year=year, month=month, day=1)
+                if year == end_year and month == end_month:
                     end = end_time
+                elif month == 12:
+                    end = datetime(year=year + 1, month=1, day=1)
                 else:
-                    end = datetime(year=year + 1, day=1, month=1)
+                    end = datetime(year=year, month=month + 1, day=1)
 
                 self.log.info(
                     "dump %s to %s" % (start.strftime("%Y-%m-%d %H:%M:%S"), end.strftime("%Y-%m-%d %H:%M:%S")))
@@ -479,6 +491,11 @@ class DumpListenStore:
                 except Exception as err:
                     self.log.exception("likely test failure: " + str(err))
                     raise
+
+                if month == 12:
+                    year, month = year + 1, 1
+                else:
+                    month += 1
 
         self.log.info('ListenBrainz spark listen dump done!')
         self.log.info('Dump present at %s!', archive_path)

--- a/listenbrainz_spark/dump/__init__.py
+++ b/listenbrainz_spark/dump/__init__.py
@@ -12,6 +12,9 @@ class DumpType(Enum):
     INCREMENTAL = "incremental"
     FULL = "full"
     SAMPLE = "sample"
+    # database dumps do not contain listens, they are never imported into the spark cluster but their ids
+    # are interleaved with the listen dump ids in the data_dump table
+    DB = "db"
 
 
 class ListensDump(NamedTuple):
@@ -110,8 +113,8 @@ class ListenbrainzDumpLoader(ABC):
         pass
 
     def check_dump_type(self, dump_id: int):
-        """ Query ListenBrainz dump info API to check whether the given dump ID is an incremental or full dump """
+        """ Query ListenBrainz dump info API to check the type of the dump with the given dump ID """
         url = f"{self.get_api_base_url()}/1/status/get-dump-info"
         response = requests.get(url, params={"id": dump_id})
         response.raise_for_status()
-        return DumpType.FULL if response.json()["dump_type"] == "full" else DumpType.INCREMENTAL
+        return DumpType(response.json()["dump_type"])

--- a/listenbrainz_spark/dump/ftp.py
+++ b/listenbrainz_spark/dump/ftp.py
@@ -56,7 +56,11 @@ class ListenBrainzFtpDumpLoader(ListenbrainzDumpLoader):
             dump_dir = os.path.join(config.FTP_LISTENS_DIR, 'sample/')
 
         self.connection.cwd(dump_dir)
-        return self.list_dir()
+        directories = self.list_dir()
+        if dump_type == DumpType.FULL:
+            # the fullexport dir also contains the database dumps which have no listens in them
+            directories = [x for x in directories if not x.replace('/', '').endswith('-db')]
+        return directories
 
     def download_file_binary(self, src, dest):
         """ Download file `src` from the FTP server to `dest`

--- a/listenbrainz_spark/dump/local.py
+++ b/listenbrainz_spark/dump/local.py
@@ -8,7 +8,8 @@ class ListenbrainzLocalDumpLoader(ListenbrainzDumpLoader):
 
     def list_dump_directories(self, dump_type: DumpType):
         files = os.listdir('listenbrainz-export')
-        return list(filter(lambda x: x.startswith(f'listenbrainz-dump-'), files))
+        # database dumps share the dump directory naming but have no listens in them
+        return [x for x in files if x.startswith('listenbrainz-dump-') and not x.endswith('-db')]
 
     def load_listens(self, directory, listens_dump_id=None, dump_type: DumpType = DumpType.FULL) -> tuple[str, str, int]:
         dump_directories = self.list_dump_directories(dump_type)

--- a/listenbrainz_spark/listens/dump.py
+++ b/listenbrainz_spark/listens/dump.py
@@ -125,11 +125,16 @@ def import_incremental_dump_handler(dump_id: int = None, local: bool = False):
 
         for dump_id in range(start_id, end_id, 1):
             try:
-                if (
-                    not search_dump(dump_id, DumpType.INCREMENTAL, imported_at)
-                    and loader.check_dump_type(dump_id) == DumpType.INCREMENTAL
-                ):
-                    imported_dumps.append(import_incremental_dump_to_hdfs(loader, dump_id=dump_id))
+                if search_dump(dump_id, DumpType.INCREMENTAL, imported_at):
+                    continue
+
+                dump_type = loader.check_dump_type(dump_id)
+                if dump_type != DumpType.INCREMENTAL:
+                    logger.info("Skipping dump ID %d of type %s while importing incremental dumps",
+                                dump_id, dump_type.value)
+                    continue
+
+                imported_dumps.append(import_incremental_dump_to_hdfs(loader, dump_id=dump_id))
             except Exception as e:
                 # Skip current dump if any error occurs during import
                 error_msg = f"Error while importing incremental dump with ID {dump_id}: {e}"

--- a/listenbrainz_spark/listens/tests/test_dump.py
+++ b/listenbrainz_spark/listens/tests/test_dump.py
@@ -151,6 +151,47 @@ class DumpImporterJobTestCase(SparkNewTestCase):
         self.assertListEqual(expected_import_list, messages[0]["imported_dump"])
 
     @patch("ftplib.FTP")
+    @patch.object(ListenBrainzFtpDumpLoader, "get_latest_dump_id", return_value=206)
+    @patch.object(
+        ListenBrainzFtpDumpLoader,
+        "check_dump_type",
+        side_effect=[DumpType.FULL, DumpType.DB, DumpType.INCREMENTAL, DumpType.INCREMENTAL],
+    )
+    @patch("listenbrainz_spark.listens.dump.import_incremental_dump_to_hdfs",
+           side_effect=mock_import_dump_to_hdfs)
+    @patch("listenbrainz_spark.listens.dump.search_dump", return_value=False)
+    @patch("listenbrainz_spark.listens.dump.get_latest_full_dump")
+    def test_import_incremental_dump_handler_skips_full_and_db_dump_ids(
+        self,
+        mock_latest_full_dump,
+        _,
+        mock_import_dump,
+        mock_check_dump_type,
+        __,
+        ___,
+    ):
+        """Full and database dump IDs interleaved in the sequence are not errors."""
+        mock_latest_full_dump.return_value = {
+            "dump_id": 202,
+            "imported_at": datetime(2020, 9, 29),
+            "dump_type": DumpType.FULL,
+        }
+
+        messages = import_incremental_dump_handler(local=False)
+
+        mock_check_dump_type.assert_has_calls([call(203), call(204), call(205), call(206)])
+        mock_import_dump.assert_has_calls([
+            call(mock.ANY, dump_id=205),
+            call(mock.ANY, dump_id=206),
+        ])
+        self.assertEqual(mock_import_dump.call_count, 2)
+        self.assertListEqual([
+            "listenbrainz-spark-dump-205-incremental.tar",
+            "listenbrainz-spark-dump-206-incremental.tar",
+        ], messages[0]["imported_dump"])
+        self.assertListEqual([], messages[0]["errors"])
+
+    @patch("ftplib.FTP")
     @patch.object(ListenBrainzFtpDumpLoader, "get_latest_dump_id", return_value=210)
     @patch.object(ListenBrainzFtpDumpLoader, "check_dump_type", return_value=DumpType.INCREMENTAL)
     @patch("listenbrainz_spark.listens.dump.import_incremental_dump_to_hdfs", side_effect=mock_import_dump_to_hdfs_error)


### PR DESCRIPTION
1. Process listen dumps month by month so each parquet write buffers less data in memory and closes the raw database connection after dumping.
2. Move the public and private database dumps into their own create_db_dump command and cron job in the regular cron container, leaving the full listens, spark and statistics dumps in the full dumps cron container. 
3. Both dump types publish into the fullexport directory. The db dumps are retained locally and backed up like incremental dumps, while the full listens and spark dumps are removed from the host after uploading to FTP.
