### PR TITLE
fix: Catch ConnectionError in LB Radio API endpoint

### DIFF
--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -1,4 +1,5 @@
 import datetime
+import requests.exceptions
 from flask import Blueprint, jsonify, request, current_app
 
 from brainzutils.ratelimit import ratelimit
@@ -205,6 +206,8 @@ def lb_radio():
         playlist = patch.generate_playlist()
     except RuntimeError as err:
         raise APIBadRequest(f"LB Radio generation failed: {err}")
+    except requests.exceptions.ConnectionError:
+        raise APIInternalServerError("LB Radio generation failed due to a connection error, please try again.")
 
     jspf = playlist.get_jspf() if playlist is not None else {
         "playlist": {"tracks": []}}


### PR DESCRIPTION
# Problem

## What is the issue?
The `/1/explore/lb-radio` API endpoint crashes with an unhandled `requests.exceptions.ConnectionError` when the troi library's internal HTTP call to `api.listenbrainz.org` fails (connection refused, remote disconnect, etc.).

Fixes [LISTENBRAINZ-GT](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-GT) (12K events).

## Why does it happen?
The `lb_radio` handler in `explore_api.py` only catches `RuntimeError` from `patch.generate_playlist()`. The troi library's tag-based recording search makes HTTP requests to `/1/lb-radio/tags`, which can raise `requests.exceptions.ConnectionError`. This is a different exception class that propagates unhandled to Sentry.

Sentry trace shows: `troi/recording_search_service.py:30` calling `http_get("https://api.listenbrainz.org/1/lb-radio/tags"...)` raising `ConnectionError: HTTPSConnectionPool Max retries exceeded ... RemoteDisconnected('Remote end closed connection without response')`.

# Solution

Add `requests.exceptions.ConnectionError` to the except clause and return a proper 500 API error response instead of letting the exception propagate.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR