### PR TITLE
fix: Strip empty optional fields from listen metadata instead of rejecting

### DIFF
--- a/listenbrainz/background/listens_importer/base.py
+++ b/listenbrainz/background/listens_importer/base.py
@@ -164,7 +164,7 @@ class BaseListensImporter(ABC):
                 validate_listen(listen, LISTEN_TYPE_IMPORT)
                 validated_listens.append(listen)
             except ListenValidationError as e:
-                current_app.logger.error("Invalid listen: %s", e)
+                current_app.logger.warning("Invalid listen: %s", e)
         
         validation_stats["success_count"] += len(validated_listens)
 

--- a/listenbrainz/tests/integration/test_api.py
+++ b/listenbrainz/tests/integration/test_api.py
@@ -561,6 +561,24 @@ class APITestCase(ListenAPIIntegrationTestCase):
         self.assertEqual(response.json['code'], 400)
         self.assertEqual(response.json['error'], "track_metadata.release_name must be a single string.")
 
+    def test_empty_release_name_stripped(self):
+        """Test that an empty or whitespace-only release_name is stripped and the listen is accepted."""
+        with open(self.path_to_data_file('valid_single.json'), 'r') as f:
+            payload = json.load(f)
+
+        payload['payload'][0]['track_metadata']['release_name'] = '   '
+        ts = int(time.time())
+        payload['payload'][0]['listened_at'] = ts
+        response = self.send_data(payload, recalculate=True)
+        self.assert200(response)
+
+        url = self.custom_url_for('api_v1.get_listens',
+                                  user_name=self.user['musicbrainz_id'])
+        response = self.wait_for_query_to_have_items(
+            url, 1, query_string={'count': '1'})
+        data = json.loads(response.data)['payload']
+        self.assertNotIn('release_name', data['listens'][0]['track_metadata'])
+
     def test_bad_track_name_format(self):
         """Test for invalid submission in which a listen has a track_name field but it's not a string"""
         with open(self.path_to_data_file('empty_track_name.json'), 'r') as f:

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -248,7 +248,9 @@ def validate_basic_metadata(listen, key, required=True):
 
         listen['track_metadata'][key] = listen['track_metadata'][key].strip()
         if len(listen['track_metadata'][key]) == 0:
-            raise ListenValidationError(f"field track_metadata.{key} is empty.", listen)
+            if required:
+                raise ListenValidationError(f"field track_metadata.{key} is empty.", listen)
+            del listen['track_metadata'][key]
     elif required:
         raise ListenValidationError(f"JSON document does not contain required field track_metadata.{key}.", listen)
 


### PR DESCRIPTION
# Problem

## What is the issue?
Listens submitted with `release_name: ""` (empty string) are rejected with a validation error, even though `release_name` is an optional field. This causes valid listens to be silently dropped during background imports.

Fixes [LISTENBRAINZ-KP](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-KP).

## Why does it happen?
The `validate_basic_metadata` function in `api_tools.py` treats all fields identically: if the value is present but empty after stripping whitespace, it raises `ListenValidationError` regardless of whether the field is required or optional.

For optional fields like `release_name`, an empty value should simply be removed from the metadata rather than rejecting the entire listen. The function already has a `required` parameter but the empty-check path didn't use it.

Sentry shows 138K events with the exact pattern: `"field track_metadata.release_name is empty."` with payloads like `{'release_name': '', 'artist_name': 'Fall Out Boy', 'track_name': 'Love From The Other Side'}`. The artist and track are valid, only the empty release_name triggers rejection.

# Solution

When `required=False` and the value is empty after strip, delete the key from the metadata instead of raising an error. Required fields still raise as before.

Also downgraded the importer's validation failure log from `error` to `warning` since these are expected data quality issues, not system errors.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR