### PR TITLE
fix(spotify): keep album tracks as a paging object after pagination

### DIFF
--- a/listenbrainz/metadata_cache/spotify/handler.py
+++ b/listenbrainz/metadata_cache/spotify/handler.py
@@ -82,6 +82,7 @@ class SpotifyCrawlerHandler(AlbumHandler):
         new_items = []
         albums = self.sp.albums(album_ids).get("albums")
 
+        transformed_albums = []
         for album in albums:
             if album is None:
                 continue
@@ -100,9 +101,7 @@ class SpotifyCrawlerHandler(AlbumHandler):
                         discovered_items = self.discover_albums(track_artist["id"])
                         new_items.extend(discovered_items)
 
-            album["tracks"] = tracks
-
-        transformed_albums = [self.transform_album(album) for album in albums]
+            transformed_albums.append(self.transform_album(album))
 
         return transformed_albums, new_items
 


### PR DESCRIPTION
Replacing album["tracks"] with a flattened list made transform_album index ["items"] on a list. Extra pages already extend the existing items array in place.

Fixes [LISTENBRAINZ-26G
](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-26G)

* [x] I have run the code and manually tested the changes

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ ] I understand all the changes made in this PR

