### PR TITLE
fix: Handle MusicBrainz revoked refresh token error correctly

### DIFF
--- a/listenbrainz/domain/brainz_service.py
+++ b/listenbrainz/domain/brainz_service.py
@@ -1,7 +1,7 @@
 import time
 
 from requests_oauthlib import OAuth2Session
-from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError, InvalidGrantError
 from listenbrainz.db import external_service_oauth
 
 from listenbrainz.domain.external_service import ExternalService, ExternalServiceInvalidGrantError
@@ -77,7 +77,7 @@ class BaseBrainzService(ExternalService):
                 client_id=self.client_id,
                 refresh_token=refresh_token,
             )
-        except (InvalidGrantError, TypeError) as e:
+        except (InvalidGrantError, InvalidClientIdError, TypeError) as e:
             raise ExternalServiceInvalidGrantError("User revoked access") from e
 
         expires_at = int(time.time()) + token["expires_in"]


### PR DESCRIPTION
# Problem

## What is the issue?
When a user revokes their MusicBrainz authorization, the token refresh call fails with an uncaught `InvalidClientIdError`, causing 400K+ Sentry events.

Fixes [LISTENBRAINZ-D](https://metabrainz-foundation-inc.sentry.io/issues/40455502/).

## Why does it happen?
MusicBrainz's OAuth server ([`refresh_grant.py`](https://github.com/metabrainz/metabrainz.org/blob/master/metabrainz/oauth/refresh_grant.py#L29)) returns `error=invalid_request` with the message `'refresh_token' in request was already revoked.` when a revoked refresh token is used.

oauthlib confusingly maps the `invalid_request` error code to `InvalidClientIdError` (not `InvalidRequestError`), which is a `FatalClientError` — a completely separate hierarchy from `InvalidGrantError`:

- `InvalidGrantError` → `OAuth2Error` (for `invalid_grant`)
- `InvalidClientIdError` → `FatalClientError` → `OAuth2Error` (for `invalid_request`)

The existing except clause only caught `(InvalidGrantError, TypeError)`, so `InvalidClientIdError` propagated up.

# Solution

Add `InvalidClientIdError` to the except clause. This routes revoked-token errors through the existing `ExternalServiceInvalidGrantError` path, which callers already handle gracefully.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR