### PR TITLE
fix: Stop reporting expected 4xx errors to Sentry from ErrorBoundary

### DIFF
--- a/frontend/js/src/error/ErrorBoundary.tsx
+++ b/frontend/js/src/error/ErrorBoundary.tsx
@@ -27,7 +27,9 @@ export function ErrorBoundary() {
   const errorMessage = error.data?.error || error.message || errorStatusMessage;
 
   React.useEffect(() => {
-    Sentry.captureException(error);
+    if (!isRouteErrorResponse(error) || errorStatus >= 500) {
+      Sentry.captureException(error);
+    }
   }, [error]);
 
   return isRouteErrorResponse(error) ? (


### PR DESCRIPTION
# Problem

## What is the issue?
The React ErrorBoundary component unconditionally calls `Sentry.captureException(error)` for every route error, including expected 404 responses. This floods Sentry with noise from normal operations: deleted playlists, non-existent users, and bots crawling stale URLs.

Fixes [LISTENBRAINZ-1RH](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-1RH) (77K events, 6K users).
Fixes [LISTENBRAINZ-2CZ](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-2CZ) (14K events, 14K users).

## Why does it happen?
The `useEffect` at `ErrorBoundary.tsx:30` reports every error without checking whether it's a route error response (React Router's representation of an HTTP error status) or a real JavaScript exception.

Route error responses with 4xx status codes are expected. "Cannot find playlist" or "Cannot find user" are normal HTTP 404s, not bugs. Sentry events confirm: serialized data shows `{"data": {"error": "Cannot find playlist: ..."}, "status": 404}`.

# Solution

Only report to Sentry when the error is either not a route error response (i.e. an unexpected JS exception) or when the HTTP status is 500+. All 4xx responses are expected operational events that should render the error page but not hit Sentry.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR