### PR TITLE
fix: Skip users with empty external_user_id in Last.fm/Libre.fm importer

### DIFF
--- a/listenbrainz/listens_importer/lastfm.py
+++ b/listenbrainz/listens_importer/lastfm.py
@@ -121,6 +121,9 @@ class BaseLastfmImporter(ListensImporter):
         """
         imported_listen_count = 0
 
+        if not user.get("external_user_id"):
+            raise LastfmUserNotRetryableException("Last.fm/Libre.fm username is empty")
+
         try:
             session = requests.Session()
             session.mount(


### PR DESCRIPTION
# Problem

## What is the issue?
The Last.fm/Libre.fm importer makes API calls with an empty `user=` parameter, causing Last.fm to return 400 errors. With retry logic (3 retries on 400), each occurrence generates multiple requests that all fail, hitting Sentry each time.

Fixes [LISTENBRAINZ-11R](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-11R) (39K events).

## Why does it happen?
Some users have an empty `external_user_id` in the database. The importer doesn't validate this before making API calls. The `get_user_recent_tracks` method uses `user["external_user_id"]` directly in the params dict, and Last.fm rejects the request with an empty username.

Sentry URL confirms: `&user=&from=1730210240` -- the `user` parameter is empty. The `max_retries` config includes status 400, so each empty-username request is retried 3 times before finally raising `RetryError`.

# Solution

Check for empty `external_user_id` at the start of `process_one_user` before making any API calls. Raise `LastfmUserNotRetryableException` so the user is marked as errored with `retry=False`, preventing repeated attempts on future importer runs.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR