### PR TITLE
Handle Last.fm/Libre.fm error JSON and empty API bodies in the importer.

### DIFF
--- a/listenbrainz/listens_importer/lastfm.py
+++ b/listenbrainz/listens_importer/lastfm.py
@@ -91,14 +91,25 @@ class BaseLastfmImporter(ListensImporter):
         response = session.get(self.api_base_url, params=params)
         match response.status_code:
             case 200:
-                return response.json()
+                try:
+                    data = response.json()
+                except requests.exceptions.JSONDecodeError:
+                    raise ExternalServiceAPIError("Error from the API while getting listens: %s" % response.text)
+                if "error" in data:
+                    # Libre.fm: no scrobbles since the given timestamp
+                    if isinstance(data["error"], dict) and str(data["error"].get("code")) == "7":
+                        return {"recenttracks": {"@attr": {"totalPages": "0"}, "track": []}}
+                    raise ExternalServiceAPIError("Error from the API while getting listens: %s" % data.get("message", data["error"]))
+                return data
             case 404:
                 raise LastfmUserNotRetryableException("Last.FM user with username %s not found" % (params["user"],))
             case 429:
                 raise ExternalServiceError("Encountered a rate limit.")
             case 400 | 403:
-                # Check for error 17 (privacy mode enabled)
-                data = response.json()
+                try:
+                    data = response.json()
+                except requests.exceptions.JSONDecodeError:
+                    raise ExternalServiceAPIError("Error from the API while getting listens: %s" % response.text)
                 if "error" in data and data.get("error") == 17:
                     raise LastfmUserNotRetryableException(
                         "Please disable privacy mode in the settings of your Last.fm account to allow importing listens."

--- a/listenbrainz/listens_importer/tests/test_lastfm.py
+++ b/listenbrainz/listens_importer/tests/test_lastfm.py
@@ -1,9 +1,13 @@
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import requests
 import requests_mock
 import listenbrainz.webserver
-from datetime import datetime, timezone
-
 import listenbrainz.db.user as db_user
 from data.model.external_service import ExternalServiceType
+from listenbrainz.domain.external_service import ExternalServiceAPIError
 from listenbrainz.domain.lastfm import LastfmService
 from listenbrainz.listens_importer.lastfm import BaseLastfmImporter
 from listenbrainz.db.testing import DatabaseTestCase
@@ -132,3 +136,29 @@ class LastfmImporterTestCase(DatabaseTestCase):
 
             self.assertEqual(success2, 1)
             self.assertEqual(failure2, 1)
+
+
+class LastfmRecentTracksTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.importer = BaseLastfmImporter("t", "t", MagicMock(), "https://ws.audioscrobbler.com/2.0/", "k")
+        self.user = {"external_user_id": "u", "latest_listened_at": datetime.fromtimestamp(0, timezone.utc)}
+
+    def _get(self, **kwargs):
+        with requests_mock.Mocker() as m:
+            m.get("https://ws.audioscrobbler.com/2.0/", **kwargs)
+            return self.importer.get_user_recent_tracks(requests.Session(), self.user, page=1)
+
+    def test_invalid_json(self):
+        with self.assertRaises(ExternalServiceAPIError):
+            self._get(text="", status_code=200)
+        with self.assertRaises(ExternalServiceAPIError):
+            self._get(text="", status_code=400)
+
+    def test_error_payload(self):
+        with self.assertRaises(ExternalServiceAPIError):
+            self._get(json={"error": 8, "message": "Operation failed"}, status_code=200)
+
+    def test_librefm_empty_range(self):
+        data = self._get(json={"error": {"code": "7"}}, status_code=200)
+        self.assertEqual(data["recenttracks"]["track"], [])


### PR DESCRIPTION
HTTP 200 can still be an error object, and 400/403 bodies are sometimes empty; wrap json() and check for error keys so the importer raises instead of crashing.

Fixes [2QX](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-2QX), [2RY](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-2RY)

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ ] I understand all the changes made in this PR
