### PR TITLE
fix: Match tags model to actual JSONB structure in recording MBID lookup

### DIFF
--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -22,6 +22,12 @@ class RecordingFromRecordingMBIDArtist(BaseModel):
     join_phrase: str
 
 
+class RecordingFromRecordingMBIDTag(BaseModel):
+    tag: str
+    count: int
+    genre_mbid: Optional[UUID] = None
+
+
 class RecordingFromRecordingMBIDOutput(BaseModel):
     artist_credit_name: Optional[str]
     recording_name: Optional[str]
@@ -34,7 +40,7 @@ class RecordingFromRecordingMBIDOutput(BaseModel):
     release_name: Optional[str]
     release_mbid: Optional[UUID]
     artists: list[RecordingFromRecordingMBIDArtist]
-    tags: list[str]
+    tags: Optional[list[RecordingFromRecordingMBIDTag]] = []
 
 
 class RecordingFromRecordingMBIDQuery(Query):


### PR DESCRIPTION
# Problem

## What is the issue?
The recording MBID lookup endpoint fails with `ValidationError: 9 validation errors for RecordingFromRecordingMBIDOutput` because the Pydantic model for `tags` doesn't match the actual data coming from the database.

Fixes [LISTENBRAINZ-EX](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-EX) (~41K events).

## Why does it happen?
The `tags` field is declared as `list[str]` in the Pydantic model, but the database stores tags as JSONB objects with `tag`, `count`, and `genre_mbid` fields. The raw JSONB is passed through without coercion, so Pydantic rejects the objects when it expects plain strings.

The actual data looks like:
```json
[{"tag": "rock", "count": 5, "genre_mbid": "..."}, ...]
```

But the model expects:
```json
["rock", "pop", ...]
```

# Solution

Add a `RecordingFromRecordingMBIDTag` model that matches the actual JSONB structure (`tag: str`, `count: int`, `genre_mbid: Optional[UUID]`), and update the `tags` field type from `list[str]` to `Optional[list[RecordingFromRecordingMBIDTag]]` with a default of `[]`.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR