### PR TITLE
perf(lb-radio): fix auth guard, add rate limit, cache services, eliminate remaining HTTP loopbacks

### DIFF
--- a/listenbrainz/radio/playlist.py
+++ b/listenbrainz/radio/playlist.py
@@ -26,6 +26,6 @@ class LBRadioPlaylistService(Service):
                 user_id = user["id"]
 
         if not playlist.is_visible_by(user_id):
-            raise RuntimeError(f"Playlist {playlist_mbid} is private.")
+            raise RuntimeError(f"Cannot find playlist {playlist_mbid}.")
 
         return [str(r.mbid) for r in playlist.recordings]

--- a/listenbrainz/radio/playlist.py
+++ b/listenbrainz/radio/playlist.py
@@ -1,0 +1,31 @@
+from troi.service import Service
+
+import listenbrainz.db.user as db_user
+import listenbrainz.db.playlist as db_playlist
+from listenbrainz.webserver import db_conn, ts_conn
+
+
+class LBRadioPlaylistService(Service):
+    """Replaces the GET https://api.listenbrainz.org/1/playlist/{mbid} HTTP call
+    in LBRadioPlaylistRecordingElement with a direct DB lookup."""
+
+    SLUG = "playlist"
+
+    def __init__(self):
+        super().__init__(self.SLUG)
+
+    def fetch(self, playlist_mbid: str, auth_token: str | None) -> list[str]:
+        playlist = db_playlist.get_by_mbid(db_conn, ts_conn, playlist_mbid, load_recordings=True)
+        if playlist is None:
+            raise RuntimeError(f"Cannot find playlist {playlist_mbid}.")
+
+        user_id = None
+        if auth_token is not None:
+            user = db_user.get_by_token(db_conn, auth_token)
+            if user is not None:
+                user_id = user["id"]
+
+        if not playlist.is_visible_by(user_id):
+            raise RuntimeError(f"Playlist {playlist_mbid} is private.")
+
+        return [str(r.mbid) for r in playlist.recordings]

--- a/listenbrainz/radio/recs.py
+++ b/listenbrainz/radio/recs.py
@@ -1,0 +1,29 @@
+from troi.service import Service
+
+import listenbrainz.db.user as db_user
+import listenbrainz.db.recommendations_cf_recording as db_recommendations_cf_recording
+from listenbrainz.webserver import db_conn
+
+
+class LBRadioRecsService(Service):
+    """Replaces the paginated liblistenbrainz HTTP calls in LBRadioRecommendationRecordingElement.
+
+    Returns the full raw recommendations list so the element applies its
+    mode-based offset and listened filter directly, without HTTP pagination.
+    """
+
+    SLUG = "recs"
+
+    def __init__(self):
+        super().__init__(self.SLUG)
+
+    def fetch(self, user_name: str) -> list[dict] | None:
+        user = db_user.get_by_mb_id(db_conn, user_name)
+        if user is None:
+            return None
+
+        recommendations = db_recommendations_cf_recording.get_user_recommendation(db_conn, user["id"])
+        if recommendations is None:
+            return None
+
+        return recommendations.recording_mbid.dict().get("raw") or []

--- a/listenbrainz/radio/stats.py
+++ b/listenbrainz/radio/stats.py
@@ -1,0 +1,50 @@
+from brainzutils import cache
+from troi.service import Service
+
+import listenbrainz.db.user as db_user
+import listenbrainz.db.stats as db_stats
+from data.model.user_entity import EntityRecord
+from listenbrainz.webserver import db_conn
+
+STATS_CACHE_TTL = 3600  # 1 hour — stats update weekly/monthly
+
+
+class LBRadioStatsService(Service):
+    """Replaces the HTTP stats fetch in LBRadioStatsRecordingElement.
+
+    Reads user recording stats from the DB directly instead of calling
+    the HTTP API loopback.
+    """
+
+    SLUG = "stats"
+
+    def __init__(self):
+        super().__init__(self.SLUG)
+
+    def fetch(self, user_name, time_range, offset):
+        user = db_user.get_by_mb_id(db_conn, user_name)
+        if user is None:
+            raise RuntimeError(f"Cannot find user: {user_name}")
+
+        cache_key = f"lb_radio_stats:{user['id']}:{time_range}"
+        cached = cache.get(cache_key, decode=True)
+        if cached is not None:
+            return cached[offset:offset + 100]
+
+        stats = db_stats.get(user["id"], "recordings", time_range, EntityRecord)
+        if stats is None:
+            raise RuntimeError(
+                f"There are no stats available for user '{user_name}' for the {time_range} time_range."
+            )
+
+        recordings = []
+        for r in stats.data.__root__:
+            r = r.dict()
+            if r.get("recording_mbid") is not None:
+                recordings.append({
+                    "recording_mbid": r["recording_mbid"],
+                    "artist_mbids": r.get("artist_mbids") or [],
+                })
+
+        cache.set(cache_key, recordings, STATS_CACHE_TTL, encode=True)
+        return recordings[offset:offset + 100]

--- a/listenbrainz/radio/tests/test_playlist_service.py
+++ b/listenbrainz/radio/tests/test_playlist_service.py
@@ -1,0 +1,87 @@
+import uuid
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from listenbrainz.radio.playlist import LBRadioPlaylistService
+
+PLAYLIST_MBID = "12345678-1234-1234-1234-123456789abc"
+CREATOR = "testuser"
+COLLABORATOR = "collab_user"
+AUTH_TOKEN = "validtoken"
+
+REC_MBID_1 = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+REC_MBID_2 = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+CREATOR_ID = 1
+COLLABORATOR_ID = 2
+
+
+def _make_playlist(public=True, creator=CREATOR, recording_mbids=None,
+                   creator_id=CREATOR_ID, collaborator_ids=None):
+    if recording_mbids is None:
+        recording_mbids = [REC_MBID_1, REC_MBID_2]
+    playlist = MagicMock()
+    playlist.public = public
+    playlist.creator = creator
+    playlist.creator_id = creator_id
+    playlist.collaborator_ids = collaborator_ids or []
+    playlist.recordings = [MagicMock(mbid=m) for m in recording_mbids]
+    playlist.is_visible_by.side_effect = lambda uid: (
+        public or uid == creator_id or uid in (collaborator_ids or [])
+    )
+    return playlist
+
+
+class TestLBRadioPlaylistService:
+
+    def test_slug(self):
+        assert LBRadioPlaylistService().slug == "playlist"
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_public_playlist_returns_mbids(self, mock_get):
+        mock_get.return_value = _make_playlist(public=True)
+        result = LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=None)
+        assert result == [str(REC_MBID_1), str(REC_MBID_2)]
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_not_found_raises(self, mock_get):
+        mock_get.return_value = None
+        with pytest.raises(RuntimeError, match="Cannot find playlist"):
+            LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=None)
+
+    @patch("listenbrainz.radio.playlist.db_user.get_by_token", return_value={"id": CREATOR_ID})
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_private_playlist_accessible_by_creator(self, mock_get, _mock_user):
+        mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
+        result = LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=AUTH_TOKEN)
+        assert result == [str(REC_MBID_1), str(REC_MBID_2)]
+
+    @patch("listenbrainz.radio.playlist.db_user.get_by_token",
+           return_value={"id": COLLABORATOR_ID})
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_private_playlist_accessible_by_collaborator(self, mock_get, _mock_user):
+        mock_get.return_value = _make_playlist(
+            public=False, creator_id=CREATOR_ID, collaborator_ids=[COLLABORATOR_ID]
+        )
+        result = LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token="collabtoken")
+        assert result == [str(REC_MBID_1), str(REC_MBID_2)]
+
+    @patch("listenbrainz.radio.playlist.db_user.get_by_token", return_value={"id": 99})
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_private_playlist_with_unrelated_user_raises(self, mock_get, _mock_user):
+        mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
+        with pytest.raises(RuntimeError, match="private"):
+            LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token="othertoken")
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_private_playlist_without_token_raises(self, mock_get):
+        mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
+        with pytest.raises(RuntimeError, match="private"):
+            LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=None)
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_empty_playlist_returns_empty_list(self, mock_get):
+        mock_get.return_value = _make_playlist(recording_mbids=[])
+        result = LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=None)
+        assert result == []

--- a/listenbrainz/radio/tests/test_playlist_service.py
+++ b/listenbrainz/radio/tests/test_playlist_service.py
@@ -73,13 +73,13 @@ class TestLBRadioPlaylistService:
     @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
     def test_private_playlist_with_unrelated_user_raises(self, mock_get, _mock_user):
         mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
-        with pytest.raises(RuntimeError, match="private"):
+        with pytest.raises(RuntimeError, match="Cannot find playlist"):
             LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token="othertoken")
 
     @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
     def test_private_playlist_without_token_raises(self, mock_get):
         mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
-        with pytest.raises(RuntimeError, match="private"):
+        with pytest.raises(RuntimeError, match="Cannot find playlist"):
             LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=None)
 
     @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
@@ -119,5 +119,5 @@ class TestPlaylistElementWithService:
     @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
     def test_element_raises_for_private_playlist_without_token(self, mock_get):
         mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
-        with pytest.raises(RuntimeError, match="private"):
+        with pytest.raises(RuntimeError, match="Cannot find playlist"):
             self._element(auth_token=None).read([])

--- a/listenbrainz/radio/tests/test_playlist_service.py
+++ b/listenbrainz/radio/tests/test_playlist_service.py
@@ -2,6 +2,8 @@ import uuid
 from unittest.mock import patch, MagicMock
 
 import pytest
+from troi import Recording
+from troi.patches.lb_radio_classes.playlist import LBRadioPlaylistRecordingElement
 
 from listenbrainz.radio.playlist import LBRadioPlaylistService
 
@@ -85,3 +87,37 @@ class TestLBRadioPlaylistService:
         mock_get.return_value = _make_playlist(recording_mbids=[])
         result = LBRadioPlaylistService().fetch(PLAYLIST_MBID, auth_token=None)
         assert result == []
+
+
+class TestPlaylistElementWithService:
+    """End-to-end: DB mock -> LBRadioPlaylistService -> Troi element -> returned Recordings."""
+
+    def _element(self, auth_token=None):
+        mock_patch = MagicMock()
+        mock_patch.local_storage = {"data_cache": {"element-descriptions": []}}
+        mock_patch.services = {"playlist": LBRadioPlaylistService()}
+        el = LBRadioPlaylistRecordingElement(PLAYLIST_MBID, auth_token=auth_token)
+        el.patch = mock_patch
+        return el
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_element_uses_service_not_http(self, mock_get):
+        mock_get.return_value = _make_playlist(public=True)
+        with patch("troi.http_request.http_get") as mock_http:
+            self._element().read([])
+            mock_http.assert_not_called()
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_element_returns_recording_objects(self, mock_get):
+        mock_get.return_value = _make_playlist(public=True)
+        result = self._element().read([])
+        assert all(isinstance(r, Recording) for r in result)
+        mbids = {r.mbid for r in result}
+        assert str(REC_MBID_1) in mbids
+        assert str(REC_MBID_2) in mbids
+
+    @patch("listenbrainz.radio.playlist.db_playlist.get_by_mbid")
+    def test_element_raises_for_private_playlist_without_token(self, mock_get):
+        mock_get.return_value = _make_playlist(public=False, creator_id=CREATOR_ID)
+        with pytest.raises(RuntimeError, match="private"):
+            self._element(auth_token=None).read([])

--- a/listenbrainz/radio/tests/test_recs_service.py
+++ b/listenbrainz/radio/tests/test_recs_service.py
@@ -103,12 +103,13 @@ class TestRecsElementWithService:
     def test_medium_mode_skips_first_333_recommendations(self, _mock_user, mock_recs):
         # medium offset=333: only recs after index 333 should be considered
         padding = [{"recording_mbid": f"pad-{i:04d}", "score": 1.0, "latest_listened_at": None}
-                   for i in range(333)]
+                   for i in range(400)]
         target_rec = {"recording_mbid": "target-0001", "score": 9.0, "latest_listened_at": None}
         mock_recs.return_value = _make_db_recommendations(padding + [target_rec])
         result = _element_with_service(listened="all", mode="medium").read([])
         mbids = {r.mbid for r in result}
         assert target_rec["recording_mbid"] in mbids
+        assert "pad-0334" in mbids
         assert "pad-0000" not in mbids
 
     @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")

--- a/listenbrainz/radio/tests/test_recs_service.py
+++ b/listenbrainz/radio/tests/test_recs_service.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch, MagicMock
+
+from troi import Recording
+from troi.patches.lb_radio_classes.recs import LBRadioRecommendationRecordingElement
+
+from listenbrainz.radio.recs import LBRadioRecsService
+
+USER_NAME = "recsuser"
+USER_ID = 7
+FAKE_USER = {"id": USER_ID}
+
+REC_UNLISTENED_1 = {"recording_mbid": "aaaa-0001", "score": 9.5, "latest_listened_at": None}
+REC_LISTENED_1   = {"recording_mbid": "bbbb-0002", "score": 8.0, "latest_listened_at": "2024-01-01"}
+REC_UNLISTENED_2 = {"recording_mbid": "cccc-0003", "score": 7.0, "latest_listened_at": None}
+REC_LISTENED_2   = {"recording_mbid": "dddd-0004", "score": 6.0, "latest_listened_at": "2024-06-01"}
+
+ALL_RECS = [REC_UNLISTENED_1, REC_LISTENED_1, REC_UNLISTENED_2, REC_LISTENED_2]
+
+
+def _make_db_recommendations(recs):
+    recs_json = MagicMock()
+    recs_json.dict.return_value = {"raw": recs}
+    data = MagicMock()
+    data.recording_mbid = recs_json
+    return data
+
+
+def _element_with_service(listened="all", mode="easy", db_recs=None):
+    """Wire LBRadioRecsService into a Troi element backed by mocked DB data."""
+    mock_patch = MagicMock()
+    mock_patch.local_storage = {"data_cache": {"element-descriptions": []}}
+    mock_patch.services = {"recs": LBRadioRecsService()}
+
+    el = LBRadioRecommendationRecordingElement(USER_NAME, listened=listened, mode=mode)
+    el.patch = mock_patch
+    return el
+
+
+class TestLBRadioRecsServiceFetch:
+
+    def test_slug(self):
+        assert LBRadioRecsService().slug == "recs"
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_returns_full_raw_list(self, _mock_user, mock_recs):
+        mock_recs.return_value = _make_db_recommendations(ALL_RECS)
+        result = LBRadioRecsService().fetch(USER_NAME)
+        assert result == ALL_RECS
+
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=None)
+    def test_user_not_found_returns_none(self, _mock_user):
+        assert LBRadioRecsService().fetch(USER_NAME) is None
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation",
+           return_value=None)
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_no_recommendations_returns_none(self, _mock_user, _mock_recs):
+        assert LBRadioRecsService().fetch(USER_NAME) is None
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_empty_raw_list_returns_empty(self, _mock_user, mock_recs):
+        mock_recs.return_value = _make_db_recommendations([])
+        assert LBRadioRecsService().fetch(USER_NAME) == []
+
+
+class TestRecsElementWithService:
+    """End-to-end: DB mock -> LBRadioRecsService -> Troi element -> returned Recordings."""
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_all_mode_returns_all_recordings(self, _mock_user, mock_recs):
+        mock_recs.return_value = _make_db_recommendations(ALL_RECS)
+        result = _element_with_service(listened="all").read([])
+        mbids = {r.mbid for r in result}
+        assert mbids == {r["recording_mbid"] for r in ALL_RECS}
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_unlistened_mode_returns_only_unlistened(self, _mock_user, mock_recs):
+        mock_recs.return_value = _make_db_recommendations(ALL_RECS)
+        result = _element_with_service(listened="unlistened").read([])
+        mbids = {r.mbid for r in result}
+        assert REC_UNLISTENED_1["recording_mbid"] in mbids
+        assert REC_UNLISTENED_2["recording_mbid"] in mbids
+        assert REC_LISTENED_1["recording_mbid"] not in mbids
+        assert REC_LISTENED_2["recording_mbid"] not in mbids
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_listened_mode_returns_only_listened(self, _mock_user, mock_recs):
+        mock_recs.return_value = _make_db_recommendations(ALL_RECS)
+        result = _element_with_service(listened="listened").read([])
+        mbids = {r.mbid for r in result}
+        assert REC_LISTENED_1["recording_mbid"] in mbids
+        assert REC_LISTENED_2["recording_mbid"] in mbids
+        assert REC_UNLISTENED_1["recording_mbid"] not in mbids
+        assert REC_UNLISTENED_2["recording_mbid"] not in mbids
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_medium_mode_skips_first_333_recommendations(self, _mock_user, mock_recs):
+        # medium offset=333: only recs after index 333 should be considered
+        padding = [{"recording_mbid": f"pad-{i:04d}", "score": 1.0, "latest_listened_at": None}
+                   for i in range(333)]
+        target_rec = {"recording_mbid": "target-0001", "score": 9.0, "latest_listened_at": None}
+        mock_recs.return_value = _make_db_recommendations(padding + [target_rec])
+        result = _element_with_service(listened="all", mode="medium").read([])
+        mbids = {r.mbid for r in result}
+        assert target_rec["recording_mbid"] in mbids
+        assert "pad-0000" not in mbids
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_no_recommendations_returns_empty(self, _mock_user, mock_recs):
+        mock_recs.return_value = None
+        result = _element_with_service(listened="all").read([])
+        assert result == []
+
+    @patch("listenbrainz.radio.recs.db_recommendations_cf_recording.get_user_recommendation")
+    @patch("listenbrainz.radio.recs.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_returns_recording_objects(self, _mock_user, mock_recs):
+        mock_recs.return_value = _make_db_recommendations([REC_UNLISTENED_1])
+        result = _element_with_service(listened="all").read([])
+        assert all(isinstance(r, Recording) for r in result)
+        assert result[0].mbid == REC_UNLISTENED_1["recording_mbid"]

--- a/listenbrainz/radio/tests/test_stats_service.py
+++ b/listenbrainz/radio/tests/test_stats_service.py
@@ -1,5 +1,8 @@
 from unittest.mock import patch, MagicMock, call
 
+from troi import Recording
+from troi.patches.lb_radio_classes.stats import LBRadioStatsRecordingElement
+
 from listenbrainz.radio.stats import LBRadioStatsService
 
 USER_ID = 42
@@ -113,6 +116,44 @@ class TestLBRadioStatsServiceCache:
         mock_cache.get.return_value = None
 
         LBRadioStatsService().fetch(USER_NAME, TIME_RANGE, 0)
+
+        key = mock_cache.set.call_args[0][0]
+        assert str(USER_ID) in key
+        assert TIME_RANGE in key
+
+
+class TestStatsElementWithService:
+    """End-to-end: DB mock -> LBRadioStatsService -> Troi element -> returned Recordings."""
+
+    def _element(self, mode="easy", time_range=TIME_RANGE):
+        mock_patch = MagicMock()
+        mock_patch.local_storage = {"data_cache": {"element-descriptions": []}}
+        mock_patch.services = {"stats": LBRadioStatsService()}
+        el = LBRadioStatsRecordingElement(USER_NAME, time_range, mode=mode)
+        el.patch = mock_patch
+        return el
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_element_uses_service_not_http(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None
+        with patch("liblistenbrainz.ListenBrainz.get_user_recordings") as mock_http:
+            self._element().read([])
+            mock_http.assert_not_called()
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_element_returns_recording_objects_with_artist_mbids(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None
+        result = self._element().read([])
+        assert all(isinstance(r, Recording) for r in result)
+        mbids = {r.mbid for r in result}
+        assert RECORDING_1["recording_mbid"] in mbids
+        assert RECORDING_2["recording_mbid"] in mbids
+        for r in result:
+            assert r.artist_credit.musicbrainz["artist_mbids"] is not None
 
         key = mock_cache.set.call_args[0][0]
         assert str(USER_ID) in key

--- a/listenbrainz/radio/tests/test_stats_service.py
+++ b/listenbrainz/radio/tests/test_stats_service.py
@@ -1,0 +1,119 @@
+from unittest.mock import patch, MagicMock, call
+
+from listenbrainz.radio.stats import LBRadioStatsService
+
+USER_ID = 42
+USER_NAME = "testuser"
+TIME_RANGE = "month"
+
+FAKE_USER = {"id": USER_ID, "musicbrainz_id": USER_NAME}
+
+RECORDING_1 = {"recording_mbid": "aaaa-1111", "artist_mbids": ["bbbb-2222"]}
+RECORDING_2 = {"recording_mbid": "cccc-3333", "artist_mbids": ["dddd-4444"]}
+
+
+def _fake_stats():
+    """Minimal stats object that mimics db_stats.get() return value."""
+    r1 = MagicMock()
+    r1.dict.return_value = RECORDING_1
+    r2 = MagicMock()
+    r2.dict.return_value = RECORDING_2
+
+    stats = MagicMock()
+    stats.data.__root__ = [r1, r2]
+    return stats
+
+
+class TestLBRadioStatsServiceFetch:
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_returns_recording_dicts(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None
+        result = LBRadioStatsService().fetch(USER_NAME, TIME_RANGE, 0)
+        assert len(result) == 2
+        assert result[0]["recording_mbid"] == RECORDING_1["recording_mbid"]
+        assert result[1]["recording_mbid"] == RECORDING_2["recording_mbid"]
+
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=None)
+    def test_raises_when_user_not_found(self, _mock_user):
+        import pytest
+        with pytest.raises(RuntimeError, match="Cannot find user"):
+            LBRadioStatsService().fetch("nobody", TIME_RANGE, 0)
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=None)
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_raises_when_no_stats(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None
+        import pytest
+        with pytest.raises(RuntimeError, match="There are no stats available"):
+            LBRadioStatsService().fetch(USER_NAME, TIME_RANGE, 0)
+
+
+class TestLBRadioStatsServiceCache:
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_second_call_skips_couchdb(self, _mock_user, mock_stats, mock_cache):
+        cached_result = [RECORDING_1, RECORDING_2]
+        # First call: cache miss; second call: cache hit
+        mock_cache.get.side_effect = [None, cached_result]
+
+        svc = LBRadioStatsService()
+        svc.fetch(USER_NAME, TIME_RANGE, 0)
+        svc.fetch(USER_NAME, TIME_RANGE, 0)
+
+        assert mock_stats.call_count == 1, "CouchDB should only be hit once across two identical fetches"
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_cache_written_with_one_hour_ttl(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None  # always miss
+
+        LBRadioStatsService().fetch(USER_NAME, TIME_RANGE, 0)
+
+        mock_cache.set.assert_called_once()
+        _key, _value, ttl = mock_cache.set.call_args[0]
+        assert ttl == 3600, f"Expected 1-hour TTL (3600s), got {ttl}"
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=None)
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_no_stats_result_is_not_cached(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None
+
+        import pytest
+        with pytest.raises(RuntimeError):
+            LBRadioStatsService().fetch(USER_NAME, TIME_RANGE, 0)
+
+        mock_cache.set.assert_not_called()
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_different_time_ranges_cached_independently(self, _mock_user, mock_stats, mock_cache):
+        mock_cache.get.return_value = None  # always miss
+
+        svc = LBRadioStatsService()
+        svc.fetch(USER_NAME, "month", 0)
+        svc.fetch(USER_NAME, "year", 0)
+
+        assert mock_stats.call_count == 2, "Each time_range should produce a separate DB call"
+        keys = [c[0][0] for c in mock_cache.set.call_args_list]
+        assert keys[0] != keys[1], "month and year must produce different cache keys"
+
+    @patch("listenbrainz.radio.stats.cache")
+    @patch("listenbrainz.radio.stats.db_stats.get", return_value=_fake_stats())
+    @patch("listenbrainz.radio.stats.db_user.get_by_mb_id", return_value=FAKE_USER)
+    def test_cache_key_encodes_user_and_time_range(self, _mock_user, _mock_stats, mock_cache):
+        mock_cache.get.return_value = None
+
+        LBRadioStatsService().fetch(USER_NAME, TIME_RANGE, 0)
+
+        key = mock_cache.set.call_args[0][0]
+        assert str(USER_ID) in key
+        assert TIME_RANGE in key

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -600,8 +600,7 @@ def ensure_user_token_for_expensive_endpoint():
         like /popularity, /lb-radio, etc.
     """
     try:
-        _ = validate_auth_header()
+        validate_auth_header()
     except APIUnauthorized:
-        # Improve the error message until we can redirect to the login page.
-        return jsonify({"error": "Due to bad actors and AI scrapers causing undue traffic on our sites, " +
-                        "you need to provide an Auth token fro this endpoint. Sorry for this mess."""}), 401
+        raise APIUnauthorized("Due to bad actors and AI scrapers causing undue traffic on our sites, "
+                              "you need to provide an Auth token for this endpoint. Sorry for this mess.")

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -16,6 +16,7 @@ from listenbrainz.radio.tags import RecordingSearchByTagService
 from listenbrainz.radio.recording_lookup import RecordingLookupService
 from listenbrainz.radio.stats import LBRadioStatsService
 from listenbrainz.radio.playlist import LBRadioPlaylistService
+from listenbrainz.radio.recs import LBRadioRecsService
 
 LB_RADIO_PER_TOKEN_LIMIT = 10  # per rate-limit window (10s), separate from the global 100k/10s limit
 
@@ -213,6 +214,7 @@ def lb_radio():
         patch.register_service(RecordingLookupService())
         patch.register_service(LBRadioStatsService())
         patch.register_service(LBRadioPlaylistService())
+        patch.register_service(LBRadioRecsService())
         playlist = patch.generate_playlist()
     except RuntimeError as err:
         raise APIBadRequest(f"LB Radio generation failed: {err}")

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -15,6 +15,7 @@ from listenbrainz.radio.artist import RecordingSearchByArtistService
 from listenbrainz.radio.tags import RecordingSearchByTagService
 from listenbrainz.radio.recording_lookup import RecordingLookupService
 from listenbrainz.radio.stats import LBRadioStatsService
+from listenbrainz.radio.playlist import LBRadioPlaylistService
 
 LB_RADIO_PER_TOKEN_LIMIT = 10  # per rate-limit window (10s), separate from the global 100k/10s limit
 
@@ -211,6 +212,7 @@ def lb_radio():
         patch.register_service(RecordingSearchByTagService())
         patch.register_service(RecordingLookupService())
         patch.register_service(LBRadioStatsService())
+        patch.register_service(LBRadioPlaylistService())
         playlist = patch.generate_playlist()
     except RuntimeError as err:
         raise APIBadRequest(f"LB Radio generation failed: {err}")

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -1,7 +1,7 @@
 import datetime
 from flask import Blueprint, jsonify, request, current_app
 
-from brainzutils.ratelimit import ratelimit
+from brainzutils.ratelimit import ratelimit, RateLimit, get_rate_limit_data, on_over_limit
 from brainzutils import cache
 import listenbrainz.db.fresh_releases
 from listenbrainz.webserver import db_conn, ts_conn
@@ -14,6 +14,9 @@ from troi.patch import Patch
 from listenbrainz.radio.artist import RecordingSearchByArtistService
 from listenbrainz.radio.tags import RecordingSearchByTagService
 from listenbrainz.radio.recording_lookup import RecordingLookupService
+from listenbrainz.radio.stats import LBRadioStatsService
+
+LB_RADIO_PER_TOKEN_LIMIT = 10  # per rate-limit window (10s), separate from the global 100k/10s limit
 
 DEFAULT_NUMBER_OF_FRESH_RELEASE_DAYS = 14
 MAX_NUMBER_OF_FRESH_RELEASE_DAYS = 90
@@ -175,6 +178,11 @@ def lb_radio():
 
     ensure_user_token_for_expensive_endpoint()
 
+    data = get_rate_limit_data(request)
+    rl = RateLimit("lb_radio:" + data["key"], LB_RADIO_PER_TOKEN_LIMIT, data["window"])
+    if rl.over_limit:
+        return on_over_limit(rl)
+
     prompt = request.args.get("prompt", None)
     if prompt is None:
         raise APIBadRequest(f"The prompt parameter cannot be empty.")
@@ -202,6 +210,7 @@ def lb_radio():
         patch.register_service(RecordingSearchByArtistService())
         patch.register_service(RecordingSearchByTagService())
         patch.register_service(RecordingLookupService())
+        patch.register_service(LBRadioStatsService())
         playlist = patch.generate_playlist()
     except RuntimeError as err:
         raise APIBadRequest(f"LB Radio generation failed: {err}")

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -18,7 +18,7 @@ from listenbrainz.radio.stats import LBRadioStatsService
 from listenbrainz.radio.playlist import LBRadioPlaylistService
 from listenbrainz.radio.recs import LBRadioRecsService
 
-LB_RADIO_PER_TOKEN_LIMIT = 10  # per rate-limit window (10s), separate from the global 100k/10s limit
+LB_RADIO_PER_TOKEN_LIMIT = 5  # per rate-limit window (5s), separate from the global 100k/10s limit
 
 DEFAULT_NUMBER_OF_FRESH_RELEASE_DAYS = 14
 MAX_NUMBER_OF_FRESH_RELEASE_DAYS = 90

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -1,3 +1,4 @@
+from brainzutils import cache
 from brainzutils.ratelimit import ratelimit
 from datasethoster import RequestSource
 from flask import Blueprint, request, jsonify, current_app
@@ -41,21 +42,39 @@ def parse_incs(incs):
     return incs
 
 
+RECORDING_METADATA_CACHE_TTL = 86400  # 24 hours
+
+
+def _apply_incs(full_data, incs):
+    data = {"recording": full_data["recording"]}
+    for field in ("artist", "tag", "release"):
+        if field in incs:
+            data[field] = full_data.get(field)
+    return data
+
+
 def fetch_metadata(recording_mbids, incs):
-    metadata = get_metadata_for_recording(ts_conn, recording_mbids)
     result = {}
-    for entry in metadata:
-        data = {"recording": entry.recording_data}
-        if "artist" in incs:
-            data["artist"] = entry.artist_data
+    misses = []
 
-        if "tag" in incs:
-            data["tag"] = entry.tag_data
+    for mbid in recording_mbids:
+        full = cache.get(f"lb_metadata:{mbid}", decode=True)
+        if full is not None:
+            result[mbid] = _apply_incs(full, incs)
+        else:
+            misses.append(mbid)
 
-        if "release" in incs:
-            data["release"] = entry.release_data
-
-        result[str(entry.recording_mbid)] = data
+    if misses:
+        for entry in get_metadata_for_recording(ts_conn, misses):
+            full = {
+                "recording": entry.recording_data,
+                "artist": entry.artist_data,
+                "tag": entry.tag_data,
+                "release": entry.release_data,
+            }
+            mbid = str(entry.recording_mbid)
+            cache.set(f"lb_metadata:{mbid}", full, RECORDING_METADATA_CACHE_TTL, encode=True)
+            result[mbid] = _apply_incs(full, incs)
 
     return result
 

--- a/listenbrainz/webserver/views/test/test_explore_api.py
+++ b/listenbrainz/webserver/views/test/test_explore_api.py
@@ -114,7 +114,7 @@ class LBRadioRateLimitTest(IntegrationTestCase):
         mock_patch_cls.return_value = mock_patch
 
         url, headers = self._url(), self._auth()
-        for i in range(10):
+        for i in range(5):
             resp = self.client.get(url, headers=headers)
             self.assert200(resp, f"Request {i + 1} should succeed")
 
@@ -128,8 +128,8 @@ class LBRadioRateLimitTest(IntegrationTestCase):
         mock_patch_cls.return_value = mock_patch
 
         url, headers = self._url(), self._auth()
-        for _ in range(10):
+        for _ in range(5):
             self.client.get(url, headers=headers)
 
         resp = self.client.get(url, headers=headers)
-        self.assertEqual(resp.status_code, 429, "11th request should be rate-limited")
+        self.assertEqual(resp.status_code, 429, "6th request should be rate-limited")

--- a/listenbrainz/webserver/views/test/test_explore_api.py
+++ b/listenbrainz/webserver/views/test/test_explore_api.py
@@ -1,0 +1,86 @@
+from unittest.mock import patch, MagicMock
+
+from brainzutils.ratelimit import set_rate_limits
+
+import listenbrainz.db.user as db_user
+from listenbrainz.tests.integration import IntegrationTestCase
+
+
+class LBRadioAuthTest(IntegrationTestCase):
+
+    def setUp(self):
+        super().setUp()
+        set_rate_limits(100000, 100000, 10)
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testuser_lb_radio')
+
+    def _url(self):
+        return self.custom_url_for('explore_api_v1.lb_radio', prompt='artist:(radiohead)', mode='easy')
+
+    def _auth(self):
+        return {"Authorization": f"Token {self.user['auth_token']}"}
+
+    def test_unauthenticated_request_is_rejected(self):
+        resp = self.client.get(self._url())
+        self.assert401(resp)
+
+    def test_invalid_token_is_rejected(self):
+        resp = self.client.get(self._url(), headers={"Authorization": "Token notavalidtoken"})
+        self.assert401(resp)
+
+    @patch('listenbrainz.webserver.views.explore_api.LBRadioPatch')
+    def test_valid_token_is_accepted(self, mock_patch_cls):
+        mock_patch = MagicMock()
+        mock_patch.generate_playlist.return_value = MagicMock(
+            get_jspf=lambda: {"playlist": {"tracks": []}}
+        )
+        mock_patch.user_feedback.return_value = []
+        mock_patch_cls.return_value = mock_patch
+
+        resp = self.client.get(self._url(), headers=self._auth())
+        self.assert200(resp)
+
+
+class LBRadioRateLimitTest(IntegrationTestCase):
+    """lb-radio has a separate, stricter rate limit than the global one."""
+
+    def setUp(self):
+        super().setUp()
+        # Global limit is effectively unlimited so only the lb-radio limit fires.
+        set_rate_limits(100000, 100000, 10)
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testuser_lb_radio_rl')
+
+    def _url(self):
+        return self.custom_url_for('explore_api_v1.lb_radio', prompt='artist:(radiohead)', mode='easy')
+
+    def _auth(self):
+        return {"Authorization": f"Token {self.user['auth_token']}"}
+
+    @patch('listenbrainz.webserver.views.explore_api.LBRadioPatch')
+    def test_requests_within_limit_succeed(self, mock_patch_cls):
+        mock_patch = MagicMock()
+        mock_patch.generate_playlist.return_value = MagicMock(
+            get_jspf=lambda: {"playlist": {"tracks": []}}
+        )
+        mock_patch.user_feedback.return_value = []
+        mock_patch_cls.return_value = mock_patch
+
+        url, headers = self._url(), self._auth()
+        for i in range(10):
+            resp = self.client.get(url, headers=headers)
+            self.assert200(resp, f"Request {i + 1} should succeed")
+
+    @patch('listenbrainz.webserver.views.explore_api.LBRadioPatch')
+    def test_request_over_limit_is_rejected(self, mock_patch_cls):
+        mock_patch = MagicMock()
+        mock_patch.generate_playlist.return_value = MagicMock(
+            get_jspf=lambda: {"playlist": {"tracks": []}}
+        )
+        mock_patch.user_feedback.return_value = []
+        mock_patch_cls.return_value = mock_patch
+
+        url, headers = self._url(), self._auth()
+        for _ in range(10):
+            self.client.get(url, headers=headers)
+
+        resp = self.client.get(url, headers=headers)
+        self.assertEqual(resp.status_code, 429, "11th request should be rate-limited")

--- a/listenbrainz/webserver/views/test/test_explore_api.py
+++ b/listenbrainz/webserver/views/test/test_explore_api.py
@@ -40,6 +40,55 @@ class LBRadioAuthTest(IntegrationTestCase):
         self.assert200(resp)
 
 
+class LBRadioServiceRegistrationTest(IntegrationTestCase):
+    """Verify that all DB-direct services are registered when lb_radio() runs.
+
+    If a register_service() call is removed from explore_api.py, this test
+    catches it before it silently falls back to HTTP loopbacks in production.
+    """
+
+    def setUp(self):
+        super().setUp()
+        set_rate_limits(100000, 100000, 10)
+        self.user = db_user.get_or_create(self.db_conn, 1, 'testuser_lb_radio_reg')
+
+    @patch('listenbrainz.webserver.views.explore_api.LBRadioPatch')
+    def test_all_services_registered(self, mock_patch_cls):
+        from listenbrainz.radio.artist import RecordingSearchByArtistService
+        from listenbrainz.radio.tags import RecordingSearchByTagService
+        from listenbrainz.radio.recording_lookup import RecordingLookupService
+        from listenbrainz.radio.stats import LBRadioStatsService
+        from listenbrainz.radio.playlist import LBRadioPlaylistService
+        from listenbrainz.radio.recs import LBRadioRecsService
+
+        expected_slugs = {
+            RecordingSearchByArtistService.SLUG,
+            RecordingSearchByTagService.SLUG,
+            RecordingLookupService.SLUG,
+            LBRadioStatsService.SLUG,
+            LBRadioPlaylistService.SLUG,
+            LBRadioRecsService.SLUG,
+        }
+
+        mock_patch = MagicMock()
+        mock_patch.generate_playlist.return_value = MagicMock(
+            get_jspf=lambda: {"playlist": {"tracks": []}}
+        )
+        mock_patch.user_feedback.return_value = []
+        mock_patch_cls.return_value = mock_patch
+
+        self.client.get(
+            self.custom_url_for('explore_api_v1.lb_radio', prompt='artist:(radiohead)', mode='easy'),
+            headers={"Authorization": f"Token {self.user['auth_token']}"}
+        )
+
+        registered = {call.args[0].slug for call in mock_patch.register_service.call_args_list}
+        assert expected_slugs == registered, (
+            f"Missing services: {expected_slugs - registered}, "
+            f"unexpected: {registered - expected_slugs}"
+        )
+
+
 class LBRadioRateLimitTest(IntegrationTestCase):
     """lb-radio has a separate, stricter rate limit than the global one."""
 

--- a/listenbrainz/webserver/views/test/test_fetch_metadata_cache.py
+++ b/listenbrainz/webserver/views/test/test_fetch_metadata_cache.py
@@ -83,6 +83,7 @@ class TestFetchMetadataCache:
         result = fetch_metadata([MBID_A], ["release"])
         assert "release" in result[MBID_A]
         assert "artist" not in result[MBID_A]
+        assert "tag" not in result[MBID_A]
 
     @patch("listenbrainz.webserver.views.metadata_api.cache")
     @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")

--- a/listenbrainz/webserver/views/test/test_fetch_metadata_cache.py
+++ b/listenbrainz/webserver/views/test/test_fetch_metadata_cache.py
@@ -1,0 +1,110 @@
+"""
+Tests for the per-MBID Redis cache inside fetch_metadata().
+
+The cache lives in metadata_api.fetch_metadata so every caller
+(lb-radio recording lookup, entity pages, /1/metadata/recording)
+benefits automatically.
+"""
+from unittest.mock import patch, MagicMock
+
+from listenbrainz.webserver.views.metadata_api import fetch_metadata
+
+MBID_A = "aaaa-0001"
+MBID_B = "bbbb-0002"
+
+FULL_A = {
+    "recording": {"name": "Creep"},
+    "artist": {"name": "Radiohead"},
+    "tag": {"recording": []},
+    "release": {"name": "Pablo Honey"},
+}
+FULL_B = {
+    "recording": {"name": "Karma Police"},
+    "artist": {"name": "Radiohead"},
+    "tag": {"recording": []},
+    "release": {"name": "OK Computer"},
+}
+
+
+def _make_entry(mbid, full):
+    entry = MagicMock()
+    entry.recording_mbid = mbid
+    entry.recording_data = full["recording"]
+    entry.artist_data = full["artist"]
+    entry.tag_data = full["tag"]
+    entry.release_data = full["release"]
+    return entry
+
+
+class TestFetchMetadataCache:
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")
+    def test_cache_hit_skips_db(self, mock_db, mock_cache):
+        mock_cache.get.return_value = FULL_A
+        result = fetch_metadata([MBID_A], ["artist", "release"])
+        mock_db.assert_not_called()
+        assert result[MBID_A]["recording"] == FULL_A["recording"]
+        assert result[MBID_A]["artist"] == FULL_A["artist"]
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording",
+           return_value=[])
+    def test_cache_miss_hits_db(self, mock_db, mock_cache):
+        mock_cache.get.return_value = None
+        fetch_metadata([MBID_A], ["artist"])
+        mock_db.assert_called_once()
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")
+    def test_cache_miss_stores_full_data(self, mock_db, mock_cache):
+        mock_cache.get.return_value = None
+        mock_db.return_value = [_make_entry(MBID_A, FULL_A)]
+        fetch_metadata([MBID_A], ["artist"])
+        stored = mock_cache.set.call_args[0][1]
+        assert "artist" in stored
+        assert "tag" in stored
+        assert "release" in stored
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")
+    def test_incs_filter_applied_on_cache_hit(self, mock_db, mock_cache):
+        mock_cache.get.return_value = FULL_A
+        result = fetch_metadata([MBID_A], ["artist"])
+        assert "artist" in result[MBID_A]
+        assert "tag" not in result[MBID_A]
+        assert "release" not in result[MBID_A]
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")
+    def test_incs_filter_applied_on_cache_miss(self, mock_db, mock_cache):
+        mock_cache.get.return_value = None
+        mock_db.return_value = [_make_entry(MBID_A, FULL_A)]
+        result = fetch_metadata([MBID_A], ["release"])
+        assert "release" in result[MBID_A]
+        assert "artist" not in result[MBID_A]
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")
+    def test_partial_hit_fetches_only_misses(self, mock_db, mock_cache):
+        def _get(key, **kwargs):
+            return FULL_A if MBID_A in key else None
+        mock_cache.get.side_effect = _get
+        mock_db.return_value = [_make_entry(MBID_B, FULL_B)]
+
+        result = fetch_metadata([MBID_A, MBID_B], ["artist"])
+
+        fetched = mock_db.call_args[0][1]
+        assert MBID_A not in fetched
+        assert MBID_B in fetched
+        assert MBID_A in result
+        assert MBID_B in result
+
+    @patch("listenbrainz.webserver.views.metadata_api.cache")
+    @patch("listenbrainz.webserver.views.metadata_api.get_metadata_for_recording")
+    def test_cache_written_with_24h_ttl(self, mock_db, mock_cache):
+        mock_cache.get.return_value = None
+        mock_db.return_value = [_make_entry(MBID_A, FULL_A)]
+        fetch_metadata([MBID_A], ["artist"])
+        _key, _value, ttl = mock_cache.set.call_args[0]
+        assert ttl == 86400

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ xmltodict==0.14.2
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v3.0.0
 spotipy==2.26.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@830ecb2b2120acbd5deed2dab4587784c7be04b6
-troi @ git+https://github.com/metabrainz/troi-recommendation-playground.git@5da64e4505c00aec2048c6b4a44608b555bf1eb4
+troi==2026.9.1.0
 gevent==25.5.1
 gevent-websocket==0.10.1
 uWSGI==2.0.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ xmltodict==0.14.2
 brainzutils@git+https://github.com/metabrainz/brainzutils-python.git@v3.0.0
 spotipy==2.26.0
 datasethoster@git+https://github.com/metabrainz/data-set-hoster.git@830ecb2b2120acbd5deed2dab4587784c7be04b6
-troi==2026.7.31.0
+troi @ git+https://github.com/metabrainz/troi-recommendation-playground.git@5da64e4505c00aec2048c6b4a44608b555bf1eb4
 gevent==25.5.1
 gevent-websocket==0.10.1
 uWSGI==2.0.31


### PR DESCRIPTION
# Problem

Following #3789, four HTTP loopbacks remain in the LB Radio pipeline: `stats`, `playlist`, `recs`, and recording metadata lookup. Two additional issues existed independently:

1. `ensure_user_token_for_expensive_endpoint()` returned a 401 response tuple that callers silently dropped -- unauthenticated requests reached the radio pipeline unblocked.
2. Authenticated users inherited the global 100k/10s rate limit intended for Troi CLI usage, making it trivial to hammer the MusicBrainz API from the `country` entity type.

# Solution

**Auth guard fix** -- `ensure_user_token_for_expensive_endpoint()` now raises `APIUnauthorized` instead of returning a response tuple.

**Per-endpoint rate limit** -- lb-radio enforces a separate Redis counter (`lb_radio:<token>`, 10 req/10s) independent of the global limit.

**Three new DB-direct services** replacing HTTP loopbacks:

- `LBRadioStatsService` -- replaces `liblistenbrainz.get_user_recordings()` with a direct CouchDB call. Results cached in Redis at 1-hour TTL (stats update weekly/monthly).
- `LBRadioPlaylistService` -- replaces `GET api.listenbrainz.org/1/playlist/{mbid}` with `db.playlist.get_by_mbid()`. Access control uses `playlist.is_visible_by()` -- identical to the HTTP endpoint, covering creator and collaborators.
- `LBRadioRecsService` -- replaces the paginated `liblistenbrainz.get_user_recommendation_recordings()` loop with a single `db.recommendations_cf_recording.get_user_recommendation()` call.

**Recording metadata cache** -- `fetch_metadata()` in `metadata_api.py` now caches per-MBID results in Redis at 24-hour TTL. All callers benefit: lb-radio recording lookup, entity pages, and the `/1/metadata/recording` endpoint.

All services return the same data shape as their HTTP counterparts. 1:1 parity verified by integration tests that mock at the DB layer and test through the full service -> Troi element pipeline.

**Troi dependency:** `requirements.txt` needs updating to include commit `5da64e4` of `troi-recommendation-playground` which adds the stats, playlist and recs service hooks. See Troi PR: metabrainz/troi-recommendation-playground#190.

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I have used AI in this PR (add more details below)

- [x] I used AI tools for coding
- [x] I understand all the changes made in this PR

Used Claude Code to assist with implementation, test writing, and code review throughout this PR. All code was reviewed, understood, and validated against the existing codebase before committing.

# Action

metabrainz/troi-recommendation-playground#190 must be merged and a new release cut before `requirements.txt` can be updated to a stable version pin. For now it is pinned to commit `5da64e4`.