### PR TITLE
Normalize Libre.fm single-track responses to always be a list

### DIFF
--- a/listenbrainz/listens_importer/lastfm.py
+++ b/listenbrainz/listens_importer/lastfm.py
@@ -91,7 +91,14 @@ class BaseLastfmImporter(ListensImporter):
         response = session.get(self.api_base_url, params=params)
         match response.status_code:
             case 200:
-                return response.json()
+                data = response.json()
+                # Libre.fm returns a single dict instead of a list when there is
+                # only one track; normalize to always be a list.
+                if "recenttracks" in data:
+                    tracks = data["recenttracks"].get("track")
+                    if isinstance(tracks, dict):
+                        data["recenttracks"]["track"] = [tracks]
+                return data
             case 404:
                 raise LastfmUserNotRetryableException("Last.FM user with username %s not found" % (params["user"],))
             case 429:

--- a/listenbrainz/listens_importer/tests/test_lastfm.py
+++ b/listenbrainz/listens_importer/tests/test_lastfm.py
@@ -1,3 +1,7 @@
+import unittest
+from unittest.mock import MagicMock
+
+import requests
 import requests_mock
 import listenbrainz.webserver
 from datetime import datetime, timezone
@@ -132,3 +136,29 @@ class LastfmImporterTestCase(DatabaseTestCase):
 
             self.assertEqual(success2, 1)
             self.assertEqual(failure2, 1)
+
+
+class SingleTrackNormalizationTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.importer = BaseLastfmImporter("t", "t", MagicMock(), "https://ws.audioscrobbler.com/2.0/", "k")
+        self.user = {"external_user_id": "u", "latest_listened_at": datetime.fromtimestamp(0, timezone.utc)}
+
+    def _get(self, **kwargs):
+        with requests_mock.Mocker() as m:
+            m.get("https://ws.audioscrobbler.com/2.0/", **kwargs)
+            return self.importer.get_user_recent_tracks(requests.Session(), self.user, page=1)
+
+    def test_single_track_dict_normalized_to_list(self):
+        """Libre.fm returns a dict instead of a list when there is one track."""
+        single_track = {"name": "Song", "artist": {"#text": "Artist", "mbid": ""}, "album": {"#text": "", "mbid": ""}, "date": {"uts": "1000"}}
+        data = self._get(json={"recenttracks": {"@attr": {"totalPages": "1"}, "track": single_track}}, status_code=200)
+        self.assertIsInstance(data["recenttracks"]["track"], list)
+        self.assertEqual(len(data["recenttracks"]["track"]), 1)
+        self.assertEqual(data["recenttracks"]["track"][0]["name"], "Song")
+
+    def test_multi_track_list_unchanged(self):
+        tracks = [{"name": "A"}, {"name": "B"}]
+        data = self._get(json={"recenttracks": {"@attr": {"totalPages": "1"}, "track": tracks}}, status_code=200)
+        self.assertIsInstance(data["recenttracks"]["track"], list)
+        self.assertEqual(len(data["recenttracks"]["track"]), 2)


### PR DESCRIPTION
Libre.fm returns recenttracks.track as a dict instead of a list when there is exactly one track on a page. Iterating over the dict yields key strings, crashing convert_scrobble_to_listen. Normalize at the API boundary in get_user_recent_tracks so all callers see a consistent array.

Fixes [LISTENBRAINZ-2MK](https://metabrainz-foundation-inc.sentry.io/issues/134015049/?project=4509276869951568)

# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ ] I understand all the changes made in this PR

