### PR TITLE
GSOC-26 Musicbrainz Release Collections Import 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -163,7 +163,7 @@ services:
 
 # Uncomment the following lines if you want to connect the LB network to a musicbrainz-docker network to access a MB replica
 # TODO: re-comment these before merging this code
-networks:
-  default:
-    name: musicbrainz-docker_default
-    external: true
+# networks:
+#   default:
+#     name: musicbrainz-docker_default
+#     external: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -163,7 +163,7 @@ services:
 
 # Uncomment the following lines if you want to connect the LB network to a musicbrainz-docker network to access a MB replica
 # TODO: re-comment these before merging this code
-# networks:
-#   default:
-#     name: musicbrainz-docker_default
-#     external: true
+networks:
+  default:
+    name: musicbrainz-docker_default
+    external: true

--- a/frontend/css/sass/listen-card.scss
+++ b/frontend/css/sass/listen-card.scss
@@ -1,5 +1,9 @@
 @use "sass:map";
 
+.collection-release-card-wrap {
+  cursor: pointer;
+}
+
 .listen-card {
   &.card {
     height: initial;

--- a/frontend/js/src/collections/Collection.tsx
+++ b/frontend/js/src/collections/Collection.tsx
@@ -3,7 +3,9 @@ import * as React from "react";
 import { faPlayCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
+  FetchNextPageOptions,
   InfiniteData,
+  InfiniteQueryObserverResult,
   QueryClient,
   useInfiniteQuery,
   useQueryClient,
@@ -25,6 +27,7 @@ import {
   PLAYLIST_ARTIST_URI_PREFIX,
   PLAYLIST_TRACK_URI_PREFIX,
 } from "../playlists/utils";
+import ListenCard from "../common/listens/ListenCard";
 import { RouteQuery } from "../utils/Loader";
 import { generateAlbumArtThumbnailLink } from "../utils/utils";
 
@@ -37,9 +40,31 @@ import type {
 
 const DEFAULT_PAGE_SIZE = 100;
 const FLATTEN_TRACKS_PAGE_SIZE = 500;
+const MAX_FLATTEN_TRACKS = 5000;
 const DEFAULT_ESTIMATED_ROW_HEIGHT_PX = 110;
 const RELEASE_ROW_ESTIMATED_HEIGHT_PX = 72;
 const LOAD_MORE_THRESHOLD_ROWS = 20;
+
+type FetchNextCollectionPage = (
+  options?: FetchNextPageOptions
+) => Promise<
+  InfiniteQueryObserverResult<
+    InfiniteData<MusicBrainzCollectionDetailResponse, number>,
+    Error
+  >
+>;
+
+type CollectionViewProps = {
+  collectionMBID: string;
+  collection: MusicBrainzCollectionDetailResponse["collection"];
+  coverArt?: string | null;
+  itemCount: number;
+  data: InfiniteData<MusicBrainzCollectionDetailResponse, number> | undefined;
+  fetchNextPage: FetchNextCollectionPage;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  isLoading: boolean;
+};
 
 function asJSPFTrack(track: MusicBrainzCollectionTrack): JSPFTrack {
   const recordingMBID = track.recording_mbid;
@@ -84,42 +109,95 @@ function asJSPFTrack(track: MusicBrainzCollectionTrack): JSPFTrack {
   return jspfTrack;
 }
 
-function ReleaseCollectionItemRow({
+function asReleaseListen(item: MusicBrainzCollectionReleaseItem): Listen {
+  return {
+    listened_at: 0,
+    track_metadata: {
+      track_name: "",
+      artist_name: item.artist_credit_name ?? "",
+      release_name: item.title ?? "",
+      additional_info: {
+        release_mbid: item.release_mbid,
+      },
+      mbid_mapping: {
+        artist_mbids: [],
+        recording_mbid: "",
+        release_mbid: item.release_mbid,
+        caa_id: item.caa_id ?? undefined,
+        caa_release_mbid: item.caa_release_mbid ?? undefined,
+      },
+    },
+  };
+}
+
+function ReleaseCollectionItemCard({
   item,
 }: {
   item: MusicBrainzCollectionReleaseItem;
 }) {
+  const navigate = useNavigate();
   const releaseUrl = `/release/${item.release_mbid}/`;
   const coverArtSrc =
     item.caa_id != null && item.caa_release_mbid
       ? generateAlbumArtThumbnailLink(item.caa_id, item.caa_release_mbid)
       : "/static/img/cover-art-placeholder.jpg";
 
+  const openReleasePage = () => {
+    navigate(releaseUrl);
+  };
+
   return (
-    <div className="card listen-card">
-      <div className="card-body">
-        <div className="listen-thumbnail">
-          <img
-            src={coverArtSrc}
-            alt={item.title ?? "Release cover art"}
-            width={64}
-            height={64}
-            loading="lazy"
-            onError={(event) => {
-              // eslint-disable-next-line no-param-reassign
-              event.currentTarget.src = "/static/img/cover-art-placeholder.jpg";
-            }}
-          />
-        </div>
-        <div className="listen-content">
-          <div className="title-duration">
-            <a href={releaseUrl}>{item.title ?? "Unknown release"}</a>
+    <div
+      role="link"
+      tabIndex={0}
+      className="collection-release-card-wrap"
+      onClick={openReleasePage}
+      onKeyDown={(event: React.KeyboardEvent) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openReleasePage();
+        }
+      }}
+    >
+      <ListenCard
+        className="playlist-item-card"
+        listen={asReleaseListen(item)}
+        showTimestamp={false}
+        showUsername={false}
+        compact
+        disablePlayback
+        customThumbnail={
+          <div className="listen-thumbnail">
+            <img
+              src={coverArtSrc}
+              alt={item.title ?? "Release cover art"}
+              width={56}
+              height={56}
+              loading="lazy"
+              onError={(event) => {
+                // eslint-disable-next-line no-param-reassign
+                event.currentTarget.src =
+                  "/static/img/cover-art-placeholder.jpg";
+              }}
+            />
           </div>
-          <div className="text-muted">
-            {item.artist_credit_name ?? "Unknown artist"}
-          </div>
-        </div>
-      </div>
+        }
+        listenDetails={
+          <>
+            <div title={item.title ?? "Unknown release"} className="ellipsis">
+              {item.title ?? "Unknown release"}
+            </div>
+            <div
+              className="small text-muted ellipsis"
+              title={item.artist_credit_name ?? "Unknown artist"}
+            >
+              {item.artist_credit_name ?? "Unknown artist"}
+            </div>
+          </>
+        }
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        feedbackComponent={<></>}
+      />
     </div>
   );
 }
@@ -140,8 +218,9 @@ async function fetchAllFlattenedCollectionTracks(
 ): Promise<JSPFTrack[]> {
   const allTracks: JSPFTrack[] = [];
   let offset = 0;
+  let totalCount: number | undefined;
 
-  while (true) {
+  while (allTracks.length < MAX_FLATTEN_TRACKS) {
     // eslint-disable-next-line no-await-in-loop
     const page = (await queryClient.fetchQuery(
       RouteQuery(
@@ -149,91 +228,135 @@ async function fetchAllFlattenedCollectionTracks(
         `/collection/${collectionMBID}/?count=${FLATTEN_TRACKS_PAGE_SIZE}&offset=${offset}&flatten=tracks`
       )
     )) as MusicBrainzCollectionDetailResponse;
+
+    if (totalCount === undefined) {
+      totalCount = page.track_count;
+      if (totalCount > MAX_FLATTEN_TRACKS) {
+        throw new Error(
+          `This collection is too large to save as a playlist (${totalCount} tracks; the limit is ${MAX_FLATTEN_TRACKS}).`
+        );
+      }
+    }
+
     const pageTracks = (page.tracks ?? []).map(asJSPFTrack);
-    allTracks.push(...pageTracks);
-    const nextOffset = offset + pageTracks.length;
-    if (nextOffset >= page.track_count || pageTracks.length === 0) {
+    if (pageTracks.length === 0) {
       break;
     }
-    offset = nextOffset;
+    allTracks.push(...pageTracks);
+    offset += pageTracks.length;
+    if (offset >= totalCount) {
+      break;
+    }
   }
 
   return allTracks;
 }
 
-export default function CollectionPage() {
-  const { currentUser, APIService } = React.useContext(GlobalAppContext);
-  const { collectionMBID } = useParams();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const loaderData = useLoaderData() as MusicBrainzCollectionDetailResponse;
+function CollectionShell({
+  title,
+  mbUrl,
+  coverArt,
+  visibilityLabel,
+  countLabel,
+  sectionTitle,
+  sectionAction,
+  saveButton,
+  isLoading,
+  children,
+}: {
+  title: string;
+  mbUrl?: string;
+  coverArt?: string | null;
+  visibilityLabel: React.ReactNode;
+  countLabel: string;
+  sectionTitle: string;
+  sectionAction?: React.ReactNode;
+  saveButton?: React.ReactNode;
+  isLoading: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div role="main">
+      <Helmet>
+        <title>{title} — ListenBrainz</title>
+        <meta property="og:title" content={`${title} — ListenBrainz`} />
+        {mbUrl && <meta property="og:url" content={mbUrl} />}
+      </Helmet>
 
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    isLoading,
-  } = useInfiniteQuery<
-    MusicBrainzCollectionDetailResponse,
-    Error,
-    InfiniteData<MusicBrainzCollectionDetailResponse, number>,
-    (string | undefined)[],
-    number
-  >({
-    queryKey: ["collection", collectionMBID],
-    queryFn: ({ pageParam = 0 }) =>
-      queryClient.fetchQuery(
-        RouteQuery(
-          ["collection", collectionMBID, pageParam],
-          `/collection/${collectionMBID}/?count=${DEFAULT_PAGE_SIZE}&offset=${pageParam}`
-        )
-      ),
-    getNextPageParam: (lastPage, pages) => {
-      const loaded = getLoadedCount(pages, lastPage.collection.entity_type);
-      return loaded < lastPage.track_count ? loaded : undefined;
-    },
-    initialPageParam: 0,
-    initialData: {
-      pages: [loaderData],
-      pageParams: [0],
-    },
-  });
+      <div className="entity-page-header flex">
+        <div
+          className="cover-art"
+          title={title}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(
+              coverArt ??
+                "<img src='/static/img/cover-art-placeholder.jpg' alt='Collection cover' />"
+            ),
+          }}
+        />
+        <div className="playlist-info">
+          <h1>{title}</h1>
+          <div className="details h4">
+            <div>
+              {visibilityLabel}
+              {mbUrl && (
+                <>
+                  {" "}
+                  ·{" "}
+                  <a href={mbUrl} target="_blank" rel="noreferrer">
+                    View on MusicBrainz
+                  </a>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="details">
+            <div>{countLabel}</div>
+          </div>
+        </div>
+        <div className="right-side">{saveButton}</div>
+      </div>
 
-  const firstPage = data?.pages[0];
-  const collection = firstPage?.collection;
-  const coverArt = firstPage?.cover_art;
-  const itemCount = firstPage?.track_count ?? 0;
-  const entityType: MusicBrainzCollectionEntityType | undefined =
-    collection?.entity_type;
-  const isRecordingCollection = entityType === "recording";
-  const isReleaseCollection = entityType === "release";
-  const itemLabel = isReleaseCollection ? "release" : "track";
-  const itemsLabel = isReleaseCollection ? "releases" : "tracks";
-  const sectionTitle = isReleaseCollection ? "Releases" : "Tracks";
-
-  const tracks = React.useMemo(
-    () =>
-      (data?.pages ?? []).flatMap((page) => page.tracks ?? []).map(asJSPFTrack),
-    [data]
+      <div className="col-md-8 offset-md-2">
+        <div className="header">
+          <h3 className="header-with-line">
+            {sectionTitle}
+            {sectionAction}
+          </h3>
+        </div>
+        <Loader isLoading={isLoading} />
+        {children}
+      </div>
+    </div>
   );
-  const releases = React.useMemo(
-    () => (data?.pages ?? []).flatMap((page) => page.items ?? []),
-    [data]
-  );
-  const loadedRowCount = isReleaseCollection ? releases.length : tracks.length;
+}
 
-  const [isSaving, setIsSaving] = React.useState(false);
-  const [isPlayingAll, setIsPlayingAll] = React.useState(false);
-
+function VirtualizedCollectionList<T>({
+  items,
+  estimatedRowHeightPx,
+  hasNextPage,
+  isFetchingNextPage,
+  isLoading,
+  fetchNextPage,
+  emptyMessage,
+  renderRow,
+}: {
+  items: T[];
+  estimatedRowHeightPx: number;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  isLoading: boolean;
+  fetchNextPage: FetchNextCollectionPage;
+  emptyMessage: string;
+  renderRow: (item: T, index: number) => React.ReactNode;
+}) {
+  const loadedRowCount = items.length;
   const hasMore = Boolean(hasNextPage);
   const totalRows = loadedRowCount + (hasMore ? 1 : 0);
   const rowVirtualizer = useWindowVirtualizer({
     count: totalRows,
-    estimateSize: () =>
-      isReleaseCollection
-        ? RELEASE_ROW_ESTIMATED_HEIGHT_PX
-        : DEFAULT_ESTIMATED_ROW_HEIGHT_PX,
+    estimateSize: () => estimatedRowHeightPx,
     measureElement: (el) => el.getBoundingClientRect().height,
     overscan: 6,
   });
@@ -259,6 +382,180 @@ export default function CollectionPage() {
     virtualItems,
   ]);
 
+  if (!isLoading && loadedRowCount === 0) {
+    return (
+      <div className="lead text-center">
+        <p>{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        height: rowVirtualizer.getTotalSize(),
+        position: "relative",
+        width: "100%",
+      }}
+    >
+      {virtualItems.map((virtualRow: VirtualItem) => {
+        const isLoaderRow = virtualRow.index >= loadedRowCount;
+        const item = items[virtualRow.index];
+        let rowContent: React.ReactNode = null;
+        if (isLoaderRow) {
+          rowContent = <Loader isLoading={isFetchingNextPage} />;
+        } else if (item) {
+          rowContent = renderRow(item, virtualRow.index);
+        }
+        return (
+          <div
+            key={String(virtualRow.key)}
+            ref={rowVirtualizer.measureElement}
+            data-index={virtualRow.index}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+          >
+            {rowContent}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function useSaveCollectionAsPlaylist(
+  collection: MusicBrainzCollectionDetailResponse["collection"],
+  mbUrl?: string
+) {
+  const { currentUser, APIService } = React.useContext(GlobalAppContext);
+  const navigate = useNavigate();
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const saveTracks = React.useCallback(
+    async (getTracks: () => Promise<JSPFTrack[]>) => {
+      if (!currentUser?.auth_token) {
+        toast.error(
+          <ToastMsg
+            title="Error"
+            message="You must be logged in for this operation"
+          />,
+          { toastId: "auth-error" }
+        );
+        return;
+      }
+      if (isSaving) {
+        return;
+      }
+
+      setIsSaving(true);
+      try {
+        const allTracks = await getTracks();
+        if (allTracks.length === 0) {
+          toast.error(
+            <ToastMsg
+              title="Could not create playlist"
+              message="No tracks found in this collection"
+            />,
+            { toastId: "mb-collection-import-empty" }
+          );
+          return;
+        }
+
+        const publicFlag = Boolean(collection.public);
+        const playlistTitle = collection.name;
+        const playlistObject: JSPFObject = {
+          playlist: {
+            creator: currentUser.name,
+            identifier: "",
+            date: "",
+            track: allTracks,
+            title: playlistTitle,
+            annotation: mbUrl
+              ? `Imported from MusicBrainz collection: ${mbUrl}`
+              : "Imported from MusicBrainz collection",
+            extension: {
+              [MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION]: {
+                public: publicFlag,
+                collaborators: [],
+              },
+            },
+          },
+        };
+
+        const newPlaylistId = await APIService.createPlaylist(
+          currentUser.auth_token,
+          playlistObject
+        );
+
+        toast.success(
+          <ToastMsg
+            title="Created playlist"
+            message={
+              <>
+                Created new {publicFlag ? "public" : "private"} playlist{" "}
+                <Link to={`/playlist/${newPlaylistId}/`}>{playlistTitle}</Link>
+              </>
+            }
+          />,
+          { toastId: "mb-collection-import-success" }
+        );
+        navigate(`/playlist/${newPlaylistId}/`);
+      } catch (error) {
+        toast.error(
+          <ToastMsg
+            title="Could not create playlist"
+            message={error?.message ?? error}
+          />,
+          { toastId: "mb-collection-import-error" }
+        );
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [
+      APIService,
+      collection,
+      currentUser?.auth_token,
+      currentUser?.name,
+      isSaving,
+      mbUrl,
+      navigate,
+    ]
+  );
+
+  return { isSaving, saveTracks };
+}
+
+function RecordingCollectionView({
+  collectionMBID,
+  collection,
+  coverArt,
+  itemCount,
+  data,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  isLoading,
+}: CollectionViewProps) {
+  const queryClient = useQueryClient();
+  const [isPlayingAll, setIsPlayingAll] = React.useState(false);
+  const mbUrl = `https://musicbrainz.org/collection/${collectionMBID}`;
+  const { isSaving, saveTracks } = useSaveCollectionAsPlaylist(
+    collection,
+    mbUrl
+  );
+
+  const tracks = React.useMemo(
+    () =>
+      (data?.pages ?? []).flatMap((page) => page.tracks ?? []).map(asJSPFTrack),
+    [data]
+  );
+
   const loadAllRemainingPages = React.useCallback(async () => {
     let hasMorePages = true;
     while (hasMorePages) {
@@ -268,16 +565,8 @@ export default function CollectionPage() {
     }
   }, [fetchNextPage]);
 
-  const title = collection?.name ?? "MusicBrainz collection";
-  const mbUrl = collectionMBID
-    ? `https://musicbrainz.org/collection/${collectionMBID}`
-    : undefined;
-  const collectionTypeLabel = isReleaseCollection
-    ? "release collection"
-    : "collection";
-
   const playAllTracks = React.useCallback(async () => {
-    if (!isRecordingCollection || !collectionMBID || isPlayingAll) {
+    if (isPlayingAll) {
       return;
     }
 
@@ -320,285 +609,243 @@ export default function CollectionPage() {
     collectionMBID,
     hasNextPage,
     isPlayingAll,
-    isRecordingCollection,
     loadAllRemainingPages,
     queryClient,
   ]);
 
   const saveAsPlaylist = React.useCallback(async () => {
-    if (!isRecordingCollection && !isReleaseCollection) {
+    if (tracks.length === 0) {
       return;
     }
-    if (!collectionMBID) {
-      return;
-    }
-    if (!currentUser?.auth_token) {
-      toast.error(
-        <ToastMsg
-          title="Error"
-          message="You must be logged in for this operation"
-        />,
-        { toastId: "auth-error" }
-      );
-      return;
-    }
-    if (!collection) {
-      toast.error(
-        <ToastMsg title="Error" message="Collection is not loaded yet" />,
-        { toastId: "collection-not-loaded" }
-      );
-      return;
-    }
-    if (isSaving) {
-      return;
-    }
-    if (isRecordingCollection && tracks.length === 0) {
-      return;
-    }
-    if (isReleaseCollection && releases.length === 0) {
-      return;
-    }
-
-    setIsSaving(true);
-    try {
-      let allTracks: JSPFTrack[] = [];
-      if (isReleaseCollection) {
-        allTracks = await fetchAllFlattenedCollectionTracks(
-          queryClient,
-          collectionMBID
-        );
-      } else {
-        if (hasNextPage) {
-          await loadAllRemainingPages();
-        }
-        allTracks =
-          queryClient
-            .getQueryData<
-              InfiniteData<MusicBrainzCollectionDetailResponse, number>
-            >(["collection", collectionMBID])
-            ?.pages.flatMap((page) => page.tracks ?? [])
-            .map(asJSPFTrack) ?? [];
+    await saveTracks(async () => {
+      if (hasNextPage) {
+        await loadAllRemainingPages();
       }
-
-      if (allTracks.length === 0) {
-        toast.error(
-          <ToastMsg
-            title="Could not create playlist"
-            message="No tracks found in this collection"
-          />,
-          { toastId: "mb-collection-import-empty" }
-        );
-        return;
-      }
-
-      const publicFlag = Boolean(collection.public);
-      const playlistTitle = collection.name;
-
-      const playlistObject: JSPFObject = {
-        playlist: {
-          creator: currentUser.name,
-          identifier: "",
-          date: "",
-          track: allTracks,
-          title: playlistTitle,
-          annotation: mbUrl
-            ? `Imported from MusicBrainz collection: ${mbUrl}`
-            : "Imported from MusicBrainz collection",
-          extension: {
-            [MUSICBRAINZ_JSPF_PLAYLIST_EXTENSION]: {
-              public: publicFlag,
-              collaborators: [],
-            },
-          },
-        },
-      };
-
-      const newPlaylistId = await APIService.createPlaylist(
-        currentUser.auth_token,
-        playlistObject
+      return (
+        queryClient
+          .getQueryData<
+            InfiniteData<MusicBrainzCollectionDetailResponse, number>
+          >(["collection", collectionMBID])
+          ?.pages.flatMap((page) => page.tracks ?? [])
+          .map(asJSPFTrack) ?? []
       );
-
-      toast.success(
-        <ToastMsg
-          title="Created playlist"
-          message={
-            <>
-              Created new {publicFlag ? "public" : "private"} playlist{" "}
-              <Link to={`/playlist/${newPlaylistId}/`}>{playlistTitle}</Link>
-            </>
-          }
-        />,
-        { toastId: "mb-collection-import-success" }
-      );
-      navigate(`/playlist/${newPlaylistId}/`);
-    } catch (error) {
-      toast.error(
-        <ToastMsg
-          title="Could not create playlist"
-          message={error?.message ?? error}
-        />,
-        { toastId: "mb-collection-import-error" }
-      );
-    } finally {
-      setIsSaving(false);
-    }
+    });
   }, [
-    APIService,
-    collection,
     collectionMBID,
-    currentUser?.auth_token,
-    currentUser?.name,
     hasNextPage,
-    isRecordingCollection,
-    isReleaseCollection,
-    isSaving,
     loadAllRemainingPages,
-    mbUrl,
-    navigate,
     queryClient,
-    releases.length,
+    saveTracks,
     tracks.length,
   ]);
 
   return (
-    <div role="main">
-      <Helmet>
-        <title>{title} — ListenBrainz</title>
-        <meta property="og:title" content={`${title} — ListenBrainz`} />
-        {mbUrl && <meta property="og:url" content={mbUrl} />}
-      </Helmet>
-
-      <div className="entity-page-header flex">
-        <div
-          className="cover-art"
-          title={title}
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(
-              coverArt ??
-                "<img src='/static/img/cover-art-placeholder.jpg' alt='Collection cover' />"
-            ),
-          }}
-        />
-        <div className="playlist-info">
-          <h1>{title}</h1>
-          <div className="details h4">
-            <div>
-              {collection ? (
-                <>
-                  {collection.public ? "Public" : "Private"} MusicBrainz{" "}
-                  {collectionTypeLabel}
-                </>
-              ) : (
-                <>MusicBrainz collection</>
-              )}
-              {mbUrl && (
-                <>
-                  {" "}
-                  ·{" "}
-                  <a href={mbUrl} target="_blank" rel="noreferrer">
-                    View on MusicBrainz
-                  </a>
-                </>
-              )}
-            </div>
-          </div>
-          <div className="details">
-            <div>
-              {itemCount} {itemCount === 1 ? itemLabel : itemsLabel}
-            </div>
-          </div>
-        </div>
-        <div className="right-side">
-          {(isRecordingCollection || isReleaseCollection) && (
-            <button
-              type="button"
-              className="btn btn-info"
-              disabled={
-                isLoading ||
-                isSaving ||
-                (isRecordingCollection && tracks.length === 0) ||
-                (isReleaseCollection && releases.length === 0)
-              }
-              onClick={saveAsPlaylist}
-            >
-              {isSaving ? "Saving..." : "Save as playlist"}
-            </button>
-          )}
-        </div>
-      </div>
-
-      <div className="col-md-8 offset-md-2">
-        <div className="header">
-          <h3 className="header-with-line">
-            {sectionTitle}
-            {isRecordingCollection && Boolean(itemCount) && (
-              <button
-                type="button"
-                className="btn btn-info btn-rounded play-tracks-button"
-                title="Play all tracks"
-                disabled={isLoading || isPlayingAll}
-                onClick={playAllTracks}
-              >
-                <FontAwesomeIcon icon={faPlayCircle} fixedWidth />{" "}
-                {isPlayingAll ? "Loading..." : "Play all"}
-              </button>
-            )}
-          </h3>
-        </div>
-
-        <Loader isLoading={isLoading} />
-
-        {!isLoading && loadedRowCount === 0 ? (
-          <div className="lead text-center">
-            <p>No {itemsLabel} found in this collection</p>
-          </div>
-        ) : (
-          <div
-            style={{
-              height: rowVirtualizer.getTotalSize(),
-              position: "relative",
-              width: "100%",
-            }}
+    <CollectionShell
+      title={collection.name}
+      mbUrl={mbUrl}
+      coverArt={coverArt}
+      visibilityLabel={
+        <>{collection.public ? "Public" : "Private"} MusicBrainz collection</>
+      }
+      countLabel={`${itemCount} ${itemCount === 1 ? "track" : "tracks"}`}
+      sectionTitle="Tracks"
+      isLoading={isLoading}
+      sectionAction={
+        Boolean(itemCount) && (
+          <button
+            type="button"
+            className="btn btn-info btn-rounded play-tracks-button"
+            title="Play all tracks"
+            disabled={isLoading || isPlayingAll}
+            onClick={playAllTracks}
           >
-            {virtualItems.map((virtualRow: VirtualItem) => {
-              const isLoaderRow = virtualRow.index >= loadedRowCount;
-              const track = tracks[virtualRow.index];
-              const release = releases[virtualRow.index];
-              let rowContent: React.ReactNode = null;
-              if (isLoaderRow) {
-                rowContent = <Loader isLoading={isFetchingNextPage} />;
-              } else if (isReleaseCollection && release) {
-                rowContent = <ReleaseCollectionItemRow item={release} />;
-              } else if (track) {
-                rowContent = (
-                  <PlaylistItemCard
-                    key={`${track.id}-${virtualRow.index.toString()}`}
-                    canEdit={false}
-                    track={track}
-                  />
-                );
-              }
-              return (
-                <div
-                  key={String(virtualRow.key)}
-                  ref={rowVirtualizer.measureElement}
-                  data-index={virtualRow.index}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${virtualRow.start}px)`,
-                  }}
-                >
-                  {rowContent}
-                </div>
-              );
-            })}
+            <FontAwesomeIcon icon={faPlayCircle} fixedWidth />{" "}
+            {isPlayingAll ? "Loading..." : "Play all"}
+          </button>
+        )
+      }
+      saveButton={
+        <button
+          type="button"
+          className="btn btn-info"
+          disabled={isLoading || isSaving || tracks.length === 0}
+          onClick={saveAsPlaylist}
+        >
+          {isSaving ? "Saving..." : "Save as playlist"}
+        </button>
+      }
+    >
+      <VirtualizedCollectionList
+        items={tracks}
+        estimatedRowHeightPx={DEFAULT_ESTIMATED_ROW_HEIGHT_PX}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        isLoading={isLoading}
+        fetchNextPage={fetchNextPage}
+        emptyMessage="No tracks found in this collection"
+        renderRow={(track, index) => (
+          <PlaylistItemCard
+            key={`${track.id}-${index.toString()}`}
+            canEdit={false}
+            track={track}
+          />
+        )}
+      />
+    </CollectionShell>
+  );
+}
+
+function ReleaseCollectionView({
+  collectionMBID,
+  collection,
+  coverArt,
+  itemCount,
+  data,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  isLoading,
+}: CollectionViewProps) {
+  const queryClient = useQueryClient();
+  const mbUrl = `https://musicbrainz.org/collection/${collectionMBID}`;
+  const { isSaving, saveTracks } = useSaveCollectionAsPlaylist(
+    collection,
+    mbUrl
+  );
+
+  const releases = React.useMemo(
+    () => (data?.pages ?? []).flatMap((page) => page.items ?? []),
+    [data]
+  );
+
+  const saveAsPlaylist = React.useCallback(async () => {
+    if (releases.length === 0) {
+      return;
+    }
+    await saveTracks(() =>
+      fetchAllFlattenedCollectionTracks(queryClient, collectionMBID)
+    );
+  }, [collectionMBID, queryClient, releases.length, saveTracks]);
+
+  return (
+    <CollectionShell
+      title={collection.name}
+      mbUrl={mbUrl}
+      coverArt={coverArt}
+      visibilityLabel={
+        <>
+          {collection.public ? "Public" : "Private"} MusicBrainz release
+          collection
+        </>
+      }
+      countLabel={`${itemCount} ${itemCount === 1 ? "release" : "releases"}`}
+      sectionTitle="Releases"
+      isLoading={isLoading}
+      saveButton={
+        <button
+          type="button"
+          className="btn btn-info"
+          disabled={isLoading || isSaving || releases.length === 0}
+          onClick={saveAsPlaylist}
+        >
+          {isSaving ? "Saving..." : "Save as playlist"}
+        </button>
+      }
+    >
+      <VirtualizedCollectionList
+        items={releases}
+        estimatedRowHeightPx={RELEASE_ROW_ESTIMATED_HEIGHT_PX}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        isLoading={isLoading}
+        fetchNextPage={fetchNextPage}
+        emptyMessage="No releases found in this collection"
+        renderRow={(release) => <ReleaseCollectionItemCard item={release} />}
+      />
+    </CollectionShell>
+  );
+}
+
+const COLLECTION_VIEWS: Record<
+  MusicBrainzCollectionEntityType,
+  React.FC<CollectionViewProps>
+> = {
+  recording: RecordingCollectionView,
+  release: ReleaseCollectionView,
+};
+
+export default function CollectionPage() {
+  const { collectionMBID } = useParams();
+  const queryClient = useQueryClient();
+  const loaderData = useLoaderData() as MusicBrainzCollectionDetailResponse;
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteQuery<
+    MusicBrainzCollectionDetailResponse,
+    Error,
+    InfiniteData<MusicBrainzCollectionDetailResponse, number>,
+    (string | undefined)[],
+    number
+  >({
+    queryKey: ["collection", collectionMBID],
+    queryFn: ({ pageParam = 0 }) =>
+      queryClient.fetchQuery(
+        RouteQuery(
+          ["collection", collectionMBID, pageParam],
+          `/collection/${collectionMBID}/?count=${DEFAULT_PAGE_SIZE}&offset=${pageParam}`
+        )
+      ),
+    getNextPageParam: (lastPage, pages) => {
+      const loaded = getLoadedCount(pages, lastPage.collection.entity_type);
+      return loaded < lastPage.track_count ? loaded : undefined;
+    },
+    initialPageParam: 0,
+    initialData: {
+      pages: [loaderData],
+      pageParams: [0],
+    },
+  });
+
+  const firstPage = data?.pages[0];
+  const collection = firstPage?.collection;
+  const entityType = collection?.entity_type;
+  const CollectionView = entityType ? COLLECTION_VIEWS[entityType] : undefined;
+
+  if (!collectionMBID || !collection || !CollectionView) {
+    return (
+      <CollectionShell
+        title={collection?.name ?? "MusicBrainz collection"}
+        coverArt={firstPage?.cover_art}
+        visibilityLabel="MusicBrainz collection"
+        countLabel=""
+        sectionTitle="Items"
+        isLoading={isLoading}
+      >
+        {!isLoading && (
+          <div className="lead text-center">
+            <p>No items found in this collection</p>
           </div>
         )}
-      </div>
-    </div>
+      </CollectionShell>
+    );
+  }
+
+  return (
+    <CollectionView
+      collectionMBID={collectionMBID}
+      collection={collection}
+      coverArt={firstPage?.cover_art}
+      itemCount={firstPage?.track_count ?? 0}
+      data={data}
+      fetchNextPage={fetchNextPage}
+      hasNextPage={Boolean(hasNextPage)}
+      isFetchingNextPage={isFetchingNextPage}
+      isLoading={isLoading}
+    />
   );
 }

--- a/frontend/js/src/collections/Collection.tsx
+++ b/frontend/js/src/collections/Collection.tsx
@@ -4,6 +4,7 @@ import { faPlayCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   InfiniteData,
+  QueryClient,
   useInfiniteQuery,
   useQueryClient,
 } from "@tanstack/react-query";
@@ -34,6 +35,7 @@ import type {
 } from "../utils/APIService";
 
 const DEFAULT_PAGE_SIZE = 100;
+const FLATTEN_TRACKS_PAGE_SIZE = 500;
 const DEFAULT_ESTIMATED_ROW_HEIGHT_PX = 110;
 const RELEASE_ROW_ESTIMATED_HEIGHT_PX = 72;
 const LOAD_MORE_THRESHOLD_ROWS = 20;
@@ -141,6 +143,33 @@ function getLoadedCount(
     return (pages ?? []).flatMap((page) => page.items ?? []).length;
   }
   return (pages ?? []).flatMap((page) => page.tracks ?? []).length;
+}
+
+async function fetchAllFlattenedCollectionTracks(
+  queryClient: QueryClient,
+  collectionMBID: string
+): Promise<JSPFTrack[]> {
+  const allTracks: JSPFTrack[] = [];
+  let offset = 0;
+
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const page = (await queryClient.fetchQuery(
+      RouteQuery(
+        ["collection", collectionMBID, "flatten", offset],
+        `/collection/${collectionMBID}/?count=${FLATTEN_TRACKS_PAGE_SIZE}&offset=${offset}&flatten=tracks`
+      )
+    )) as MusicBrainzCollectionDetailResponse;
+    const pageTracks = (page.tracks ?? []).map(asJSPFTrack);
+    allTracks.push(...pageTracks);
+    const nextOffset = offset + pageTracks.length;
+    if (nextOffset >= page.track_count || pageTracks.length === 0) {
+      break;
+    }
+    offset = nextOffset;
+  }
+
+  return allTracks;
 }
 
 export default function CollectionPage() {
@@ -308,7 +337,7 @@ export default function CollectionPage() {
   ]);
 
   const saveAsPlaylist = React.useCallback(async () => {
-    if (!isRecordingCollection) {
+    if (!isRecordingCollection && !isReleaseCollection) {
       return;
     }
     if (!collectionMBID) {
@@ -334,19 +363,44 @@ export default function CollectionPage() {
     if (isSaving) {
       return;
     }
+    if (isRecordingCollection && tracks.length === 0) {
+      return;
+    }
+    if (isReleaseCollection && releases.length === 0) {
+      return;
+    }
 
     setIsSaving(true);
     try {
-      if (hasNextPage) {
-        await loadAllRemainingPages();
+      let allTracks: JSPFTrack[] = [];
+      if (isReleaseCollection) {
+        allTracks = await fetchAllFlattenedCollectionTracks(
+          queryClient,
+          collectionMBID
+        );
+      } else {
+        if (hasNextPage) {
+          await loadAllRemainingPages();
+        }
+        allTracks =
+          queryClient
+            .getQueryData<
+              InfiniteData<MusicBrainzCollectionDetailResponse, number>
+            >(["collection", collectionMBID])
+            ?.pages.flatMap((page) => page.tracks ?? [])
+            .map(asJSPFTrack) ?? [];
       }
-      const allTracks =
-        queryClient
-          .getQueryData<
-            InfiniteData<MusicBrainzCollectionDetailResponse, number>
-          >(["collection", collectionMBID])
-          ?.pages.flatMap((page) => page.tracks ?? [])
-          .map(asJSPFTrack) ?? [];
+
+      if (allTracks.length === 0) {
+        toast.error(
+          <ToastMsg
+            title="Could not create playlist"
+            message="No tracks found in this collection"
+          />,
+          { toastId: "mb-collection-import-empty" }
+        );
+        return;
+      }
 
       const publicFlag = Boolean(collection.public);
       const playlistTitle = collection.name;
@@ -407,11 +461,14 @@ export default function CollectionPage() {
     currentUser?.name,
     hasNextPage,
     isRecordingCollection,
+    isReleaseCollection,
     isSaving,
     loadAllRemainingPages,
     mbUrl,
     navigate,
     queryClient,
+    releases.length,
+    tracks.length,
   ]);
 
   return (
@@ -464,11 +521,16 @@ export default function CollectionPage() {
           </div>
         </div>
         <div className="right-side">
-          {isRecordingCollection && (
+          {(isRecordingCollection || isReleaseCollection) && (
             <button
               type="button"
               className="btn btn-info"
-              disabled={isLoading || isSaving || tracks.length === 0}
+              disabled={
+                isLoading ||
+                isSaving ||
+                (isRecordingCollection && tracks.length === 0) ||
+                (isReleaseCollection && releases.length === 0)
+              }
               onClick={saveAsPlaylist}
             >
               {isSaving ? "Saving..." : "Save as playlist"}
@@ -514,6 +576,20 @@ export default function CollectionPage() {
               const isLoaderRow = virtualRow.index >= loadedRowCount;
               const track = tracks[virtualRow.index];
               const release = releases[virtualRow.index];
+              let rowContent: React.ReactNode = null;
+              if (isLoaderRow) {
+                rowContent = <Loader isLoading={isFetchingNextPage} />;
+              } else if (isReleaseCollection && release) {
+                rowContent = <ReleaseCollectionItemRow item={release} />;
+              } else if (track) {
+                rowContent = (
+                  <PlaylistItemCard
+                    key={`${track.id}-${virtualRow.index.toString()}`}
+                    canEdit={false}
+                    track={track}
+                  />
+                );
+              }
               return (
                 <div
                   key={String(virtualRow.key)}
@@ -527,19 +603,7 @@ export default function CollectionPage() {
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
                 >
-                  {isLoaderRow ? (
-                    <Loader isLoading={isFetchingNextPage} />
-                  ) : isReleaseCollection && release ? (
-                    <ReleaseCollectionItemRow item={release} />
-                  ) : (
-                    track && (
-                      <PlaylistItemCard
-                        key={`${track.id}-${virtualRow.index.toString()}`}
-                        canEdit={false}
-                        track={track}
-                      />
-                    )
-                  )}
+                  {rowContent}
                 </div>
               );
             })}

--- a/frontend/js/src/collections/Collection.tsx
+++ b/frontend/js/src/collections/Collection.tsx
@@ -28,11 +28,14 @@ import { RouteQuery } from "../utils/Loader";
 
 import type {
   MusicBrainzCollectionDetailResponse,
+  MusicBrainzCollectionEntityType,
+  MusicBrainzCollectionReleaseItem,
   MusicBrainzCollectionTrack,
 } from "../utils/APIService";
 
 const DEFAULT_PAGE_SIZE = 100;
 const DEFAULT_ESTIMATED_ROW_HEIGHT_PX = 110;
+const RELEASE_ROW_ESTIMATED_HEIGHT_PX = 72;
 const LOAD_MORE_THRESHOLD_ROWS = 20;
 
 function asJSPFTrack(track: MusicBrainzCollectionTrack): JSPFTrack {
@@ -78,6 +81,68 @@ function asJSPFTrack(track: MusicBrainzCollectionTrack): JSPFTrack {
   return jspfTrack;
 }
 
+function formatReleaseDate(
+  item: MusicBrainzCollectionReleaseItem
+): string | null {
+  const { date_year: year, date_month: month, date_day: day } = item;
+  if (year == null) {
+    return null;
+  }
+  if (month != null && day != null) {
+    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(
+      2,
+      "0"
+    )}`;
+  }
+  if (month != null) {
+    return `${year}-${String(month).padStart(2, "0")}`;
+  }
+  return String(year);
+}
+
+function ReleaseCollectionItemRow({
+  item,
+}: {
+  item: MusicBrainzCollectionReleaseItem;
+}) {
+  const releaseUrl = `/release/${item.release_mbid}/`;
+  const dateLabel = formatReleaseDate(item);
+
+  return (
+    <div className="card listen-card">
+      <div className="card-body">
+        <div className="listen-thumbnail">
+          <img
+            src="/static/img/cover-art-placeholder.jpg"
+            alt=""
+            width={64}
+            height={64}
+          />
+        </div>
+        <div className="listen-content">
+          <div className="title-duration">
+            <a href={releaseUrl}>{item.title ?? "Unknown release"}</a>
+          </div>
+          <div className="text-muted">
+            {item.artist_credit_name ?? "Unknown artist"}
+            {dateLabel ? ` · ${dateLabel}` : ""}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getLoadedCount(
+  pages: MusicBrainzCollectionDetailResponse[] | undefined,
+  entityType: MusicBrainzCollectionEntityType | undefined
+): number {
+  if (entityType === "release") {
+    return (pages ?? []).flatMap((page) => page.items ?? []).length;
+  }
+  return (pages ?? []).flatMap((page) => page.tracks ?? []).length;
+}
+
 export default function CollectionPage() {
   const { currentUser, APIService } = React.useContext(GlobalAppContext);
   const { collectionMBID } = useParams();
@@ -107,7 +172,7 @@ export default function CollectionPage() {
         )
       ),
     getNextPageParam: (lastPage, pages) => {
-      const loaded = pages.flatMap((page) => page.tracks ?? []).length;
+      const loaded = getLoadedCount(pages, lastPage.collection.entity_type);
       return loaded < lastPage.track_count ? loaded : undefined;
     },
     initialPageParam: 0,
@@ -120,23 +185,37 @@ export default function CollectionPage() {
   const firstPage = data?.pages[0];
   const collection = firstPage?.collection;
   const coverArt = firstPage?.cover_art;
-  const trackCount = firstPage?.track_count ?? 0;
+  const itemCount = firstPage?.track_count ?? 0;
+  const entityType: MusicBrainzCollectionEntityType | undefined =
+    collection?.entity_type;
+  const isRecordingCollection = entityType === "recording";
+  const isReleaseCollection = entityType === "release";
+  const itemLabel = isReleaseCollection ? "release" : "track";
+  const itemsLabel = isReleaseCollection ? "releases" : "tracks";
+  const sectionTitle = isReleaseCollection ? "Releases" : "Tracks";
+
   const tracks = React.useMemo(
     () =>
       (data?.pages ?? []).flatMap((page) => page.tracks ?? []).map(asJSPFTrack),
     [data]
   );
+  const releases = React.useMemo(
+    () => (data?.pages ?? []).flatMap((page) => page.items ?? []),
+    [data]
+  );
+  const loadedRowCount = isReleaseCollection ? releases.length : tracks.length;
 
   const [isSaving, setIsSaving] = React.useState(false);
   const [isPlayingAll, setIsPlayingAll] = React.useState(false);
 
   const hasMore = Boolean(hasNextPage);
-  const totalRows = tracks.length + (hasMore ? 1 : 0); // +1 row for loader
+  const totalRows = loadedRowCount + (hasMore ? 1 : 0);
   const rowVirtualizer = useWindowVirtualizer({
     count: totalRows,
-    estimateSize: () => DEFAULT_ESTIMATED_ROW_HEIGHT_PX,
-    // PlaylistItemCard height varies depending on metadata/menu.
-    // Measure real heights to avoid visual gaps between rows since virtualization is used.
+    estimateSize: () =>
+      isReleaseCollection
+        ? RELEASE_ROW_ESTIMATED_HEIGHT_PX
+        : DEFAULT_ESTIMATED_ROW_HEIGHT_PX,
     measureElement: (el) => el.getBoundingClientRect().height,
     overscan: 6,
   });
@@ -150,11 +229,17 @@ export default function CollectionPage() {
     if (!last) {
       return;
     }
-    if (last.index >= tracks.length - LOAD_MORE_THRESHOLD_ROWS) {
+    if (last.index >= loadedRowCount - LOAD_MORE_THRESHOLD_ROWS) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       fetchNextPage();
     }
-  }, [fetchNextPage, hasMore, isFetchingNextPage, tracks.length, virtualItems]);
+  }, [
+    fetchNextPage,
+    hasMore,
+    isFetchingNextPage,
+    loadedRowCount,
+    virtualItems,
+  ]);
 
   const loadAllRemainingPages = React.useCallback(async () => {
     let hasMorePages = true;
@@ -169,9 +254,12 @@ export default function CollectionPage() {
   const mbUrl = collectionMBID
     ? `https://musicbrainz.org/collection/${collectionMBID}`
     : undefined;
+  const collectionTypeLabel = isReleaseCollection
+    ? "release collection"
+    : "collection";
 
   const playAllTracks = React.useCallback(async () => {
-    if (!collectionMBID || isPlayingAll) {
+    if (!isRecordingCollection || !collectionMBID || isPlayingAll) {
       return;
     }
 
@@ -214,11 +302,15 @@ export default function CollectionPage() {
     collectionMBID,
     hasNextPage,
     isPlayingAll,
+    isRecordingCollection,
     loadAllRemainingPages,
     queryClient,
   ]);
 
   const saveAsPlaylist = React.useCallback(async () => {
+    if (!isRecordingCollection) {
+      return;
+    }
     if (!collectionMBID) {
       return;
     }
@@ -261,7 +353,6 @@ export default function CollectionPage() {
 
       const playlistObject: JSPFObject = {
         playlist: {
-          // Required fields for TS types; backend only uses title + identifiers.
           creator: currentUser.name,
           identifier: "",
           date: "",
@@ -315,6 +406,7 @@ export default function CollectionPage() {
     currentUser?.auth_token,
     currentUser?.name,
     hasNextPage,
+    isRecordingCollection,
     isSaving,
     loadAllRemainingPages,
     mbUrl,
@@ -348,8 +440,8 @@ export default function CollectionPage() {
             <div>
               {collection ? (
                 <>
-                  {collection.public ? "Public" : "Private"} MusicBrainz
-                  collection
+                  {collection.public ? "Public" : "Private"} MusicBrainz{" "}
+                  {collectionTypeLabel}
                 </>
               ) : (
                 <>MusicBrainz collection</>
@@ -367,27 +459,29 @@ export default function CollectionPage() {
           </div>
           <div className="details">
             <div>
-              {trackCount} {trackCount === 1 ? "track" : "tracks"}
+              {itemCount} {itemCount === 1 ? itemLabel : itemsLabel}
             </div>
           </div>
         </div>
         <div className="right-side">
-          <button
-            type="button"
-            className="btn btn-info"
-            disabled={isLoading || isSaving || tracks.length === 0}
-            onClick={saveAsPlaylist}
-          >
-            {isSaving ? "Saving..." : "Save as playlist"}
-          </button>
+          {isRecordingCollection && (
+            <button
+              type="button"
+              className="btn btn-info"
+              disabled={isLoading || isSaving || tracks.length === 0}
+              onClick={saveAsPlaylist}
+            >
+              {isSaving ? "Saving..." : "Save as playlist"}
+            </button>
+          )}
         </div>
       </div>
 
       <div className="col-md-8 offset-md-2">
         <div className="header">
           <h3 className="header-with-line">
-            Tracks
-            {Boolean(trackCount) && (
+            {sectionTitle}
+            {isRecordingCollection && Boolean(itemCount) && (
               <button
                 type="button"
                 className="btn btn-info btn-rounded play-tracks-button"
@@ -404,9 +498,9 @@ export default function CollectionPage() {
 
         <Loader isLoading={isLoading} />
 
-        {!isLoading && tracks.length === 0 ? (
+        {!isLoading && loadedRowCount === 0 ? (
           <div className="lead text-center">
-            <p>No tracks found in this collection</p>
+            <p>No {itemsLabel} found in this collection</p>
           </div>
         ) : (
           <div
@@ -417,8 +511,9 @@ export default function CollectionPage() {
             }}
           >
             {virtualItems.map((virtualRow: VirtualItem) => {
-              const isLoaderRow = virtualRow.index >= tracks.length;
+              const isLoaderRow = virtualRow.index >= loadedRowCount;
               const track = tracks[virtualRow.index];
+              const release = releases[virtualRow.index];
               return (
                 <div
                   key={String(virtualRow.key)}
@@ -434,12 +529,16 @@ export default function CollectionPage() {
                 >
                   {isLoaderRow ? (
                     <Loader isLoading={isFetchingNextPage} />
+                  ) : isReleaseCollection && release ? (
+                    <ReleaseCollectionItemRow item={release} />
                   ) : (
-                    <PlaylistItemCard
-                      key={`${track.id}-${virtualRow.index.toString()}`}
-                      canEdit={false}
-                      track={track}
-                    />
+                    track && (
+                      <PlaylistItemCard
+                        key={`${track.id}-${virtualRow.index.toString()}`}
+                        canEdit={false}
+                        track={track}
+                      />
+                    )
                   )}
                 </div>
               );

--- a/frontend/js/src/collections/Collection.tsx
+++ b/frontend/js/src/collections/Collection.tsx
@@ -26,6 +26,7 @@ import {
   PLAYLIST_TRACK_URI_PREFIX,
 } from "../playlists/utils";
 import { RouteQuery } from "../utils/Loader";
+import { generateAlbumArtThumbnailLink } from "../utils/utils";
 
 import type {
   MusicBrainzCollectionDetailResponse,
@@ -83,42 +84,31 @@ function asJSPFTrack(track: MusicBrainzCollectionTrack): JSPFTrack {
   return jspfTrack;
 }
 
-function formatReleaseDate(
-  item: MusicBrainzCollectionReleaseItem
-): string | null {
-  const { date_year: year, date_month: month, date_day: day } = item;
-  if (year == null) {
-    return null;
-  }
-  if (month != null && day != null) {
-    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(
-      2,
-      "0"
-    )}`;
-  }
-  if (month != null) {
-    return `${year}-${String(month).padStart(2, "0")}`;
-  }
-  return String(year);
-}
-
 function ReleaseCollectionItemRow({
   item,
 }: {
   item: MusicBrainzCollectionReleaseItem;
 }) {
   const releaseUrl = `/release/${item.release_mbid}/`;
-  const dateLabel = formatReleaseDate(item);
+  const coverArtSrc =
+    item.caa_id != null && item.caa_release_mbid
+      ? generateAlbumArtThumbnailLink(item.caa_id, item.caa_release_mbid)
+      : "/static/img/cover-art-placeholder.jpg";
 
   return (
     <div className="card listen-card">
       <div className="card-body">
         <div className="listen-thumbnail">
           <img
-            src="/static/img/cover-art-placeholder.jpg"
-            alt=""
+            src={coverArtSrc}
+            alt={item.title ?? "Release cover art"}
             width={64}
             height={64}
+            loading="lazy"
+            onError={(event) => {
+              // eslint-disable-next-line no-param-reassign
+              event.currentTarget.src = "/static/img/cover-art-placeholder.jpg";
+            }}
           />
         </div>
         <div className="listen-content">
@@ -127,7 +117,6 @@ function ReleaseCollectionItemRow({
           </div>
           <div className="text-muted">
             {item.artist_credit_name ?? "Unknown artist"}
-            {dateLabel ? ` · ${dateLabel}` : ""}
           </div>
         </div>
       </div>

--- a/frontend/js/src/common/listens/ListenCard.tsx
+++ b/frontend/js/src/common/listens/ListenCard.tsx
@@ -96,6 +96,8 @@ export type ListenCardProps = {
   additionalMenuItems?: JSX.Element[];
   // This optional JSX element is for a custom icon
   additionalActions?: JSX.Element;
+  // Hide play button
+  disablePlayback?: boolean;
 };
 
 export default function ListenCard(props: ListenCardProps) {
@@ -113,6 +115,7 @@ export default function ListenCard(props: ListenCardProps) {
     feedbackComponent,
     additionalMenuItems,
     additionalActions,
+    disablePlayback,
     ...otherProps
   } = props;
 
@@ -285,7 +288,8 @@ export default function ListenCard(props: ListenCardProps) {
   const hideActionsMenu = compact || !hasActionOptions;
 
   const renderBrainzplayer =
-    userPreferences?.brainzplayer?.brainzplayerEnabled ?? true;
+    !disablePlayback &&
+    (userPreferences?.brainzplayer?.brainzplayerEnabled ?? true);
 
   const isCurrentUsersListen =
     !!currentUser?.name && displayListen.user_name === currentUser.name;

--- a/frontend/js/src/user/playlists/components/ImportMusicBrainzCollectionModal.tsx
+++ b/frontend/js/src/user/playlists/components/ImportMusicBrainzCollectionModal.tsx
@@ -82,7 +82,7 @@ export default NiceModal.create(() => {
         >
           {!isLoading && collections.length === 0 ? (
             <p className="text-center text-muted mb-0">
-              No recording collections found
+              No recording or release collections found
             </p>
           ) : (
             collections.map((collection) => (
@@ -95,7 +95,10 @@ export default NiceModal.create(() => {
               >
                 <div style={{ fontWeight: 600 }}>{collection.name}</div>
                 <div className="text-muted">
-                  {collection.item_count} recordings
+                  {collection.item_count}{" "}
+                  {collection.entity_type === "release"
+                    ? "releases"
+                    : "recordings"}
                 </div>
               </button>
             ))

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -45,9 +45,8 @@ export type MusicBrainzCollectionReleaseItem = {
   release_mbid: string;
   title: string | null;
   artist_credit_name: string | null;
-  date_year: number | null;
-  date_month: number | null;
-  date_day: number | null;
+  caa_id?: number | null;
+  caa_release_mbid?: string | null;
 };
 
 export type MusicBrainzCollectionDetailResponse = {

--- a/frontend/js/src/utils/APIService.ts
+++ b/frontend/js/src/utils/APIService.ts
@@ -14,10 +14,13 @@ export interface LBRadioResponse {
   payload: { jspf: JSPFObject; feedback: string[] };
 }
 
+export type MusicBrainzCollectionEntityType = "recording" | "release";
+
 export type MusicBrainzCollectionSummary = {
   mbid: string;
   name: string;
   public: boolean;
+  entity_type: MusicBrainzCollectionEntityType;
   item_count: number;
 };
 
@@ -38,16 +41,27 @@ export type MusicBrainzCollectionTrack = {
   }> | null;
 };
 
+export type MusicBrainzCollectionReleaseItem = {
+  release_mbid: string;
+  title: string | null;
+  artist_credit_name: string | null;
+  date_year: number | null;
+  date_month: number | null;
+  date_day: number | null;
+};
+
 export type MusicBrainzCollectionDetailResponse = {
   collection: {
     mbid: string;
     name: string;
     public: boolean;
+    entity_type: MusicBrainzCollectionEntityType;
   };
   track_count: number;
   count: number;
   offset: number;
   tracks: MusicBrainzCollectionTrack[];
+  items: MusicBrainzCollectionReleaseItem[];
   cover_art?: string | null;
 };
 

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -160,12 +160,11 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
                         "release_mbid": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
                         "title": "Example Album",
                         "artist_credit_name": "Example Artist",
-                        "date_year": 2020,
-                        "date_month": 5,
-                        "date_day": 1,
+                        "caa_id": 12345,
+                        "caa_release_mbid": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
                     },
                 ],
-                "cover_art": None,
+                "cover_art": "<svg></svg>",
             },
             None,
         )
@@ -186,6 +185,12 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
             response.json["items"][0]["release_mbid"],
             "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
         )
+        self.assertEqual(response.json["items"][0]["caa_id"], 12345)
+        self.assertEqual(
+            response.json["items"][0]["caa_release_mbid"],
+            "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+        )
+        self.assertEqual(response.json["cover_art"], "<svg></svg>")
 
     @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
     def test_release_collection_flatten_tracks_returns_recordings(self, mock_connect):

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -187,6 +187,70 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
             "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
         )
 
+    @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
+    def test_release_collection_flatten_tracks_returns_recordings(self, mock_connect):
+        fake_cursor = mock.MagicMock()
+
+        fake_cursor.fetchone.side_effect = [
+            {
+                "collection_id": 456,
+                "collection_mbid": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+                "name": "My Albums",
+                "public": True,
+                "owner_editor_id": 1,
+                "entity_type": "release",
+            },
+            {"track_count": 3},
+        ]
+
+        fake_cursor.fetchall.return_value = [
+            {
+                "recording_mbid": "11111111-1111-1111-1111-111111111111",
+                "title": "Track One",
+                "artist_credit_name": "Example Artist",
+                "length": 180000,
+                "release_mbid": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+                "release_name": "Example Album",
+            },
+            {
+                "recording_mbid": "22222222-2222-2222-2222-222222222222",
+                "title": "Track Two",
+                "artist_credit_name": "Example Artist",
+                "length": 200000,
+                "release_mbid": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+                "release_name": "Example Album",
+            },
+        ]
+
+        mock_conn = mock.MagicMock()
+        mock_connect.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = fake_cursor
+
+        response = self.client.post(
+            self.custom_url_for(
+                "collection.load_collection",
+                collection_mbid="dddddddd-dddd-dddd-dddd-dddddddddddd",
+            )
+            + "?flatten=tracks"
+        )
+
+        self.assert200(response)
+        data = response.json
+        track = data["tracks"][0]
+        self.assertEqual(data["collection"]["entity_type"], "release")
+        self.assertEqual(data["track_count"], 3)
+        self.assertEqual(data["items"], [])
+        self.assertEqual(len(data["tracks"]), 2)
+        self.assertEqual(
+            track["recording_mbid"],
+            "11111111-1111-1111-1111-111111111111",
+        )
+        self.assertEqual(
+            track["release_mbid"],
+            "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+        )
+        self.assertEqual(track["release_name"], "Example Album")
+
     @mock.patch("listenbrainz.webserver.views.collection.fetch_collection_payload")
     def test_private_collection_requires_login(self, mock_fetch):
         mock_fetch.return_value = (

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -192,6 +192,7 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
         )
         self.assertEqual(response.json["cover_art"], "<svg></svg>")
 
+    @mock.patch("listenbrainz.webserver.views.collection.DictCursor", new=mock.MagicMock)
     @mock.patch("listenbrainz.webserver.views.collection.psycopg2.connect")
     def test_release_collection_flatten_tracks_returns_recordings(self, mock_connect):
         fake_cursor = mock.MagicMock()
@@ -227,9 +228,19 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
             },
         ]
 
-        mock_conn = mock.MagicMock()
-        mock_connect.return_value.__enter__.return_value = mock_conn
-        mock_conn.cursor.return_value.__enter__.return_value = fake_cursor
+        fake_mb_conn = mock.MagicMock()
+        fake_mb_conn.__enter__.return_value.cursor.return_value.__enter__.return_value = (
+            fake_cursor
+        )
+
+        mb_dsn = self.app.config["MB_DATABASE_URI"]
+
+        def connect_side_effect(*args, **kwargs):
+            if args and args[0] == mb_dsn:
+                return fake_mb_conn
+            return _REAL_PSYCOPG2_CONNECT(*args, **kwargs)
+
+        mock_connect.side_effect = connect_side_effect
 
         response = self.client.post(
             self.custom_url_for(

--- a/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
+++ b/listenbrainz/tests/integration/test_musicbrainz_collections_import.py
@@ -32,13 +32,15 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
                 "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 "name": "Road Trip Songs",
                 "public": True,
+                "entity_type": "recording",
                 "item_count": 2,
             },
             {
                 "mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                "name": "Private Favorites",
-                "public": False,
-                "item_count": 0,
+                "name": "My Albums",
+                "public": True,
+                "entity_type": "release",
+                "item_count": 3,
             },
         ]
 
@@ -70,13 +72,15 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
                     "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "name": "Road Trip Songs",
                     "public": True,
+                    "entity_type": "recording",
                     "item_count": 2,
                 },
                 {
                     "mbid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-                    "name": "Private Favorites",
-                    "public": False,
-                    "item_count": 0,
+                    "name": "My Albums",
+                    "public": True,
+                    "entity_type": "release",
+                    "item_count": 3,
                 },
             ],
         )
@@ -89,6 +93,7 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
                     "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                     "name": "Road Trip Songs",
                     "public": True,
+                    "entity_type": "recording",
                 },
                 "track_count": 1,
                 "count": 100,
@@ -103,6 +108,7 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
                         "caa_release_mbid": "dddddddd-dddd-dddd-dddd-dddddddddddd",
                     }
                 ],
+                "items": [],
                 "cover_art": "<svg></svg>",
             },
             None,
@@ -122,8 +128,10 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
         )
         self.assertEqual(response.json["collection"]["name"], "Road Trip Songs")
         self.assertEqual(response.json["collection"]["public"], True)
+        self.assertEqual(response.json["collection"]["entity_type"], "recording")
         self.assertEqual(response.json["track_count"], 1)
         self.assertEqual(len(response.json["tracks"]), 1)
+        self.assertEqual(response.json["items"], [])
         self.assertEqual(response.json["tracks"][0]["caa_id"], 12345)
         self.assertEqual(
             response.json["tracks"][0]["caa_release_mbid"],
@@ -132,6 +140,52 @@ class MusicBrainzCollectionsImportTestCase(IntegrationTestCase):
         self.assertEqual(response.json["cover_art"], "<svg></svg>")
         mock_fetch.assert_called_once()
         self.assertIsNone(mock_fetch.call_args.kwargs["viewer_editor_id"])
+
+    @mock.patch("listenbrainz.webserver.views.collection.fetch_collection_payload")
+    def test_public_release_collection_returns_release_items(self, mock_fetch):
+        mock_fetch.return_value = (
+            {
+                "collection": {
+                    "mbid": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+                    "name": "My Albums",
+                    "public": True,
+                    "entity_type": "release",
+                },
+                "track_count": 2,
+                "count": 100,
+                "offset": 0,
+                "tracks": [],
+                "items": [
+                    {
+                        "release_mbid": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+                        "title": "Example Album",
+                        "artist_credit_name": "Example Artist",
+                        "date_year": 2020,
+                        "date_month": 5,
+                        "date_day": 1,
+                    },
+                ],
+                "cover_art": None,
+            },
+            None,
+        )
+
+        response = self.client.post(
+            self.custom_url_for(
+                "collection.load_collection",
+                collection_mbid="dddddddd-dddd-dddd-dddd-dddddddddddd",
+            )
+        )
+
+        self.assert200(response)
+        self.assertEqual(response.json["collection"]["entity_type"], "release")
+        self.assertEqual(response.json["track_count"], 2)
+        self.assertEqual(response.json["tracks"], [])
+        self.assertEqual(len(response.json["items"]), 1)
+        self.assertEqual(
+            response.json["items"][0]["release_mbid"],
+            "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+        )
 
     @mock.patch("listenbrainz.webserver.views.collection.fetch_collection_payload")
     def test_private_collection_requires_login(self, mock_fetch):

--- a/listenbrainz/webserver/views/collection.py
+++ b/listenbrainz/webserver/views/collection.py
@@ -1,7 +1,7 @@
 import psycopg2
 from psycopg2.extras import DictCursor
 
-from flask import Blueprint, current_app, jsonify, render_template
+from flask import Blueprint, current_app, jsonify, render_template, request
 from flask_login import current_user
 
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
@@ -89,6 +89,59 @@ def _fetch_release_collection_item_count(mb_curs, collection_id: int) -> int:
     )
     row = mb_curs.fetchone()
     return int(row["item_count"] or 0)
+
+
+def _fetch_release_collection_flattened_track_count(mb_curs, collection_id: int) -> int:
+    mb_curs.execute(
+        """
+          SELECT COUNT(*)::int AS track_count
+            FROM musicbrainz.editor_collection_release ecrel
+            JOIN musicbrainz.release rel
+              ON rel.id = ecrel.release
+            JOIN musicbrainz.medium m
+              ON m.release = rel.id
+            JOIN musicbrainz.track t
+              ON t.medium = m.id
+            JOIN musicbrainz.recording r
+              ON r.id = t.recording
+           WHERE ecrel.collection = %s
+        """,
+        (collection_id,),
+    )
+    row = mb_curs.fetchone()
+    return int(row["track_count"] or 0)
+
+
+def _fetch_release_collection_flattened_tracks(mb_curs, collection_id: int, *, count: int, offset: int):
+    mb_curs.execute(
+        """
+          SELECT r.gid::text AS recording_mbid
+               , r.name AS title
+               , r.length AS length
+               , ac.name AS artist_credit_name
+               , rel.gid::text AS release_mbid
+               , rel.name AS release_name
+            FROM musicbrainz.editor_collection_release ecrel
+            JOIN musicbrainz.release rel
+              ON rel.id = ecrel.release
+            JOIN musicbrainz.medium m
+              ON m.release = rel.id
+            JOIN musicbrainz.track t
+              ON t.medium = m.id
+            JOIN musicbrainz.recording r
+              ON r.id = t.recording
+            JOIN musicbrainz.artist_credit ac
+              ON ac.id = r.artist_credit
+           WHERE ecrel.collection = %s
+           ORDER BY ecrel.position NULLS LAST
+                  , rel.id
+                  , m.position
+                  , t.position
+           LIMIT %s OFFSET %s
+        """,
+        (collection_id, count, offset),
+    )
+    return mb_curs.fetchall()
 
 
 def _fetch_release_collection_items(mb_curs, collection_id: int, *, count: int, offset: int):
@@ -310,7 +363,51 @@ def _serialize_release_collection_payload(collection, collection_id: int, *, cou
     }
 
 
-def fetch_collection_payload(collection_mbid: str, *, viewer_editor_id: int | None, count: int, offset: int):
+def _serialize_release_collection_flattened_payload(
+    collection, collection_id: int, *, count: int, offset: int, mb_curs,
+):
+    """Flatten release collection releases into recordings for playlist import."""
+    track_count = _fetch_release_collection_flattened_track_count(mb_curs, collection_id)
+    tracks = _fetch_release_collection_flattened_tracks(
+        mb_curs,
+        collection_id,
+        count=count,
+        offset=offset,
+    )
+    return {
+        "collection": {
+            "mbid": collection["collection_mbid"],
+            "name": collection["name"],
+            "public": bool(collection["public"]),
+            "entity_type": collection["entity_type"],
+        },
+        "track_count": track_count,
+        "count": count,
+        "offset": offset,
+        "tracks": [
+            {
+                "recording_mbid": t["recording_mbid"],
+                "title": t["title"],
+                "artist_credit_name": t["artist_credit_name"],
+                "length": t["length"],
+                "release_mbid": t["release_mbid"],
+                "release_name": t["release_name"],
+            }
+            for t in tracks
+        ],
+        "items": [],
+        "cover_art": None,
+    }
+
+
+def fetch_collection_payload(
+    collection_mbid: str,
+    *,
+    viewer_editor_id: int | None,
+    count: int,
+    offset: int,
+    flatten_tracks: bool = False,
+):
     """Fetch collection and items from the MusicBrainz database."""
     if not is_valid_uuid(collection_mbid):
         return None, ({"error": f"Provided collection ID is invalid: {collection_mbid}"}, 400)
@@ -352,6 +449,10 @@ def fetch_collection_payload(collection_mbid: str, *, viewer_editor_id: int | No
                 payload = _serialize_recording_collection_payload(
                     collection, collection_id, count=count, offset=offset, mb_curs=mb_curs,
                 )
+            elif flatten_tracks:
+                payload = _serialize_release_collection_flattened_payload(
+                    collection, collection_id, count=count, offset=offset, mb_curs=mb_curs,
+                )
             else:
                 payload = _serialize_release_collection_payload(
                     collection, collection_id, count=count, offset=offset, mb_curs=mb_curs,
@@ -376,7 +477,8 @@ def load_collection(collection_mbid: str):
     """Load collection page data for React RouteLoader.
 
     Called by:
-      Collection page load-more / play-all / save-as-playlist pagination
+      Collection page RouteLoader, load-more, play-all, and save-as-playlist.
+      Release collections use flatten=tracks to expand recordings.
     """
     viewer_editor_id = None
     if current_user.is_authenticated:
@@ -384,12 +486,14 @@ def load_collection(collection_mbid: str):
 
     count = get_positive_param("count", DEFAULT_COLLECTION_TRACKS_PER_CALL)
     offset = get_non_negative_param("offset", 0)
+    flatten_tracks = request.args.get("flatten") == "tracks"
 
     payload, error = fetch_collection_payload(
         collection_mbid,
         viewer_editor_id=viewer_editor_id,
         count=count,
         offset=offset,
+        flatten_tracks=flatten_tracks,
     )
     if error:
         body, code = error

--- a/listenbrainz/webserver/views/collection.py
+++ b/listenbrainz/webserver/views/collection.py
@@ -18,6 +18,7 @@ collection_bp = Blueprint("collection", __name__)
 
 DEFAULT_COLLECTION_TRACKS_PER_CALL = 100
 MAX_COLLECTION_TRACKS_PER_CALL = 500
+SUPPORTED_COLLECTION_ENTITY_TYPES = frozenset({"recording", "release"})
 
 
 def _fetch_collection_row(mb_curs, collection_mbid: str):
@@ -28,7 +29,10 @@ def _fetch_collection_row(mb_curs, collection_mbid: str):
                , ec.name AS name
                , ec.public AS public
                , ec.editor AS owner_editor_id
+               , ect.entity_type AS entity_type
             FROM musicbrainz.editor_collection ec
+            JOIN musicbrainz.editor_collection_type ect
+              ON ect.id = ec.type
            WHERE ec.gid = %s
         """,
         (collection_mbid,),
@@ -65,6 +69,45 @@ def _fetch_recording_collection_tracks(mb_curs, collection_id: int, *, count: in
               ON ac.id = r.artist_credit
            WHERE ecr.collection = %s
            ORDER BY ecr.position NULLS LAST, ecr.recording
+           LIMIT %s OFFSET %s
+        """,
+        (collection_id, count, offset),
+    )
+    return mb_curs.fetchall()
+
+
+def _fetch_release_collection_item_count(mb_curs, collection_id: int) -> int:
+    mb_curs.execute(
+        """
+          SELECT COUNT(*)::int AS item_count
+            FROM musicbrainz.editor_collection_release ecrel
+            JOIN musicbrainz.release rel
+              ON rel.id = ecrel.release
+           WHERE ecrel.collection = %s
+        """,
+        (collection_id,),
+    )
+    row = mb_curs.fetchone()
+    return int(row["item_count"] or 0)
+
+
+def _fetch_release_collection_items(mb_curs, collection_id: int, *, count: int, offset: int):
+    mb_curs.execute(
+        """
+          SELECT rel.gid::text AS release_mbid
+               , rel.name AS title
+               , ac.name AS artist_credit_name
+               -- release date columns vary across dumps/schemas; keep them nullable for preview
+               , NULL::int AS date_year
+               , NULL::int AS date_month
+               , NULL::int AS date_day
+            FROM musicbrainz.editor_collection_release ecrel
+            JOIN musicbrainz.release rel
+              ON rel.id = ecrel.release
+            JOIN musicbrainz.artist_credit ac
+              ON ac.id = rel.artist_credit
+           WHERE ecrel.collection = %s
+           ORDER BY ecrel.position NULLS LAST, rel.id
            LIMIT %s OFFSET %s
         """,
         (collection_id, count, offset),
@@ -193,8 +236,82 @@ def _generate_collection_cover_art(collection_name: str, tracks: list[dict]) -> 
     )
 
 
+def _serialize_recording_collection_payload(collection, collection_id: int, *, count: int, offset: int, mb_curs):
+    track_count = _fetch_recording_collection_track_count(mb_curs, collection_id)
+    tracks = _fetch_recording_collection_tracks(
+        mb_curs,
+        collection_id,
+        count=count,
+        offset=offset,
+    )
+    enriched_tracks = _enrich_recording_collection_tracks(mb_curs, tracks)
+    payload = {
+        "collection": {
+            "mbid": collection["collection_mbid"],
+            "name": collection["name"],
+            "public": bool(collection["public"]),
+            "entity_type": collection["entity_type"],
+        },
+        "track_count": track_count,
+        "count": count,
+        "offset": offset,
+        "tracks": enriched_tracks,
+        "items": [],
+    }
+
+    if offset == 0:
+        try:
+            payload["cover_art"] = _generate_collection_cover_art(
+                collection["name"], enriched_tracks,
+            )
+        except Exception:
+            current_app.logger.error(
+                "Error generating cover art for MusicBrainz collection:",
+                exc_info=True,
+            )
+            payload["cover_art"] = None
+    else:
+        payload["cover_art"] = None
+
+    return payload
+
+
+def _serialize_release_collection_payload(collection, collection_id: int, *, count: int, offset: int, mb_curs):
+    item_count = _fetch_release_collection_item_count(mb_curs, collection_id)
+    releases = _fetch_release_collection_items(
+        mb_curs,
+        collection_id,
+        count=count,
+        offset=offset,
+    )
+    return {
+        "collection": {
+            "mbid": collection["collection_mbid"],
+            "name": collection["name"],
+            "public": bool(collection["public"]),
+            "entity_type": collection["entity_type"],
+        },
+        "track_count": item_count,
+        "count": count,
+        "offset": offset,
+        "tracks": [],
+        "items": [
+            {
+                "release_mbid": r["release_mbid"],
+                "title": r["title"],
+                "artist_credit_name": r["artist_credit_name"],
+                "date_year": r["date_year"],
+                "date_month": r["date_month"],
+                "date_day": r["date_day"],
+            }
+            for r in releases
+        ],
+        "cover_art": None,
+    }
+
+
 def fetch_collection_payload(collection_mbid: str, *, viewer_editor_id: int | None, count: int, offset: int):
-    """Fetch collection and tracks from the MusicBrainz database."""
+    """Fetch collection and items from the MusicBrainz database."""
     if not is_valid_uuid(collection_mbid):
         return None, ({"error": f"Provided collection ID is invalid: {collection_mbid}"}, 400)
 
@@ -221,44 +338,27 @@ def fetch_collection_payload(collection_mbid: str, *, viewer_editor_id: int | No
                 if int(collection["owner_editor_id"]) != int(viewer_editor_id):
                     return None, ({"error": "You are not allowed to access this collection"}, 403)
 
+            entity_type = collection["entity_type"]
+            if entity_type not in SUPPORTED_COLLECTION_ENTITY_TYPES:
+                return None, ({
+                    "error": (
+                        f"Collection type '{entity_type}' is not supported for import. "
+                        "Only recording and release collections can be previewed."
+                    )
+                }, 400)
+
             collection_id = int(collection["collection_id"])
-            track_count = _fetch_recording_collection_track_count(mb_curs, collection_id)
-            tracks = _fetch_recording_collection_tracks(
-                mb_curs,
-                collection_id,
-                count=count,
-                offset=offset,
-            )
-            enriched_tracks = _enrich_recording_collection_tracks(mb_curs, tracks)
+            if entity_type == "recording":
+                payload = _serialize_recording_collection_payload(
+                    collection, collection_id, count=count, offset=offset, mb_curs=mb_curs,
+                )
+            else:
+                payload = _serialize_release_collection_payload(
+                    collection, collection_id, count=count, offset=offset, mb_curs=mb_curs,
+                )
     except Exception:
         current_app.logger.error("Error fetching MusicBrainz collection:", exc_info=True)
         return None, ({"error": "Failed to fetch collection from MusicBrainz. Please try again."}, 500)
-
-    payload = {
-        "collection": {
-            "mbid": collection["collection_mbid"],
-            "name": collection["name"],
-            "public": bool(collection["public"]),
-        },
-        "track_count": track_count,
-        "count": count,
-        "offset": offset,
-        "tracks": enriched_tracks,
-    }
-
-    if offset == 0:
-        try:
-            payload["cover_art"] = _generate_collection_cover_art(
-                collection["name"], enriched_tracks,
-            )
-        except Exception:
-            current_app.logger.error(
-                "Error generating cover art for MusicBrainz collection:",
-                exc_info=True,
-            )
-            payload["cover_art"] = None
-    else:
-        payload["cover_art"] = None
 
     return payload, None
 

--- a/listenbrainz/webserver/views/collection.py
+++ b/listenbrainz/webserver/views/collection.py
@@ -5,6 +5,7 @@ from flask import Blueprint, current_app, jsonify, render_template, request
 from flask_login import current_user
 
 from listenbrainz.art.cover_art_generator import CoverArtGenerator
+from listenbrainz.db.cover_art import get_caa_ids_for_release_mbids
 from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
 from listenbrainz.webserver import ts_conn
 from listenbrainz.webserver.decorators import web_musicbrainz_needed
@@ -150,10 +151,6 @@ def _fetch_release_collection_items(mb_curs, collection_id: int, *, count: int, 
           SELECT rel.gid::text AS release_mbid
                , rel.name AS title
                , ac.name AS artist_credit_name
-               -- release date columns vary across dumps/schemas; keep them nullable for preview
-               , NULL::int AS date_year
-               , NULL::int AS date_month
-               , NULL::int AS date_day
             FROM musicbrainz.editor_collection_release ecrel
             JOIN musicbrainz.release rel
               ON rel.id = ecrel.release
@@ -226,14 +223,14 @@ def _enrich_recording_collection_tracks(mb_curs, tracks) -> list[dict]:
     ]
 
 
-def _get_cover_art_options_from_tracks(tracks: list[dict]) -> list[dict]:
-    """Collect unique cover art images from enriched tracks"""
+def _get_cover_art_options_from_items(items: list[dict], *, entity_mbid_key: str) -> list[dict]:
+    """Collect unique cover art images from enriched collection items/tracks."""
     selected_image_ids = set()
     images = []
 
-    for track in tracks:
-        caa_id = track.get("caa_id")
-        caa_release_mbid = track.get("caa_release_mbid")
+    for item in items:
+        caa_id = item.get("caa_id")
+        caa_release_mbid = item.get("caa_release_mbid")
         if not (caa_id and caa_release_mbid):
             continue
 
@@ -244,17 +241,22 @@ def _get_cover_art_options_from_tracks(tracks: list[dict]) -> list[dict]:
         images.append({
             "caa_id": caa_id,
             "caa_release_mbid": caa_release_mbid,
-            "title": track.get("title"),
-            "entity_mbid": track.get("recording_mbid"),
-            "artist": track.get("artist_credit_name"),
+            "title": item.get("title"),
+            "entity_mbid": item.get(entity_mbid_key),
+            "artist": item.get("artist_credit_name"),
         })
 
     return images
 
 
-def _generate_collection_cover_art(collection_name: str, tracks: list[dict]) -> str | None:
-    """Build playlist-style mosaic SVG for the collection header from track cover art."""
-    images = _get_cover_art_options_from_tracks(tracks)
+def _generate_collection_cover_art(
+    collection_name: str,
+    items: list[dict],
+    *,
+    entity_mbid_key: str = "recording_mbid",
+) -> str | None:
+    """Build playlist-style mosaic SVG for the collection header from cover art."""
+    images = _get_cover_art_options_from_items(items, entity_mbid_key=entity_mbid_key)
     if not images:
         return None
 
@@ -329,6 +331,40 @@ def _serialize_recording_collection_payload(collection, collection_id: int, *, c
     return payload
 
 
+def _serialize_release_item(release_row, cover_row=None) -> dict:
+    """Build API release dict from MB collection row and optional CAA enrichment."""
+    item = {
+        "release_mbid": release_row["release_mbid"],
+        "title": release_row["title"],
+        "artist_credit_name": release_row["artist_credit_name"],
+    }
+    if cover_row and cover_row.get("caa_id") is not None and cover_row.get("caa_release_mbid"):
+        item["caa_id"] = cover_row["caa_id"]
+        item["caa_release_mbid"] = cover_row["caa_release_mbid"]
+    return item
+
+
+def _enrich_release_collection_items(mb_curs, releases) -> list[dict]:
+    """Attach CAA ids to release collection items for thumbnails and header mosaic."""
+    if not releases:
+        return []
+
+    release_mbids = [r["release_mbid"] for r in releases]
+    covers_by_mbid = {}
+    try:
+        covers_by_mbid = get_caa_ids_for_release_mbids(mb_curs, release_mbids)
+    except Exception:
+        current_app.logger.error(
+            "Error enriching MusicBrainz release collection items with cover art:",
+            exc_info=True,
+        )
+
+    return [
+        _serialize_release_item(r, covers_by_mbid.get(r["release_mbid"]))
+        for r in releases
+    ]
+
+
 def _serialize_release_collection_payload(collection, collection_id: int, *, count: int, offset: int, mb_curs):
     item_count = _fetch_release_collection_item_count(mb_curs, collection_id)
     releases = _fetch_release_collection_items(
@@ -337,7 +373,8 @@ def _serialize_release_collection_payload(collection, collection_id: int, *, cou
         count=count,
         offset=offset,
     )
-    return {
+    enriched_items = _enrich_release_collection_items(mb_curs, releases)
+    payload = {
         "collection": {
             "mbid": collection["collection_mbid"],
             "name": collection["name"],
@@ -348,19 +385,26 @@ def _serialize_release_collection_payload(collection, collection_id: int, *, cou
         "count": count,
         "offset": offset,
         "tracks": [],
-        "items": [
-            {
-                "release_mbid": r["release_mbid"],
-                "title": r["title"],
-                "artist_credit_name": r["artist_credit_name"],
-                "date_year": r["date_year"],
-                "date_month": r["date_month"],
-                "date_day": r["date_day"],
-            }
-            for r in releases
-        ],
-        "cover_art": None,
+        "items": enriched_items,
     }
+
+    if offset == 0:
+        try:
+            payload["cover_art"] = _generate_collection_cover_art(
+                collection["name"],
+                enriched_items,
+                entity_mbid_key="release_mbid",
+            )
+        except Exception:
+            current_app.logger.error(
+                "Error generating cover art for MusicBrainz release collection:",
+                exc_info=True,
+            )
+            payload["cover_art"] = None
+    else:
+        payload["cover_art"] = None
+
+    return payload
 
 
 def _serialize_release_collection_flattened_payload(
@@ -478,7 +522,6 @@ def load_collection(collection_mbid: str):
 
     Called by:
       Collection page RouteLoader, load-more, play-all, and save-as-playlist.
-      Release collections use flatten=tracks to expand recordings.
     """
     viewer_editor_id = None
     if current_user.is_authenticated:

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -1085,7 +1085,7 @@ def import_playlist_from_music_service(service):
 @ratelimit()
 @api_musicbrainz_needed
 def import_musicbrainz_collections():
-    """List the authenticated user's MusicBrainz recording collections."""
+    """List the authenticated user's MusicBrainz recording and release collections."""
     user = validate_auth_header()
 
     if not current_app.config.get("MB_DATABASE_URI"):
@@ -1104,15 +1104,29 @@ def import_musicbrainz_collections():
                   SELECT ec.gid::text AS mbid
                        , ec.name AS name
                        , ec.public AS public
-                       , COUNT(ecr.recording) AS item_count
+                       , ect.entity_type AS entity_type
+                       , CASE ect.entity_type
+                             WHEN 'recording' THEN (
+                               SELECT COUNT(*)::int
+                                 FROM musicbrainz.editor_collection_recording ecr
+                                 JOIN musicbrainz.recording r
+                                   ON r.id = ecr.recording
+                                WHERE ecr.collection = ec.id
+                             )
+                             WHEN 'release' THEN (
+                               SELECT COUNT(*)::int
+                                 FROM musicbrainz.editor_collection_release ecrel
+                                 JOIN musicbrainz.release rel
+                                   ON rel.id = ecrel.release
+                                WHERE ecrel.collection = ec.id
+                             )
+                             ELSE 0
+                         END AS item_count
                     FROM musicbrainz.editor_collection ec
                     JOIN musicbrainz.editor_collection_type ect
                       ON ect.id = ec.type
-               LEFT JOIN musicbrainz.editor_collection_recording ecr
-                      ON ecr.collection = ec.id
                    WHERE ec.editor = %s
-                     AND ect.entity_type = 'recording'
-                GROUP BY ec.id
+                     AND ect.entity_type IN ('recording', 'release')
                 ORDER BY LOWER(ec.name)
                 """,
                 (user["musicbrainz_row_id"],),
@@ -1127,6 +1141,7 @@ def import_musicbrainz_collections():
             "mbid": row["mbid"],
             "name": row["name"],
             "public": bool(row["public"]),
+            "entity_type": row["entity_type"],
             "item_count": int(row["item_count"] or 0),
         }
         for row in collections


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/musicbrainz-server/blob/master/CONTRIBUTING.md
    
    Dont skip our AI usage policy if you plan on using AI tooling.
-->

# Problem

The import for recording MB collection in Listenbrainz is already done . 

Users could not open a release collection page to inspect its contents, and they could not save a release collection as a ListenBrainz playlist.

# Solution

This pr focuses on release collections . Clicking on import collection now shows both release and recording collections . When clicked on release collection , a new page opens showing list of releases .Each release row now links to the ListenBrainz release page at `/release/<release_mbid>/ `when clicked. . One can click on save as playlist button where releases will be flattened to tracks and then saved as usual LB playlist.
A` flatten=tracks` mode is used  for converting releases into playlist tracks

Attached is the example of a preview page , listing the releases.

<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/c9b3f3e4-83b8-4f05-b653-979ce34f2902" />



# AI usage
<!--
    If you used AI / LLM tools while working on this pull request, you must
    disclose it as per the MetaBrainz Foundation's contribution guidelines
    (https://github.com/metabrainz/guidelines).
-->

:beginner: If you used AI at all, you [must disclose it](https://github.com/metabrainz/guidelines/?tab=readme-ov-file#ai-use-policy), and what for, such as:
>Used Copilot when writing the tests I added to `testfile.js`

* [ ] I did not use any AI
* [ Yes ] I have used AI in this PR (add more details below)

I used claude for generating some pieces of code .

#### If you did use AI:
* [ ] I used AI tools for communication
* [Yes] I used AI tools for coding
* [Yes] I understand all the changes made in this PR


# Tests

Tests covering invalid MBIDs, public collections, and private collection access.
Integration tests for release collection payloads.
Added test for flattening release collections into recordings when saving as a playlist.