### PR TITLE
Fetch and backfill MetaBrainz user emails

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -212,6 +212,7 @@ OAUTH_WEBHOOK_SECRET = '''{{template "KEY" "oauth/webhook_secret"}}'''
 OAUTH_AUTHORIZE_URL = f"{OAUTH_BASE_URL}/oauth2/authorize"
 OAUTH_TOKEN_URL = f"{OAUTH_BASE_URL}/oauth2/token"
 OAUTH_INTROSPECTION_URL = f"{OAUTH_BASE_URL}/oauth2/introspect"
+OAUTH_USERINFO_URL = f"{OAUTH_BASE_URL}/oauth2/userinfo"
 
 LASTFM_API_URL = '''{{template "KEY" "lastfm_api_url"}}'''
 LASTFM_API_KEY = '''{{template "KEY" "lastfm_api_key"}}'''

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -107,6 +107,7 @@ OAUTH_WEBHOOK_SECRET = "WEBHOOK_SECRET"
 OAUTH_AUTHORIZE_URL = f"{OAUTH_BASE_URL}/oauth2/authorize"
 OAUTH_TOKEN_URL = f"{OAUTH_BASE_URL}/oauth2/token"
 OAUTH_INTROSPECTION_URL = f"{OAUTH_BASE_URL}/oauth2/introspect"
+OAUTH_USERINFO_URL = f"{OAUTH_BASE_URL}/oauth2/userinfo"
 
 # Lastfm API
 LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"

--- a/listenbrainz/domain/musicbrainz.py
+++ b/listenbrainz/domain/musicbrainz.py
@@ -4,7 +4,7 @@ from flask import current_app, url_for
 from data.model.external_service import ExternalServiceType
 from listenbrainz.domain.brainz_service import BaseBrainzService
 
-MUSICBRAINZ_SCOPES = ["musicbrainz:tag", "musicbrainz:rating", "profile"]
+MUSICBRAINZ_SCOPES = ["musicbrainz:tag", "musicbrainz:rating", "profile", "email"]
 
 
 class MusicBrainzService(BaseBrainzService):
@@ -38,6 +38,14 @@ class MusicBrainzService(BaseBrainzService):
                 "token_type_hint": "access_token",
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_user_profile(self, token: str):
+        response = requests.get(
+            current_app.config["OAUTH_USERINFO_URL"],
+            headers={"Authorization": f"Bearer {token}"},
         )
         response.raise_for_status()
         return response.json()

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -231,6 +231,7 @@ def init_ts_db(force, create_db):
 
 @cli.command(name="update_user_emails")
 def update_user_emails():
+    """Backfill missing ListenBrainz emails from the MetaBrainz user database."""
     from listenbrainz.webserver.login import copy_files_from_mb_to_lb
     application = webserver.create_app()
     with application.app_context():

--- a/listenbrainz/webserver/login/copy_files_from_mb_to_lb.py
+++ b/listenbrainz/webserver/login/copy_files_from_mb_to_lb.py
@@ -1,34 +1,88 @@
 import psycopg2
 from psycopg2.extras import execute_values
-from brainzutils.musicbrainz_db.editor import fetch_multiple_editors
 from flask import current_app
 
 from listenbrainz import db as lb_db
+from listenbrainz.db import donation
+
+EMAIL_BATCH_SIZE = 10_000
 
 
-def copy_emails():
+def copy_emails(batch_size: int = EMAIL_BATCH_SIZE) -> int:
+    """Backfill missing ListenBrainz emails from confirmed MetaBrainz accounts."""
+    if donation.engine is None:
+        raise RuntimeError("MetaBrainz database connection is not configured")
+    if batch_size <= 0:
+        raise ValueError("Email batch size must be positive")
+
     current_app.logger.info("Beginning to update emails for users...")
-    connection = lb_db.engine.raw_connection()
+    lb_connection = None
+    meb_connection = None
+    updated = 0
+    last_lb_user_id = 0
+
     try:
-        with connection.cursor() as cursor:
-            cursor.execute('''SELECT musicbrainz_row_id FROM "user"''')
-            current_app.logger.info("Fetched editor ids from ListenBrainz.")
-            editor_ids = [row[0] for row in cursor.fetchall()]
-            editors = fetch_multiple_editors(editor_ids)
-            current_app.logger.info("Fetched editor emails from MusicBrainz.")
-            emails = [(editor_id, editor['email']) for editor_id, editor in editors.items()]
-            query = """
-                UPDATE "user"
-                SET email = editor_email_temp.email
-                FROM (VALUES %s)
-                AS editor_email_temp(id, email)
-                WHERE editor_email_temp.id = "user".musicbrainz_row_id
-            """
-            execute_values(cursor, query, emails, template=None)
-            current_app.logger.info("Updated emails of ListenBrainz users.")
-        connection.commit()
-    except psycopg2.errors.OperationalError:
+        lb_connection = lb_db.engine.raw_connection()
+        meb_connection = donation.engine.raw_connection()
+        with lb_connection.cursor() as lb_cursor, meb_connection.cursor() as meb_cursor:
+            while True:
+                lb_cursor.execute(
+                    """
+                    SELECT id, musicbrainz_row_id
+                      FROM "user"
+                     WHERE id > %s
+                       AND musicbrainz_row_id IS NOT NULL
+                       AND email IS NULL
+                  ORDER BY id
+                     LIMIT %s
+                    """,
+                    (last_lb_user_id, batch_size),
+                )
+                lb_users = lb_cursor.fetchall()
+                if not lb_users:
+                    break
+
+                last_lb_user_id = lb_users[-1][0]
+                meb_user_ids = [row[1] for row in lb_users]
+                meb_cursor.execute(
+                    """
+                    SELECT id, email
+                      FROM "user"
+                     WHERE id = ANY(%s)
+                       AND email IS NOT NULL
+                    """,
+                    (meb_user_ids,),
+                )
+                emails = meb_cursor.fetchall()
+                if not emails:
+                    continue
+
+                updated_rows = execute_values(
+                    lb_cursor,
+                    """
+                    UPDATE "user" AS lb_user
+                       SET email = meb_user.email
+                      FROM (VALUES %s) AS meb_user(id, email)
+                     WHERE lb_user.musicbrainz_row_id = meb_user.id
+                       AND lb_user.email IS NULL
+                 RETURNING lb_user.id
+                    """,
+                    emails,
+                    template=None,
+                    fetch=True,
+                )
+                lb_connection.commit()
+                updated += len(updated_rows)
+
+        current_app.logger.info("Updated emails of %d ListenBrainz users.", updated)
+        return updated
+    except psycopg2.Error:
         current_app.logger.error("Error while updating emails of ListenBrainz users", exc_info=True)
-        connection.rollback()
+        if lb_connection is not None:
+            lb_connection.rollback()
+        raise
     finally:
-        connection.close()
+        if meb_connection is not None:
+            meb_connection.close()
+        if lb_connection is not None:
+            lb_connection.close()

--- a/listenbrainz/webserver/login/provider.py
+++ b/listenbrainz/webserver/login/provider.py
@@ -1,4 +1,5 @@
 from flask import current_app, request, session
+import requests
 
 from listenbrainz.domain.musicbrainz import MusicBrainzService, MUSICBRAINZ_SCOPES
 from listenbrainz.webserver import db_conn
@@ -32,7 +33,13 @@ def get_user():
     user = db_user.get_by_mb_row_id(db_conn, musicbrainz_row_id, musicbrainz_id, fetch_email=True)
 
     if user is None:
-        db_user.create(db_conn, musicbrainz_row_id, musicbrainz_id)
+        email = _get_new_user_email(service, token["access_token"], musicbrainz_row_id)
+        db_user.create(
+            db_conn,
+            musicbrainz_row_id,
+            musicbrainz_id,
+            email=email,
+        )
         user = db_user.get_by_mb_id(db_conn, musicbrainz_id, fetch_email=True)
         ts.set_empty_values_for_user(user["id"])
 
@@ -44,6 +51,22 @@ def get_user():
         service.update_user(user["id"], token)
 
     return user
+
+
+def _get_new_user_email(service: MusicBrainzService, token: str, musicbrainz_row_id: int):
+    """Return a new user's verified email from OAuth UserInfo."""
+    try:
+        info = service.get_user_profile(token)
+    except requests.RequestException as error:
+        current_app.logger.error("Unable to fetch email from MetaBrainz OAuth UserInfo", exc_info=True)
+        raise MusicBrainzAuthSessionError() from error
+
+    has_email = "email" in info
+    has_email_verified = "email_verified" in info
+    if not has_email and not has_email_verified:
+        return None
+
+    return info["email"] if info["email_verified"] is True else None
 
 
 def get_authentication_uri(login_hint=None):

--- a/listenbrainz/webserver/views/test/test_login.py
+++ b/listenbrainz/webserver/views/test/test_login.py
@@ -1,5 +1,14 @@
+from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
+import requests
+import requests_mock
+from flask import session
+
+import listenbrainz.db.user as db_user
+from listenbrainz.domain.musicbrainz import MusicBrainzService
+from listenbrainz.tests.integration import IntegrationTestCase
+from listenbrainz.webserver.login import provider
 from listenbrainz.webserver.testing import ServerTestCase
 
 
@@ -8,6 +17,9 @@ class LoginViewsTestCase(ServerTestCase):
     def test_login_musicbrainz_redirects(self):
         response = self.client.get(self.custom_url_for('login.musicbrainz'))
         self.assertStatus(response, 302)
+
+        query = parse_qs(urlparse(response.location).query)
+        self.assertIn("email", query["scope"][0].split())
 
     def test_login_musicbrainz_forwards_register_hint_to_oauth_domain(self):
         response = self.client.get(
@@ -23,6 +35,7 @@ class LoginViewsTestCase(ServerTestCase):
         self.assertEqual(parsed_url.netloc, parsed_authorize_url.netloc)
         self.assertEqual(parsed_url.path, parsed_authorize_url.path)
         self.assertEqual(query["login_hint"], ["register"])
+        self.assertIn("email", query["scope"][0].split())
 
     def test_login_musicbrainz_does_not_forward_unknown_login_hint(self):
         response = self.client.get(
@@ -32,3 +45,134 @@ class LoginViewsTestCase(ServerTestCase):
 
         query = parse_qs(urlparse(response.location).query)
         self.assertNotIn("login_hint", query)
+
+
+class LoginProviderTestCase(IntegrationTestCase):
+
+    def _get_user(self, *, musicbrainz_row_id=123, musicbrainz_id="old-user",
+                  user_info=None, user_info_error=None):
+        with self.app.test_request_context(), requests_mock.Mocker() as mock_requests:
+            service = MusicBrainzService()
+            service.get_user = mock.Mock(return_value=None)
+            service.add_new_user = mock.Mock()
+            service.update_user = mock.Mock()
+
+            mock_requests.post(self.app.config["OAUTH_TOKEN_URL"], json={
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            })
+            mock_requests.post(self.app.config["OAUTH_INTROSPECTION_URL"], json={
+                "active": True,
+                "sub": str(musicbrainz_row_id),
+                "username": musicbrainz_id,
+            })
+
+            user_info_response = user_info if user_info is not None else {
+                "sub": str(musicbrainz_row_id),
+            }
+            if user_info_error is not None:
+                mock_requests.get(self.app.config["OAUTH_USERINFO_URL"], exc=user_info_error)
+            else:
+                mock_requests.get(self.app.config["OAUTH_USERINFO_URL"], json=user_info_response)
+
+            mock_ts = mock.Mock()
+            session["musicbrainz"] = {
+                "code": "authorization-code",
+            }
+            with mock.patch.object(provider, "MusicBrainzService", return_value=service), \
+                    mock.patch.object(provider, "ts", mock_ts):
+                user = provider.get_user()
+
+            service.oauth_requests = list(mock_requests.request_history)
+            service.profile_request = next((
+                oauth_request
+                for oauth_request in service.oauth_requests
+                if oauth_request.url == self.app.config["OAUTH_USERINFO_URL"]
+            ), None)
+
+        return user, mock_ts.set_empty_values_for_user, service
+
+    def test_new_user_stores_verified_email(self):
+        user, mock_set_empty_values, service = self._get_user(user_info={
+            "sub": "123",
+            "email": "verified@example.com",
+            "email_verified": True,
+        })
+
+        self.assertEqual(user["email"], "verified@example.com")
+        mock_set_empty_values.assert_called_once_with(user["id"])
+        self.assertEqual(
+            [(request.method, request.url) for request in service.oauth_requests],
+            [
+                ("POST", self.app.config["OAUTH_TOKEN_URL"]),
+                ("POST", self.app.config["OAUTH_INTROSPECTION_URL"]),
+                ("GET", self.app.config["OAUTH_USERINFO_URL"]),
+            ],
+        )
+        self.assertEqual(
+            service.profile_request.url,
+            self.app.config["OAUTH_USERINFO_URL"],
+        )
+        self.assertEqual(
+            service.profile_request.headers["Authorization"],
+            "Bearer access-token",
+        )
+
+    def test_user_created_by_webhook_does_not_request_email(self):
+        user_id = db_user.create(self.db_conn, 123, "old-user")
+
+        user, mock_set_empty_values, service = self._get_user(user_info={
+            "sub": "123",
+            "email": "verified@example.com",
+            "email_verified": True,
+        })
+
+        self.assertEqual(user["id"], user_id)
+        self.assertIsNone(user["email"])
+        mock_set_empty_values.assert_not_called()
+        self.assertIsNone(service.profile_request)
+
+    def test_new_user_does_not_store_unverified_email(self):
+        user, _, service = self._get_user(user_info={
+            "sub": "123",
+            "email": "pending@example.com",
+            "email_verified": False,
+        })
+
+        self.assertIsNone(user["email"])
+        self.assertIsNotNone(service.profile_request)
+
+    def test_new_user_without_email_claims_stores_no_email(self):
+        user, _, service = self._get_user(user_info={"sub": "123"})
+
+        self.assertIsNone(user["email"])
+        self.assertIsNotNone(service.profile_request)
+
+    def test_existing_user_does_not_request_or_update_email(self):
+        user_id = db_user.create(self.db_conn, 123, "old-user", "old@example.com")
+
+        user, _, service = self._get_user(user_info={
+            "sub": "123",
+            "email": "new@example.com",
+            "email_verified": True,
+        })
+
+        self.assertEqual(user["id"], user_id)
+        self.assertEqual(user["email"], "old@example.com")
+        self.assertIsNone(service.profile_request)
+
+    def test_missing_email_claim_preserves_webhook_synced_email(self):
+        user_id = db_user.create(self.db_conn, 123, "old-user", "webhook@example.com")
+
+        user, _, _ = self._get_user(user_info={"sub": "123"})
+
+        self.assertEqual(user["id"], user_id)
+        self.assertEqual(user["email"], "webhook@example.com")
+
+    def test_new_userinfo_failure_aborts_login(self):
+        with self.assertRaises(provider.MusicBrainzAuthSessionError):
+            self._get_user(user_info_error=requests.HTTPError("userinfo unavailable"))
+
+        self.assertIsNone(db_user.get_by_mb_row_id(self.db_conn, 123))


### PR DESCRIPTION
Request the email scope for MetaBrainz OAuth and use the UserInfo endpoint when creating new ListenBrainz users. Store confirmed addresses locally while treating UserInfo request failures as login failures for new users.

Replace the legacy MusicBrainz editor database email copier with a batched backfill from the MetaBrainz user database. Only fill missing ListenBrainz emails so webhook-synced and existing values are preserved.