### PR TITLE
fix: Handle empty string minutes param in atom feed

### DIFF
--- a/listenbrainz/webserver/views/atom.py
+++ b/listenbrainz/webserver/views/atom.py
@@ -183,10 +183,10 @@ def get_listens(user_name):
     if user is None:
         return NotFound("User not found")
 
-    minutes = request.args.get("minutes", DEFAULT_MINUTES_OF_LISTENS)
+    minutes = request.args.get("minutes") or DEFAULT_MINUTES_OF_LISTENS
     try:
         minutes = int(minutes)
-    except (ValueError, TypeError):
+    except ValueError:
         return BadRequest("Invalid value for minutes")
     if minutes < 1 or minutes > MAX_MINUTES_OF_LISTENS:
         return BadRequest("Value of minutes is out of range")

--- a/listenbrainz/webserver/views/atom.py
+++ b/listenbrainz/webserver/views/atom.py
@@ -184,11 +184,10 @@ def get_listens(user_name):
         return NotFound("User not found")
 
     minutes = request.args.get("minutes", DEFAULT_MINUTES_OF_LISTENS)
-    if minutes:
-        try:
-            minutes = int(minutes)
-        except ValueError:
-            return BadRequest("Invalid value for minutes")
+    try:
+        minutes = int(minutes)
+    except (ValueError, TypeError):
+        return BadRequest("Invalid value for minutes")
     if minutes < 1 or minutes > MAX_MINUTES_OF_LISTENS:
         return BadRequest("Value of minutes is out of range")
 


### PR DESCRIPTION
# Problem

## What is the issue?
The atom feed endpoint crashes when `minutes` is passed as an empty string. `request.args.get("minutes", DEFAULT)` returns `""` (not the default) for `?minutes=`, then `int("")` raises `ValueError` and the range check fails on the wrong type.

Fixes [LISTENBRAINZ-2W8](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-2W8).

## Why does it happen?
`request.args.get("minutes", DEFAULT_MINUTES_OF_LISTENS)` only uses the default when the param is completely absent. When present but empty (`?minutes=`), it returns `""`. The old `if minutes:` guard skipped the `int()` conversion for falsy values, letting the raw empty string reach the `<` comparison.

# Solution

Use `request.args.get("minutes") or DEFAULT_MINUTES_OF_LISTENS` so that both missing and empty-string cases fall back to the default — which is the expected user experience. Invalid non-empty values like `?minutes=abc` still return `BadRequest`. Dropped the `TypeError` catch since `minutes` can no longer be `None` at that point.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR