### PR TITLE
Use AUTOCOMMIT isolation to eliminate idle-in-transaction connections

### DIFF
--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -175,7 +175,12 @@ def export_listens_for_user(export_id, db_conn, ts_conn, tmp_dir: str, user_id: 
             update_export_progress(db_conn, export_id, f"Exporting listens for the period {period_str}")
             file_path = os.path.join(year_dir, f"{period['month']}.jsonl")
 
-            rowcount = export_listens_for_time_range(ts_conn, file_path, user_id, period["start"], period["end"])
+            # ``yield_per`` below uses a PostgreSQL server-side cursor, which
+            # requires a real transaction. The request-scoped Timescale
+            # connection is AUTOCOMMIT, so check out a short-lived transactional
+            # connection for each streamed export file.
+            with ts_conn.engine.begin() as txn:
+                rowcount = export_listens_for_time_range(txn, file_path, user_id, period["start"], period["end"])
             if rowcount > 0:
                 files.append(file_path)
 

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -61,10 +61,7 @@ def get_time_ranges_for_listens(min_dt: datetime, max_dt: datetime):
 
 def export_query_to_jsonl(conn, file_path, query, **kwargs):
     """ Export the given query's data to the given file path in jsonl format. """
-    # ``yield_per`` uses a PostgreSQL server-side cursor, which requires a
-    # transaction. Per-request connections use AUTOCOMMIT, so borrow a
-    # short-lived transactional connection only for the duration of a streamed
-    # export query.
+    # Server-side cursors need a transaction; AUTOCOMMIT connections do not have one.
     if conn.get_execution_options().get("isolation_level") == "AUTOCOMMIT":
         with conn.engine.begin() as txn:
             return export_query_to_jsonl(txn, file_path, query, **kwargs)

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -61,6 +61,14 @@ def get_time_ranges_for_listens(min_dt: datetime, max_dt: datetime):
 
 def export_query_to_jsonl(conn, file_path, query, **kwargs):
     """ Export the given query's data to the given file path in jsonl format. """
+    # ``yield_per`` uses a PostgreSQL server-side cursor, which requires a
+    # transaction. Per-request connections use AUTOCOMMIT, so borrow a
+    # short-lived transactional connection only for the duration of a streamed
+    # export query.
+    if conn.get_execution_options().get("isolation_level") == "AUTOCOMMIT":
+        with conn.engine.begin() as txn:
+            return export_query_to_jsonl(txn, file_path, query, **kwargs)
+
     rowcount = 0
     with conn.execute(
         text(query).execution_options(yield_per=BATCH_SIZE),
@@ -175,12 +183,7 @@ def export_listens_for_user(export_id, db_conn, ts_conn, tmp_dir: str, user_id: 
             update_export_progress(db_conn, export_id, f"Exporting listens for the period {period_str}")
             file_path = os.path.join(year_dir, f"{period['month']}.jsonl")
 
-            # ``yield_per`` below uses a PostgreSQL server-side cursor, which
-            # requires a real transaction. The request-scoped Timescale
-            # connection is AUTOCOMMIT, so check out a short-lived transactional
-            # connection for each streamed export file.
-            with ts_conn.engine.begin() as txn:
-                rowcount = export_listens_for_time_range(txn, file_path, user_id, period["start"], period["end"])
+            rowcount = export_listens_for_time_range(ts_conn, file_path, user_id, period["start"], period["end"])
             if rowcount > 0:
                 files.append(file_path)
 

--- a/listenbrainz/background/listens_importer/__init__.py
+++ b/listenbrainz/background/listens_importer/__init__.py
@@ -45,5 +45,8 @@ def import_listens(db_conn, ts_conn, user_id, bg_task_metadata):
     else:
         msg = f"Unsupported service: {service}"
         update_import_task(db_conn, import_id, status="failed", progress=msg)
-        raise ValueError(msg)
+        # This is a terminal error: the worker cannot process the task until a
+        # newer deployment supports the service. Returning lets the task be
+        # removed instead of immediately claiming and retrying it forever.
+        return
     importer.import_listens(user_id, import_task)

--- a/listenbrainz/background/listens_importer/__init__.py
+++ b/listenbrainz/background/listens_importer/__init__.py
@@ -45,8 +45,6 @@ def import_listens(db_conn, ts_conn, user_id, bg_task_metadata):
     else:
         msg = f"Unsupported service: {service}"
         update_import_task(db_conn, import_id, status="failed", progress=msg)
-        # This is a terminal error: the worker cannot process the task until a
-        # newer deployment supports the service. Returning lets the task be
-        # removed instead of immediately claiming and retrying it forever.
+        # The task is already marked failed, so do not retry it.
         return
     importer.import_listens(user_id, import_task)

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -35,57 +35,58 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
     # be explicitly set to the default value (which would have been used if the row was
     # inserted instead).
     token_expires = datetime.fromtimestamp(token_expires_ts, timezone.utc) if token_expires_ts else None
-    with db_conn.begin():
-        result = db_conn.execute(sqlalchemy.text("""
-            INSERT INTO external_service_oauth AS eso
-            (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
-             refresh_token_expiry_last_notified, scopes)
+    result = db_conn.execute(sqlalchemy.text("""
+        INSERT INTO external_service_oauth AS eso
+        (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
+         refresh_token_expiry_last_notified, scopes)
+        VALUES
+        (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
+         :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
+        ON CONFLICT (user_id, service)
+        DO UPDATE SET
+            external_user_id = EXCLUDED.external_user_id,
+            access_token = EXCLUDED.access_token,
+            refresh_token = EXCLUDED.refresh_token,
+            token_expires = EXCLUDED.token_expires,
+            refresh_token_expires = EXCLUDED.refresh_token_expires,
+            refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
+            scopes = EXCLUDED.scopes,
+            last_updated = NOW()
+        RETURNING id
+        """), {
+        "user_id": user_id,
+        "external_user_id": external_user_id,
+        "service": service.value,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_expires": token_expires,
+        "refresh_token_expires": refresh_token_expires,
+        "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
+        "scopes": scopes,
+    })
+
+    if record_listens:
+        external_service_oauth_id = result.fetchone().id
+        db_conn.execute(sqlalchemy.text("""
+            INSERT INTO listens_importer
+            (external_service_oauth_id, user_id, service, latest_listened_at)
             VALUES
-            (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
-             :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
-            ON CONFLICT (user_id, service)
-            DO UPDATE SET
-                external_user_id = EXCLUDED.external_user_id,
-                access_token = EXCLUDED.access_token,
-                refresh_token = EXCLUDED.refresh_token,
-                token_expires = EXCLUDED.token_expires,
-                refresh_token_expires = EXCLUDED.refresh_token_expires,
-                refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
-                scopes = EXCLUDED.scopes,
-                last_updated = NOW()
-            RETURNING id
+            (:external_service_oauth_id, :user_id, :service, :latest_listened_at)
+            ON CONFLICT (user_id, service) DO UPDATE SET
+                external_service_oauth_id = EXCLUDED.external_service_oauth_id,
+                user_id = EXCLUDED.user_id,
+                service = EXCLUDED.service,
+                last_updated = NULL,
+                latest_listened_at = EXCLUDED.latest_listened_at,
+                error = NULL
             """), {
+            "external_service_oauth_id": external_service_oauth_id,
             "user_id": user_id,
-            "external_user_id": external_user_id,
             "service": service.value,
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "token_expires": token_expires,
-            "refresh_token_expires": refresh_token_expires,
-            "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
-            "scopes": scopes,
+            "latest_listened_at": latest_listened_at,
         })
 
-        if record_listens:
-            external_service_oauth_id = result.fetchone().id
-            db_conn.execute(sqlalchemy.text("""
-                INSERT INTO listens_importer
-                (external_service_oauth_id, user_id, service, latest_listened_at)
-                VALUES
-                (:external_service_oauth_id, :user_id, :service, :latest_listened_at)
-                ON CONFLICT (user_id, service) DO UPDATE SET
-                    external_service_oauth_id = EXCLUDED.external_service_oauth_id,
-                    user_id = EXCLUDED.user_id,
-                    service = EXCLUDED.service,
-                    last_updated = NULL,
-                    latest_listened_at = EXCLUDED.latest_listened_at,
-                    error = NULL
-                """), {
-                "external_service_oauth_id": external_service_oauth_id,
-                "user_id": user_id,
-                "service": service.value,
-                "latest_listened_at": latest_listened_at,
-            })
+    db_conn.commit()
 
 
 def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_import_log: bool):
@@ -97,22 +98,23 @@ def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_imp
         service: the service for which the token should be deleted
         remove_import_log: whether the (user, service) combination should be removed from the listens_importer table also
     """
-    with db_conn.begin():
+    db_conn.execute(sqlalchemy.text("""
+        DELETE FROM external_service_oauth
+              WHERE user_id = :user_id AND service = :service
+    """), {
+        "user_id": user_id,
+        "service": service.value
+    })
+    if remove_import_log:
         db_conn.execute(sqlalchemy.text("""
-            DELETE FROM external_service_oauth
-                  WHERE user_id = :user_id AND service = :service
+            DELETE FROM listens_importer
+                WHERE user_id = :user_id AND service = :service
         """), {
             "user_id": user_id,
             "service": service.value
         })
-        if remove_import_log:
-            db_conn.execute(sqlalchemy.text("""
-                DELETE FROM listens_importer
-                    WHERE user_id = :user_id AND service = :service
-            """), {
-                "user_id": user_id,
-                "service": service.value
-            })
+
+    db_conn.commit()
 
 
 def update_token(db_conn, user_id: int, service: ExternalServiceType, access_token: str,

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -35,58 +35,57 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
     # be explicitly set to the default value (which would have been used if the row was
     # inserted instead).
     token_expires = datetime.fromtimestamp(token_expires_ts, timezone.utc) if token_expires_ts else None
-    result = db_conn.execute(sqlalchemy.text("""
-        INSERT INTO external_service_oauth AS eso
-        (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
-         refresh_token_expiry_last_notified, scopes)
-        VALUES
-        (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
-         :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
-        ON CONFLICT (user_id, service)
-        DO UPDATE SET
-            external_user_id = EXCLUDED.external_user_id,
-            access_token = EXCLUDED.access_token,
-            refresh_token = EXCLUDED.refresh_token,
-            token_expires = EXCLUDED.token_expires,
-            refresh_token_expires = EXCLUDED.refresh_token_expires,
-            refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
-            scopes = EXCLUDED.scopes,
-            last_updated = NOW()
-        RETURNING id
-        """), {
-        "user_id": user_id,
-        "external_user_id": external_user_id,
-        "service": service.value,
-        "access_token": access_token,
-        "refresh_token": refresh_token,
-        "token_expires": token_expires,
-        "refresh_token_expires": refresh_token_expires,
-        "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
-        "scopes": scopes,
-    })
-
-    if record_listens:
-        external_service_oauth_id = result.fetchone().id
-        db_conn.execute(sqlalchemy.text("""
-            INSERT INTO listens_importer
-            (external_service_oauth_id, user_id, service, latest_listened_at)
+    with db_conn.engine.begin() as txn:
+        result = txn.execute(sqlalchemy.text("""
+            INSERT INTO external_service_oauth AS eso
+            (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
+             refresh_token_expiry_last_notified, scopes)
             VALUES
-            (:external_service_oauth_id, :user_id, :service, :latest_listened_at)
-            ON CONFLICT (user_id, service) DO UPDATE SET
-                external_service_oauth_id = EXCLUDED.external_service_oauth_id,
-                user_id = EXCLUDED.user_id,
-                service = EXCLUDED.service,
-                last_updated = NULL,
-                latest_listened_at = EXCLUDED.latest_listened_at,
-                error = NULL
+            (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
+             :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
+            ON CONFLICT (user_id, service)
+            DO UPDATE SET
+                external_user_id = EXCLUDED.external_user_id,
+                access_token = EXCLUDED.access_token,
+                refresh_token = EXCLUDED.refresh_token,
+                token_expires = EXCLUDED.token_expires,
+                refresh_token_expires = EXCLUDED.refresh_token_expires,
+                refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
+                scopes = EXCLUDED.scopes,
+                last_updated = NOW()
+            RETURNING id
             """), {
-            "external_service_oauth_id": external_service_oauth_id,
             "user_id": user_id,
+            "external_user_id": external_user_id,
             "service": service.value,
-            "latest_listened_at": latest_listened_at,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "token_expires": token_expires,
+            "refresh_token_expires": refresh_token_expires,
+            "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
+            "scopes": scopes,
         })
 
-    db_conn.commit()
+        if record_listens:
+            external_service_oauth_id = result.fetchone().id
+            txn.execute(sqlalchemy.text("""
+                INSERT INTO listens_importer
+                (external_service_oauth_id, user_id, service, latest_listened_at)
+                VALUES
+                (:external_service_oauth_id, :user_id, :service, :latest_listened_at)
+                ON CONFLICT (user_id, service) DO UPDATE SET
+                    external_service_oauth_id = EXCLUDED.external_service_oauth_id,
+                    user_id = EXCLUDED.user_id,
+                    service = EXCLUDED.service,
+                    last_updated = NULL,
+                    latest_listened_at = EXCLUDED.latest_listened_at,
+                    error = NULL
+                """), {
+                "external_service_oauth_id": external_service_oauth_id,
+                "user_id": user_id,
+                "service": service.value,
+                "latest_listened_at": latest_listened_at,
+            })
 
 
 def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_import_log: bool):
@@ -98,23 +97,22 @@ def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_imp
         service: the service for which the token should be deleted
         remove_import_log: whether the (user, service) combination should be removed from the listens_importer table also
     """
-    db_conn.execute(sqlalchemy.text("""
-        DELETE FROM external_service_oauth
-              WHERE user_id = :user_id AND service = :service
-    """), {
-        "user_id": user_id,
-        "service": service.value
-    })
-    if remove_import_log:
-        db_conn.execute(sqlalchemy.text("""
-            DELETE FROM listens_importer
-                WHERE user_id = :user_id AND service = :service
+    with db_conn.engine.begin() as txn:
+        txn.execute(sqlalchemy.text("""
+            DELETE FROM external_service_oauth
+                  WHERE user_id = :user_id AND service = :service
         """), {
             "user_id": user_id,
             "service": service.value
         })
-
-    db_conn.commit()
+        if remove_import_log:
+            txn.execute(sqlalchemy.text("""
+                DELETE FROM listens_importer
+                    WHERE user_id = :user_id AND service = :service
+            """), {
+                "user_id": user_id,
+                "service": service.value
+            })
 
 
 def update_token(db_conn, user_id: int, service: ExternalServiceType, access_token: str,

--- a/listenbrainz/db/external_service_oauth.py
+++ b/listenbrainz/db/external_service_oauth.py
@@ -35,58 +35,57 @@ def save_token(db_conn, user_id: int, service: ExternalServiceType, access_token
     # be explicitly set to the default value (which would have been used if the row was
     # inserted instead).
     token_expires = datetime.fromtimestamp(token_expires_ts, timezone.utc) if token_expires_ts else None
-    result = db_conn.execute(sqlalchemy.text("""
-        INSERT INTO external_service_oauth AS eso
-        (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
-         refresh_token_expiry_last_notified, scopes)
-        VALUES
-        (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
-         :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
-        ON CONFLICT (user_id, service)
-        DO UPDATE SET
-            external_user_id = EXCLUDED.external_user_id,
-            access_token = EXCLUDED.access_token,
-            refresh_token = EXCLUDED.refresh_token,
-            token_expires = EXCLUDED.token_expires,
-            refresh_token_expires = EXCLUDED.refresh_token_expires,
-            refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
-            scopes = EXCLUDED.scopes,
-            last_updated = NOW()
-        RETURNING id
-        """), {
-        "user_id": user_id,
-        "external_user_id": external_user_id,
-        "service": service.value,
-        "access_token": access_token,
-        "refresh_token": refresh_token,
-        "token_expires": token_expires,
-        "refresh_token_expires": refresh_token_expires,
-        "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
-        "scopes": scopes,
-    })
-
-    if record_listens:
-        external_service_oauth_id = result.fetchone().id
-        db_conn.execute(sqlalchemy.text("""
-            INSERT INTO listens_importer
-            (external_service_oauth_id, user_id, service, latest_listened_at)
+    with db_conn.begin():
+        result = db_conn.execute(sqlalchemy.text("""
+            INSERT INTO external_service_oauth AS eso
+            (user_id, external_user_id, service, access_token, refresh_token, token_expires, refresh_token_expires,
+             refresh_token_expiry_last_notified, scopes)
             VALUES
-            (:external_service_oauth_id, :user_id, :service, :latest_listened_at)
-            ON CONFLICT (user_id, service) DO UPDATE SET
-                external_service_oauth_id = EXCLUDED.external_service_oauth_id,
-                user_id = EXCLUDED.user_id,
-                service = EXCLUDED.service,
-                last_updated = NULL,
-                latest_listened_at = EXCLUDED.latest_listened_at,
-                error = NULL
+            (:user_id, :external_user_id, :service, :access_token, :refresh_token, :token_expires,
+             :refresh_token_expires, :refresh_token_expiry_last_notified, :scopes)
+            ON CONFLICT (user_id, service)
+            DO UPDATE SET
+                external_user_id = EXCLUDED.external_user_id,
+                access_token = EXCLUDED.access_token,
+                refresh_token = EXCLUDED.refresh_token,
+                token_expires = EXCLUDED.token_expires,
+                refresh_token_expires = EXCLUDED.refresh_token_expires,
+                refresh_token_expiry_last_notified = EXCLUDED.refresh_token_expiry_last_notified,
+                scopes = EXCLUDED.scopes,
+                last_updated = NOW()
+            RETURNING id
             """), {
-            "external_service_oauth_id": external_service_oauth_id,
             "user_id": user_id,
+            "external_user_id": external_user_id,
             "service": service.value,
-            "latest_listened_at": latest_listened_at,
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "token_expires": token_expires,
+            "refresh_token_expires": refresh_token_expires,
+            "refresh_token_expiry_last_notified": refresh_token_expiry_last_notified,
+            "scopes": scopes,
         })
 
-    db_conn.commit()
+        if record_listens:
+            external_service_oauth_id = result.fetchone().id
+            db_conn.execute(sqlalchemy.text("""
+                INSERT INTO listens_importer
+                (external_service_oauth_id, user_id, service, latest_listened_at)
+                VALUES
+                (:external_service_oauth_id, :user_id, :service, :latest_listened_at)
+                ON CONFLICT (user_id, service) DO UPDATE SET
+                    external_service_oauth_id = EXCLUDED.external_service_oauth_id,
+                    user_id = EXCLUDED.user_id,
+                    service = EXCLUDED.service,
+                    last_updated = NULL,
+                    latest_listened_at = EXCLUDED.latest_listened_at,
+                    error = NULL
+                """), {
+                "external_service_oauth_id": external_service_oauth_id,
+                "user_id": user_id,
+                "service": service.value,
+                "latest_listened_at": latest_listened_at,
+            })
 
 
 def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_import_log: bool):
@@ -98,23 +97,22 @@ def delete_token(db_conn, user_id: int, service: ExternalServiceType, remove_imp
         service: the service for which the token should be deleted
         remove_import_log: whether the (user, service) combination should be removed from the listens_importer table also
     """
-    db_conn.execute(sqlalchemy.text("""
-        DELETE FROM external_service_oauth
-              WHERE user_id = :user_id AND service = :service
-    """), {
-        "user_id": user_id,
-        "service": service.value
-    })
-    if remove_import_log:
+    with db_conn.begin():
         db_conn.execute(sqlalchemy.text("""
-            DELETE FROM listens_importer
-                WHERE user_id = :user_id AND service = :service
+            DELETE FROM external_service_oauth
+                  WHERE user_id = :user_id AND service = :service
         """), {
             "user_id": user_id,
             "service": service.value
         })
-
-    db_conn.commit()
+        if remove_import_log:
+            db_conn.execute(sqlalchemy.text("""
+                DELETE FROM listens_importer
+                    WHERE user_id = :user_id AND service = :service
+            """), {
+                "user_id": user_id,
+                "service": service.value
+            })
 
 
 def update_token(db_conn, user_id: int, service: ExternalServiceType, access_token: str,

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -68,9 +68,9 @@ def insert(db_conn, feedback: Feedback):
     # delete the existing feedback and then insert new feedback. we cannot use ON CONFLICT DO UPDATE
     # because it is possible for a user to submit the feedback using recording_msid only and then using
     # both recording_msid and recording_mbid at once in which case the ON CONFLICT doesn't work well.
-    with db_conn.begin():
-        db_conn.execute(text(delete_query), params)
-        db_conn.execute(text(insert_query), params)
+    db_conn.execute(text(delete_query), params)
+    db_conn.execute(text(insert_query), params)
+    db_conn.commit()
 
 
 def delete(db_conn, feedback: Feedback):

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -68,9 +68,9 @@ def insert(db_conn, feedback: Feedback):
     # delete the existing feedback and then insert new feedback. we cannot use ON CONFLICT DO UPDATE
     # because it is possible for a user to submit the feedback using recording_msid only and then using
     # both recording_msid and recording_mbid at once in which case the ON CONFLICT doesn't work well.
-    db_conn.execute(text(delete_query), params)
-    db_conn.execute(text(insert_query), params)
-    db_conn.commit()
+    with db_conn.begin():
+        db_conn.execute(text(delete_query), params)
+        db_conn.execute(text(insert_query), params)
 
 
 def delete(db_conn, feedback: Feedback):

--- a/listenbrainz/db/feedback.py
+++ b/listenbrainz/db/feedback.py
@@ -68,9 +68,9 @@ def insert(db_conn, feedback: Feedback):
     # delete the existing feedback and then insert new feedback. we cannot use ON CONFLICT DO UPDATE
     # because it is possible for a user to submit the feedback using recording_msid only and then using
     # both recording_msid and recording_mbid at once in which case the ON CONFLICT doesn't work well.
-    db_conn.execute(text(delete_query), params)
-    db_conn.execute(text(insert_query), params)
-    db_conn.commit()
+    with db_conn.engine.begin() as txn:
+        txn.execute(text(delete_query), params)
+        txn.execute(text(insert_query), params)
 
 
 def delete(db_conn, feedback: Feedback):

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -35,19 +35,19 @@ def pin(db_conn, pinned_recording: WritablePinnedRecording):
         'created': pinned_recording.created
     }
 
-    with db_conn.begin():
-        db_conn.execute(sqlalchemy.text("""
-            UPDATE pinned_recording
-               SET pinned_until = NOW()
-             WHERE (user_id = :user_id AND pinned_until >= NOW())
-        """), {"user_id": pinned_recording.user_id})
+    db_conn.execute(sqlalchemy.text("""
+        UPDATE pinned_recording
+           SET pinned_until = NOW()
+         WHERE (user_id = :user_id AND pinned_until >= NOW())
+    """), {"user_id": pinned_recording.user_id})
 
-        result = db_conn.execute(sqlalchemy.text("""
-            INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
-                 VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
-              RETURNING (id)
-            """), args)
-        row_id = result.fetchone().id
+    result = db_conn.execute(sqlalchemy.text("""
+        INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
+             VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
+          RETURNING (id)
+        """), args)
+    row_id = result.fetchone().id
+    db_conn.commit()
 
     pinned_recording.row_id = row_id
     return PinnedRecording.parse_obj(pinned_recording.dict())

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -35,19 +35,19 @@ def pin(db_conn, pinned_recording: WritablePinnedRecording):
         'created': pinned_recording.created
     }
 
-    db_conn.execute(sqlalchemy.text("""
-        UPDATE pinned_recording
-           SET pinned_until = NOW()
-         WHERE (user_id = :user_id AND pinned_until >= NOW())
-    """), {"user_id": pinned_recording.user_id})
+    with db_conn.begin():
+        db_conn.execute(sqlalchemy.text("""
+            UPDATE pinned_recording
+               SET pinned_until = NOW()
+             WHERE (user_id = :user_id AND pinned_until >= NOW())
+        """), {"user_id": pinned_recording.user_id})
 
-    result = db_conn.execute(sqlalchemy.text("""
-        INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
-             VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
-          RETURNING (id)
-        """), args)
-    row_id = result.fetchone().id
-    db_conn.commit()
+        result = db_conn.execute(sqlalchemy.text("""
+            INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
+                 VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
+              RETURNING (id)
+            """), args)
+        row_id = result.fetchone().id
 
     pinned_recording.row_id = row_id
     return PinnedRecording.parse_obj(pinned_recording.dict())

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -35,19 +35,19 @@ def pin(db_conn, pinned_recording: WritablePinnedRecording):
         'created': pinned_recording.created
     }
 
-    db_conn.execute(sqlalchemy.text("""
-        UPDATE pinned_recording
-           SET pinned_until = NOW()
-         WHERE (user_id = :user_id AND pinned_until >= NOW())
-    """), {"user_id": pinned_recording.user_id})
+    with db_conn.engine.begin() as txn:
+        txn.execute(sqlalchemy.text("""
+            UPDATE pinned_recording
+               SET pinned_until = NOW()
+             WHERE (user_id = :user_id AND pinned_until >= NOW())
+        """), {"user_id": pinned_recording.user_id})
 
-    result = db_conn.execute(sqlalchemy.text("""
-        INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
-             VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
-          RETURNING (id)
-        """), args)
-    row_id = result.fetchone().id
-    db_conn.commit()
+        result = txn.execute(sqlalchemy.text("""
+            INSERT INTO pinned_recording (user_id, recording_msid, recording_mbid, blurb_content, pinned_until, created)
+                 VALUES (:user_id, :recording_msid, :recording_mbid, :blurb_content, :pinned_until, :created)
+              RETURNING (id)
+            """), args)
+        row_id = result.fetchone().id
 
     pinned_recording.row_id = row_id
     return PinnedRecording.parse_obj(pinned_recording.dict())

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -759,30 +759,31 @@ def create(db_conn, ts_conn, playlist: model_playlist.WritablePlaylist) -> model
     # This code seems out of place for a create function, but in order to keep the deletion of
     # old collaborative playlists in the same transaction as creating new playlists, it needs to
     # to be here.
-    with ts_conn.begin():
-        if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
-                playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
-                and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
-            _remove_old_collaborative_playlists(
-                ts_conn,
-                playlist.creator_id,
-                playlist.created_for_id,
-                playlist.additional_metadata["algorithm_metadata"]["source_patch"]
-            )
+    if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
+            playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
+            and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
+        _remove_old_collaborative_playlists(
+            ts_conn,
+            playlist.creator_id,
+            playlist.created_for_id,
+            playlist.additional_metadata["algorithm_metadata"]["source_patch"]
+        )
 
-        result = ts_conn.execute(query, fields)
-        row = result.fetchone()
-        playlist.id = row.id
-        playlist.mbid = row.mbid
-        playlist.created = row.created
-        playlist.creator = creator["musicbrainz_id"]
-        playlist.recordings = insert_recordings(db_conn, ts_conn, playlist.id, playlist.recordings, 0)
+    result = ts_conn.execute(query, fields)
+    row = result.fetchone()
+    playlist.id = row.id
+    playlist.mbid = row.mbid
+    playlist.created = row.created
+    playlist.creator = creator["musicbrainz_id"]
+    playlist.recordings = insert_recordings(db_conn, ts_conn, playlist.id, playlist.recordings, 0)
 
-        if playlist.collaborator_ids:
-            add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
-            collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
-            collaborator_ids = collaborator_ids.get(playlist.id, [])
-            playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
+    if playlist.collaborator_ids:
+        add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
+        collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
+        collaborator_ids = collaborator_ids.get(playlist.id, [])
+        playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
+
+    ts_conn.commit()
 
     return model_playlist.Playlist.parse_obj(playlist.dict())
 
@@ -836,17 +837,17 @@ def update_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist):
         'public': playlist.public,
         'additional_metadata': orjson.dumps(playlist.additional_metadata or {}).decode('utf-8')
     }
-    with ts_conn.begin():
-        ts_conn.execute(query, params)
-        # Unconditionally add collaborators, this allows us to delete all collaborators
-        # if [] is passed in.
-        # TODO: Optimise this by getting collaborators from the database and only updating
-        #  if what has passed is different to what exists
-        add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
-        collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
-        collaborator_ids = collaborator_ids.get(playlist.id, [])
-        playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
-        playlist.last_updated = set_last_updated(ts_conn, playlist.id)
+    ts_conn.execute(query, params)
+    # Unconditionally add collaborators, this allows us to delete all collaborators
+    # if [] is passed in.
+    # TODO: Optimise this by getting collaborators from the database and only updating
+    #  if what has passed is different to what exists
+    add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
+    collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
+    collaborator_ids = collaborator_ids.get(playlist.id, [])
+    playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
+    playlist.last_updated = set_last_updated(ts_conn, playlist.id)
+    ts_conn.commit()
     return playlist
 
 
@@ -1015,15 +1016,15 @@ def delete_recordings_from_playlist(ts_conn, playlist: model_playlist.Playlist, 
     delete_params = {"playlist_id": playlist.id,
                      "position_start": remove_from,
                      "position_end": remove_from+remove_count}
-    with ts_conn.begin():
-        ts_conn.execute(delete, delete_params)
-        if remove_from + remove_count < len(playlist.recordings):
-            reorder_params = {"playlist_id": playlist.id,
-                              "position": remove_from + remove_count,
-                              "offset": -1 * remove_count}
-            ts_conn.execute(reorder, reorder_params)
-        # TODO: In move_recordings we call delete and then add, so this is called twice
-        set_last_updated(ts_conn, playlist.id)
+    ts_conn.execute(delete, delete_params)
+    if remove_from + remove_count < len(playlist.recordings):
+        reorder_params = {"playlist_id": playlist.id,
+                          "position": remove_from + remove_count,
+                          "offset": -1 * remove_count}
+        ts_conn.execute(reorder, reorder_params)
+    # TODO: In move_recordings we call delete and then add, so this is called twice
+    set_last_updated(ts_conn, playlist.id)
+    ts_conn.commit()
 
 
 def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist,
@@ -1058,23 +1059,23 @@ def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playli
     if position is None:
         position = len(playlist.recordings)
 
-    with ts_conn.begin():
-        if position < len(playlist.recordings):
-            reorder_params = {"playlist_id": playlist.id,
-                              "offset": len(recordings),
-                              "position": position}
-            ts_conn.execute(reorder, reorder_params)
-        recordings = insert_recordings(db_conn, ts_conn, playlist.id, recordings, position)
-        playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
-        set_last_updated(ts_conn, playlist.id)
+    if position < len(playlist.recordings):
+        reorder_params = {"playlist_id": playlist.id,
+                          "offset": len(recordings),
+                          "position": position}
+        ts_conn.execute(reorder, reorder_params)
+    recordings = insert_recordings(db_conn, ts_conn, playlist.id, recordings, position)
+    playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
+    set_last_updated(ts_conn, playlist.id)
+    ts_conn.commit()
     return playlist
 
 
 def move_recordings(db_conn, ts_conn, playlist: model_playlist.Playlist, position_from: int, position_to: int, count: int):
-    with ts_conn.begin():
-        removed = playlist.recordings[position_from:position_from+count]
-        delete_recordings_from_playlist(ts_conn, playlist, position_from, count)
-        add_recordings_to_playlist(db_conn, ts_conn, playlist, removed, position_to)
+    # TODO: This must be done in a single transaction
+    removed = playlist.recordings[position_from:position_from+count]
+    delete_recordings_from_playlist(ts_conn, playlist, position_from, count)
+    add_recordings_to_playlist(db_conn, ts_conn, playlist, removed, position_to)
 
 
 def get_playlist_recordings_metadata(mb_curs, ts_curs, playlist: Playlist) -> Playlist:
@@ -1135,11 +1136,12 @@ def delete_playlists_by_user_id(ts_conn, user_id: int) -> int:
         DELETE FROM playlist.playlist_collaborator
               WHERE collaborator_id = :user_id
     """)
+    ts_conn.execute(delete_collaborators_query, {"user_id": user_id})
+
     delete_playlist_query = text("""
         DELETE FROM playlist.playlist
               WHERE creator_id = :user_id
                  OR created_for_id = :user_id
     """)
-    with ts_conn.begin():
-        ts_conn.execute(delete_collaborators_query, {"user_id": user_id})
-        ts_conn.execute(delete_playlist_query, {"user_id": user_id})
+    ts_conn.execute(delete_playlist_query, {"user_id": user_id})
+    ts_conn.commit()

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -759,31 +759,30 @@ def create(db_conn, ts_conn, playlist: model_playlist.WritablePlaylist) -> model
     # This code seems out of place for a create function, but in order to keep the deletion of
     # old collaborative playlists in the same transaction as creating new playlists, it needs to
     # to be here.
-    if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
-            playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
-            and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
-        _remove_old_collaborative_playlists(
-            ts_conn,
-            playlist.creator_id,
-            playlist.created_for_id,
-            playlist.additional_metadata["algorithm_metadata"]["source_patch"]
-        )
+    with ts_conn.begin():
+        if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
+                playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
+                and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
+            _remove_old_collaborative_playlists(
+                ts_conn,
+                playlist.creator_id,
+                playlist.created_for_id,
+                playlist.additional_metadata["algorithm_metadata"]["source_patch"]
+            )
 
-    result = ts_conn.execute(query, fields)
-    row = result.fetchone()
-    playlist.id = row.id
-    playlist.mbid = row.mbid
-    playlist.created = row.created
-    playlist.creator = creator["musicbrainz_id"]
-    playlist.recordings = insert_recordings(db_conn, ts_conn, playlist.id, playlist.recordings, 0)
+        result = ts_conn.execute(query, fields)
+        row = result.fetchone()
+        playlist.id = row.id
+        playlist.mbid = row.mbid
+        playlist.created = row.created
+        playlist.creator = creator["musicbrainz_id"]
+        playlist.recordings = insert_recordings(db_conn, ts_conn, playlist.id, playlist.recordings, 0)
 
-    if playlist.collaborator_ids:
-        add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
-        collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
-        collaborator_ids = collaborator_ids.get(playlist.id, [])
-        playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
-
-    ts_conn.commit()
+        if playlist.collaborator_ids:
+            add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
+            collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
+            collaborator_ids = collaborator_ids.get(playlist.id, [])
+            playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
 
     return model_playlist.Playlist.parse_obj(playlist.dict())
 
@@ -837,17 +836,17 @@ def update_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist):
         'public': playlist.public,
         'additional_metadata': orjson.dumps(playlist.additional_metadata or {}).decode('utf-8')
     }
-    ts_conn.execute(query, params)
-    # Unconditionally add collaborators, this allows us to delete all collaborators
-    # if [] is passed in.
-    # TODO: Optimise this by getting collaborators from the database and only updating
-    #  if what has passed is different to what exists
-    add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
-    collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
-    collaborator_ids = collaborator_ids.get(playlist.id, [])
-    playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
-    playlist.last_updated = set_last_updated(ts_conn, playlist.id)
-    ts_conn.commit()
+    with ts_conn.begin():
+        ts_conn.execute(query, params)
+        # Unconditionally add collaborators, this allows us to delete all collaborators
+        # if [] is passed in.
+        # TODO: Optimise this by getting collaborators from the database and only updating
+        #  if what has passed is different to what exists
+        add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
+        collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
+        collaborator_ids = collaborator_ids.get(playlist.id, [])
+        playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
+        playlist.last_updated = set_last_updated(ts_conn, playlist.id)
     return playlist
 
 
@@ -1016,15 +1015,15 @@ def delete_recordings_from_playlist(ts_conn, playlist: model_playlist.Playlist, 
     delete_params = {"playlist_id": playlist.id,
                      "position_start": remove_from,
                      "position_end": remove_from+remove_count}
-    ts_conn.execute(delete, delete_params)
-    if remove_from + remove_count < len(playlist.recordings):
-        reorder_params = {"playlist_id": playlist.id,
-                          "position": remove_from + remove_count,
-                          "offset": -1 * remove_count}
-        ts_conn.execute(reorder, reorder_params)
-    # TODO: In move_recordings we call delete and then add, so this is called twice
-    set_last_updated(ts_conn, playlist.id)
-    ts_conn.commit()
+    with ts_conn.begin():
+        ts_conn.execute(delete, delete_params)
+        if remove_from + remove_count < len(playlist.recordings):
+            reorder_params = {"playlist_id": playlist.id,
+                              "position": remove_from + remove_count,
+                              "offset": -1 * remove_count}
+            ts_conn.execute(reorder, reorder_params)
+        # TODO: In move_recordings we call delete and then add, so this is called twice
+        set_last_updated(ts_conn, playlist.id)
 
 
 def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist,
@@ -1059,23 +1058,23 @@ def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playli
     if position is None:
         position = len(playlist.recordings)
 
-    if position < len(playlist.recordings):
-        reorder_params = {"playlist_id": playlist.id,
-                          "offset": len(recordings),
-                          "position": position}
-        ts_conn.execute(reorder, reorder_params)
-    recordings = insert_recordings(db_conn, ts_conn, playlist.id, recordings, position)
-    playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
-    set_last_updated(ts_conn, playlist.id)
-    ts_conn.commit()
+    with ts_conn.begin():
+        if position < len(playlist.recordings):
+            reorder_params = {"playlist_id": playlist.id,
+                              "offset": len(recordings),
+                              "position": position}
+            ts_conn.execute(reorder, reorder_params)
+        recordings = insert_recordings(db_conn, ts_conn, playlist.id, recordings, position)
+        playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
+        set_last_updated(ts_conn, playlist.id)
     return playlist
 
 
 def move_recordings(db_conn, ts_conn, playlist: model_playlist.Playlist, position_from: int, position_to: int, count: int):
-    # TODO: This must be done in a single transaction
-    removed = playlist.recordings[position_from:position_from+count]
-    delete_recordings_from_playlist(ts_conn, playlist, position_from, count)
-    add_recordings_to_playlist(db_conn, ts_conn, playlist, removed, position_to)
+    with ts_conn.begin():
+        removed = playlist.recordings[position_from:position_from+count]
+        delete_recordings_from_playlist(ts_conn, playlist, position_from, count)
+        add_recordings_to_playlist(db_conn, ts_conn, playlist, removed, position_to)
 
 
 def get_playlist_recordings_metadata(mb_curs, ts_curs, playlist: Playlist) -> Playlist:
@@ -1136,12 +1135,11 @@ def delete_playlists_by_user_id(ts_conn, user_id: int) -> int:
         DELETE FROM playlist.playlist_collaborator
               WHERE collaborator_id = :user_id
     """)
-    ts_conn.execute(delete_collaborators_query, {"user_id": user_id})
-
     delete_playlist_query = text("""
         DELETE FROM playlist.playlist
               WHERE creator_id = :user_id
                  OR created_for_id = :user_id
     """)
-    ts_conn.execute(delete_playlist_query, {"user_id": user_id})
-    ts_conn.commit()
+    with ts_conn.begin():
+        ts_conn.execute(delete_collaborators_query, {"user_id": user_id})
+        ts_conn.execute(delete_playlist_query, {"user_id": user_id})

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -759,31 +759,30 @@ def create(db_conn, ts_conn, playlist: model_playlist.WritablePlaylist) -> model
     # This code seems out of place for a create function, but in order to keep the deletion of
     # old collaborative playlists in the same transaction as creating new playlists, it needs to
     # to be here.
-    if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
-            playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
-            and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
-        _remove_old_collaborative_playlists(
-            ts_conn,
-            playlist.creator_id,
-            playlist.created_for_id,
-            playlist.additional_metadata["algorithm_metadata"]["source_patch"]
-        )
+    with ts_conn.engine.begin() as txn:
+        if playlist.creator_id in (LISTENBRAINZ_USER_ID, TROI_BOT_USER_ID) and playlist.created_for_id is not None and \
+                playlist.additional_metadata is not None and "algorithm_metadata" in playlist.additional_metadata\
+                and "source_patch" in playlist.additional_metadata["algorithm_metadata"]:
+            _remove_old_collaborative_playlists(
+                txn,
+                playlist.creator_id,
+                playlist.created_for_id,
+                playlist.additional_metadata["algorithm_metadata"]["source_patch"]
+            )
 
-    result = ts_conn.execute(query, fields)
-    row = result.fetchone()
-    playlist.id = row.id
-    playlist.mbid = row.mbid
-    playlist.created = row.created
-    playlist.creator = creator["musicbrainz_id"]
-    playlist.recordings = insert_recordings(db_conn, ts_conn, playlist.id, playlist.recordings, 0)
+        result = txn.execute(query, fields)
+        row = result.fetchone()
+        playlist.id = row.id
+        playlist.mbid = row.mbid
+        playlist.created = row.created
+        playlist.creator = creator["musicbrainz_id"]
+        playlist.recordings = insert_recordings(db_conn, txn, playlist.id, playlist.recordings, 0)
 
-    if playlist.collaborator_ids:
-        add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
-        collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
-        collaborator_ids = collaborator_ids.get(playlist.id, [])
-        playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
-
-    ts_conn.commit()
+        if playlist.collaborator_ids:
+            add_playlist_collaborators(txn, playlist.id, playlist.collaborator_ids)
+            collaborator_ids = get_collaborators_for_playlists(txn, [playlist.id])
+            collaborator_ids = collaborator_ids.get(playlist.id, [])
+            playlist.collaborators = get_collaborators_names_from_ids(db_conn, collaborator_ids)
 
     return model_playlist.Playlist.parse_obj(playlist.dict())
 
@@ -837,17 +836,17 @@ def update_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist):
         'public': playlist.public,
         'additional_metadata': orjson.dumps(playlist.additional_metadata or {}).decode('utf-8')
     }
-    ts_conn.execute(query, params)
-    # Unconditionally add collaborators, this allows us to delete all collaborators
-    # if [] is passed in.
-    # TODO: Optimise this by getting collaborators from the database and only updating
-    #  if what has passed is different to what exists
-    add_playlist_collaborators(ts_conn, playlist.id, playlist.collaborator_ids)
-    collaborator_ids = get_collaborators_for_playlists(ts_conn, [playlist.id])
-    collaborator_ids = collaborator_ids.get(playlist.id, [])
-    playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
-    playlist.last_updated = set_last_updated(ts_conn, playlist.id)
-    ts_conn.commit()
+    with ts_conn.engine.begin() as txn:
+        txn.execute(query, params)
+        # Unconditionally add collaborators, this allows us to delete all collaborators
+        # if [] is passed in.
+        # TODO: Optimise this by getting collaborators from the database and only updating
+        #  if what has passed is different to what exists
+        add_playlist_collaborators(txn, playlist.id, playlist.collaborator_ids)
+        collaborator_ids = get_collaborators_for_playlists(txn, [playlist.id])
+        collaborator_ids = collaborator_ids.get(playlist.id, [])
+        playlist.collaborators = get_collaborators_names_from_ids(db_conn, playlist.collaborator_ids)
+        playlist.last_updated = set_last_updated(txn, playlist.id)
     return playlist
 
 
@@ -1016,15 +1015,15 @@ def delete_recordings_from_playlist(ts_conn, playlist: model_playlist.Playlist, 
     delete_params = {"playlist_id": playlist.id,
                      "position_start": remove_from,
                      "position_end": remove_from+remove_count}
-    ts_conn.execute(delete, delete_params)
-    if remove_from + remove_count < len(playlist.recordings):
-        reorder_params = {"playlist_id": playlist.id,
-                          "position": remove_from + remove_count,
-                          "offset": -1 * remove_count}
-        ts_conn.execute(reorder, reorder_params)
-    # TODO: In move_recordings we call delete and then add, so this is called twice
-    set_last_updated(ts_conn, playlist.id)
-    ts_conn.commit()
+    with ts_conn.engine.begin() as txn:
+        txn.execute(delete, delete_params)
+        if remove_from + remove_count < len(playlist.recordings):
+            reorder_params = {"playlist_id": playlist.id,
+                              "position": remove_from + remove_count,
+                              "offset": -1 * remove_count}
+            txn.execute(reorder, reorder_params)
+        # TODO: In move_recordings we call delete and then add, so this is called twice
+        set_last_updated(txn, playlist.id)
 
 
 def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playlist,
@@ -1059,15 +1058,15 @@ def add_recordings_to_playlist(db_conn, ts_conn, playlist: model_playlist.Playli
     if position is None:
         position = len(playlist.recordings)
 
-    if position < len(playlist.recordings):
-        reorder_params = {"playlist_id": playlist.id,
-                          "offset": len(recordings),
-                          "position": position}
-        ts_conn.execute(reorder, reorder_params)
-    recordings = insert_recordings(db_conn, ts_conn, playlist.id, recordings, position)
-    playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
-    set_last_updated(ts_conn, playlist.id)
-    ts_conn.commit()
+    with ts_conn.engine.begin() as txn:
+        if position < len(playlist.recordings):
+            reorder_params = {"playlist_id": playlist.id,
+                              "offset": len(recordings),
+                              "position": position}
+            txn.execute(reorder, reorder_params)
+        recordings = insert_recordings(db_conn, txn, playlist.id, recordings, position)
+        playlist.recordings = playlist.recordings[0:position] + recordings + playlist.recordings[position:]
+        set_last_updated(txn, playlist.id)
     return playlist
 
 
@@ -1136,12 +1135,12 @@ def delete_playlists_by_user_id(ts_conn, user_id: int) -> int:
         DELETE FROM playlist.playlist_collaborator
               WHERE collaborator_id = :user_id
     """)
-    ts_conn.execute(delete_collaborators_query, {"user_id": user_id})
+    with ts_conn.engine.begin() as txn:
+        txn.execute(delete_collaborators_query, {"user_id": user_id})
 
-    delete_playlist_query = text("""
-        DELETE FROM playlist.playlist
-              WHERE creator_id = :user_id
-                 OR created_for_id = :user_id
-    """)
-    ts_conn.execute(delete_playlist_query, {"user_id": user_id})
-    ts_conn.commit()
+        delete_playlist_query = text("""
+            DELETE FROM playlist.playlist
+                  WHERE creator_id = :user_id
+                     OR created_for_id = :user_id
+        """)
+        txn.execute(delete_playlist_query, {"user_id": user_id})

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -21,7 +21,7 @@ class DatabaseTestCase(unittest.TestCase):
     def setUp(self):
         db_connect = create_test_database_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])
-        self.db_conn = db.engine.connect()
+        self.db_conn = db.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
 
     def tearDown(self):
         self.db_conn.close()
@@ -62,7 +62,7 @@ class TimescaleTestCase(unittest.TestCase):
         ts_connect = create_test_timescale_connect_strings()
         ts.init_db_connection(ts_connect["DB_CONNECT"])
         self.reset_timescale_db()
-        self.ts_conn = ts.engine.connect()
+        self.ts_conn = ts.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
 
         # listens are dual written, so reset the partitioned database alongside timescale
         listens_connect = create_test_listens_connect_strings()

--- a/listenbrainz/dumps/tests/test_dump.py
+++ b/listenbrainz/dumps/tests/test_dump.py
@@ -58,7 +58,7 @@ class DumpTestCase(DatabaseTestCase):
             "private_temp": self.tempdir_private_temp,
         }
         self.app = create_app()
-        self.ts_conn = timescale.engine.connect()
+        self.ts_conn = timescale.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
 
     def tearDown(self):
         self.ts_conn.close()

--- a/listenbrainz/tests/integration/test_feedback_api.py
+++ b/listenbrainz/tests/integration/test_feedback_api.py
@@ -16,7 +16,7 @@ class FeedbackAPITestCase(IntegrationTestCase):
         super(FeedbackAPITestCase, self).setUp()
         self.user = db_user.get_or_create(self.db_conn, 1, "testuserpleaseignore")
         self.user2 = db_user.get_or_create(self.db_conn, 2, "anothertestuserpleaseignore")
-        self.ts_conn = timescale.engine.connect()
+        self.ts_conn = timescale.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
 
     def tearDown(self):
         self.ts_conn.close()

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -359,9 +359,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assert200(response)
         second_file_path = response.json["file_path"]
 
-        # The worker can process and remove an empty import file immediately;
-        # verify the collision protection using the persisted task paths rather
-        # than the transient upload directory contents.
+        # Empty files may be removed by the worker before this assertion.
         self.assertNotEqual(first_file_path, second_file_path)
 
     def test_import_task_auth(self):

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -161,6 +161,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             content_type="multipart/form-data"
         )
         self.assert200(response)
+        first_file_path = response.json["file_path"]
 
         orig_data = response.json
         response = self.client.get(
@@ -356,11 +357,12 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             content_type="multipart/form-data"
         )
         self.assert200(response)
+        second_file_path = response.json["file_path"]
 
-        self.assertEqual(
-            len(list(Path(self.app.config["UPLOAD_FOLDER"]).iterdir())),
-            2
-        )
+        # The worker can process and remove an empty import file immediately;
+        # verify the collision protection using the persisted task paths rather
+        # than the transient upload directory contents.
+        self.assertNotEqual(first_file_path, second_file_path)
 
     def test_import_task_auth(self):
         from_date = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -161,7 +161,6 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             content_type="multipart/form-data"
         )
         self.assert200(response)
-        first_file_path = response.json["file_path"]
 
         orig_data = response.json
         response = self.client.get(
@@ -342,6 +341,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             content_type="multipart/form-data"
         )
         self.assert200(response)
+        first_file_path = response.json["file_path"]
 
         user2 = db_user.get_or_create(self.db_conn, 1851, "listens-import2")
         data = {

--- a/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
+++ b/listenbrainz/tests/integration/test_missing_musicbrainz_data_api.py
@@ -23,7 +23,7 @@ class MissingMusicBrainzDataViewsTestCase(IntegrationTestCase):
             missing_musicbrainz_data=UserMissingMusicBrainzDataJson(missing_musicbrainz_data=missing_musicbrainz_data),
             source='cf'
         )
-        self.ts_conn = timescale.engine.connect()
+        self.ts_conn = timescale.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
         self.data = db_missing_musicbrainz_data.get_user_missing_musicbrainz_data(
             self.db_conn,
             self.ts_conn,

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -32,21 +32,21 @@ RATELIMIT_PER_TOKEN = 100000  # a very high limit so that troi can make virtuall
 def _get_db_conn():
     _db_conn = getattr(g, "_db_conn", None)
     if _db_conn is None:
-        _db_conn = g._db_conn = db.engine.connect()
+        _db_conn = g._db_conn = db.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
     return _db_conn
 
 
 def _get_ts_conn():
     _ts_conn = getattr(g, "_ts_conn", None)
     if _ts_conn is None:
-        _ts_conn = g._ts_conn = timescale.engine.connect()
+        _ts_conn = g._ts_conn = timescale.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
     return _ts_conn
 
 
 def _get_meb_conn():
     _meb_conn = getattr(g, "_meb_conn", None)
     if donation.engine is not None and _meb_conn is None:
-        _meb_conn = g._meb_conn = donation.engine.connect()
+        _meb_conn = g._meb_conn = donation.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
     return _meb_conn
 
 

--- a/listenbrainz/webserver/views/export.py
+++ b/listenbrainz/webserver/views/export.py
@@ -20,42 +20,44 @@ export_bp = Blueprint("export", __name__)
 def create_export_task():
     """ Add a request to export the user data to an archive in background. """
     try:
-        with db_conn.begin():
-            query = """
-                INSERT INTO user_data_export (user_id, type, status, progress)
-                     VALUES (:user_id, :type, 'waiting', :progress)
-                ON CONFLICT (user_id, type)
-                      WHERE status = 'waiting' OR status = 'in_progress'
-                 DO NOTHING
-                  RETURNING id, type, available_until, created, progress, status, filename
-            """
+        query = """
+            INSERT INTO user_data_export (user_id, type, status, progress)
+                 VALUES (:user_id, :type, 'waiting', :progress)
+            ON CONFLICT (user_id, type)
+                  WHERE status = 'waiting' OR status = 'in_progress'
+             DO NOTHING
+              RETURNING id, type, available_until, created, progress, status, filename
+        """
+        result = db_conn.execute(text(query), {
+            "user_id": current_user.id,
+            "type": "export_all_user_data",
+            "progress": "Your data export will start soon."
+        })
+        export = result.first()
+
+        if export is not None:
+            query = "INSERT INTO background_tasks (user_id, task, metadata) VALUES (:user_id, :task, :metadata) ON CONFLICT DO NOTHING RETURNING id"
             result = db_conn.execute(text(query), {
                 "user_id": current_user.id,
-                "type": "export_all_user_data",
-                "progress": "Your data export will start soon."
+                "task": "export_all_user_data",
+                "metadata": json.dumps({"export_id": export.id})
             })
-            export = result.first()
-
-            if export is not None:
-                query = "INSERT INTO background_tasks (user_id, task, metadata) VALUES (:user_id, :task, :metadata) ON CONFLICT DO NOTHING RETURNING id"
-                result = db_conn.execute(text(query), {
-                    "user_id": current_user.id,
-                    "task": "export_all_user_data",
-                    "metadata": json.dumps({"export_id": export.id})
+            task = result.first()
+            if task is not None:
+                db_conn.commit()
+                return jsonify({
+                    "export_id": export.id,
+                    "type": export.type,
+                    "available_until": export.available_until.isoformat() if export.available_until is not None else None,
+                    "created": export.created.isoformat(),
+                    "progress": export.progress,
+                    "status": export.status,
+                    "filename": export.filename,
                 })
-                task = result.first()
-                if task is not None:
-                    return jsonify({
-                        "export_id": export.id,
-                        "type": export.type,
-                        "available_until": export.available_until.isoformat() if export.available_until is not None else None,
-                        "created": export.created.isoformat(),
-                        "progress": export.progress,
-                        "status": export.status,
-                        "filename": export.filename,
-                    })
 
-            raise APIBadRequest(message="Data export already requested.")
+        # task already exists in queue, rollback new entry
+        db_conn.rollback()
+        raise APIBadRequest(message="Data export already requested.")
 
     except DatabaseError:
         current_app.logger.error('Error while exporting user data: %s', current_user.musicbrainz_id, exc_info=True)
@@ -129,16 +131,18 @@ def download_export_archive(export_id):
 @web_listenstore_needed
 def delete_export_archive(export_id):
     """ Delete the specified export archive """
-    with db_conn.begin():
-        result = db_conn.execute(
-            text("DELETE FROM user_data_export WHERE user_id = :user_id AND id = :export_id RETURNING filename"),
+    result = db_conn.execute(
+        text("DELETE FROM user_data_export WHERE user_id = :user_id AND id = :export_id RETURNING filename"),
+        {"user_id": current_user.id, "export_id": export_id}
+    )
+    row = result.first()
+    if row is not None:
+        db_conn.execute(
+            text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->'export_id')::int = :export_id"),
             {"user_id": current_user.id, "export_id": export_id}
         )
-        row = result.first()
-        if row is not None:
-            db_conn.execute(
-                text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->'export_id')::int = :export_id"),
-                {"user_id": current_user.id, "export_id": export_id}
-            )
-            return jsonify({"success": True})
-    raise APINotFound("Export not found")
+        db_conn.commit()
+        # file is deleted from disk by cronjob
+        return jsonify({"success": True})
+    else:
+        raise APINotFound("Export not found")

--- a/listenbrainz/webserver/views/export.py
+++ b/listenbrainz/webserver/views/export.py
@@ -20,44 +20,42 @@ export_bp = Blueprint("export", __name__)
 def create_export_task():
     """ Add a request to export the user data to an archive in background. """
     try:
-        query = """
-            INSERT INTO user_data_export (user_id, type, status, progress)
-                 VALUES (:user_id, :type, 'waiting', :progress)
-            ON CONFLICT (user_id, type)
-                  WHERE status = 'waiting' OR status = 'in_progress'
-             DO NOTHING
-              RETURNING id, type, available_until, created, progress, status, filename
-        """
-        result = db_conn.execute(text(query), {
-            "user_id": current_user.id,
-            "type": "export_all_user_data",
-            "progress": "Your data export will start soon."
-        })
-        export = result.first()
-
-        if export is not None:
-            query = "INSERT INTO background_tasks (user_id, task, metadata) VALUES (:user_id, :task, :metadata) ON CONFLICT DO NOTHING RETURNING id"
+        with db_conn.begin():
+            query = """
+                INSERT INTO user_data_export (user_id, type, status, progress)
+                     VALUES (:user_id, :type, 'waiting', :progress)
+                ON CONFLICT (user_id, type)
+                      WHERE status = 'waiting' OR status = 'in_progress'
+                 DO NOTHING
+                  RETURNING id, type, available_until, created, progress, status, filename
+            """
             result = db_conn.execute(text(query), {
                 "user_id": current_user.id,
-                "task": "export_all_user_data",
-                "metadata": json.dumps({"export_id": export.id})
+                "type": "export_all_user_data",
+                "progress": "Your data export will start soon."
             })
-            task = result.first()
-            if task is not None:
-                db_conn.commit()
-                return jsonify({
-                    "export_id": export.id,
-                    "type": export.type,
-                    "available_until": export.available_until.isoformat() if export.available_until is not None else None,
-                    "created": export.created.isoformat(),
-                    "progress": export.progress,
-                    "status": export.status,
-                    "filename": export.filename,
-                })
+            export = result.first()
 
-        # task already exists in queue, rollback new entry
-        db_conn.rollback()
-        raise APIBadRequest(message="Data export already requested.")
+            if export is not None:
+                query = "INSERT INTO background_tasks (user_id, task, metadata) VALUES (:user_id, :task, :metadata) ON CONFLICT DO NOTHING RETURNING id"
+                result = db_conn.execute(text(query), {
+                    "user_id": current_user.id,
+                    "task": "export_all_user_data",
+                    "metadata": json.dumps({"export_id": export.id})
+                })
+                task = result.first()
+                if task is not None:
+                    return jsonify({
+                        "export_id": export.id,
+                        "type": export.type,
+                        "available_until": export.available_until.isoformat() if export.available_until is not None else None,
+                        "created": export.created.isoformat(),
+                        "progress": export.progress,
+                        "status": export.status,
+                        "filename": export.filename,
+                    })
+
+            raise APIBadRequest(message="Data export already requested.")
 
     except DatabaseError:
         current_app.logger.error('Error while exporting user data: %s', current_user.musicbrainz_id, exc_info=True)
@@ -131,18 +129,16 @@ def download_export_archive(export_id):
 @web_listenstore_needed
 def delete_export_archive(export_id):
     """ Delete the specified export archive """
-    result = db_conn.execute(
-        text("DELETE FROM user_data_export WHERE user_id = :user_id AND id = :export_id RETURNING filename"),
-        {"user_id": current_user.id, "export_id": export_id}
-    )
-    row = result.first()
-    if row is not None:
-        db_conn.execute(
-            text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->'export_id')::int = :export_id"),
+    with db_conn.begin():
+        result = db_conn.execute(
+            text("DELETE FROM user_data_export WHERE user_id = :user_id AND id = :export_id RETURNING filename"),
             {"user_id": current_user.id, "export_id": export_id}
         )
-        db_conn.commit()
-        # file is deleted from disk by cronjob
-        return jsonify({"success": True})
-    else:
-        raise APINotFound("Export not found")
+        row = result.first()
+        if row is not None:
+            db_conn.execute(
+                text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->'export_id')::int = :export_id"),
+                {"user_id": current_user.id, "export_id": export_id}
+            )
+            return jsonify({"success": True})
+    raise APINotFound("Export not found")

--- a/listenbrainz/webserver/views/export.py
+++ b/listenbrainz/webserver/views/export.py
@@ -28,36 +28,34 @@ def create_export_task():
              DO NOTHING
               RETURNING id, type, available_until, created, progress, status, filename
         """
-        result = db_conn.execute(text(query), {
-            "user_id": current_user.id,
-            "type": "export_all_user_data",
-            "progress": "Your data export will start soon."
-        })
-        export = result.first()
-
-        if export is not None:
-            query = "INSERT INTO background_tasks (user_id, task, metadata) VALUES (:user_id, :task, :metadata) ON CONFLICT DO NOTHING RETURNING id"
-            result = db_conn.execute(text(query), {
+        with db_conn.engine.begin() as txn:
+            result = txn.execute(text(query), {
                 "user_id": current_user.id,
-                "task": "export_all_user_data",
-                "metadata": json.dumps({"export_id": export.id})
+                "type": "export_all_user_data",
+                "progress": "Your data export will start soon."
             })
-            task = result.first()
-            if task is not None:
-                db_conn.commit()
-                return jsonify({
-                    "export_id": export.id,
-                    "type": export.type,
-                    "available_until": export.available_until.isoformat() if export.available_until is not None else None,
-                    "created": export.created.isoformat(),
-                    "progress": export.progress,
-                    "status": export.status,
-                    "filename": export.filename,
-                })
+            export = result.first()
 
-        # task already exists in queue, rollback new entry
-        db_conn.rollback()
-        raise APIBadRequest(message="Data export already requested.")
+            if export is not None:
+                query = "INSERT INTO background_tasks (user_id, task, metadata) VALUES (:user_id, :task, :metadata) ON CONFLICT DO NOTHING RETURNING id"
+                result = txn.execute(text(query), {
+                    "user_id": current_user.id,
+                    "task": "export_all_user_data",
+                    "metadata": json.dumps({"export_id": export.id})
+                })
+                task = result.first()
+                if task is not None:
+                    return jsonify({
+                        "export_id": export.id,
+                        "type": export.type,
+                        "available_until": export.available_until.isoformat() if export.available_until is not None else None,
+                        "created": export.created.isoformat(),
+                        "progress": export.progress,
+                        "status": export.status,
+                        "filename": export.filename,
+                    })
+
+            raise APIBadRequest(message="Data export already requested.")
 
     except DatabaseError:
         current_app.logger.error('Error while exporting user data: %s', current_user.musicbrainz_id, exc_info=True)
@@ -131,18 +129,17 @@ def download_export_archive(export_id):
 @web_listenstore_needed
 def delete_export_archive(export_id):
     """ Delete the specified export archive """
-    result = db_conn.execute(
-        text("DELETE FROM user_data_export WHERE user_id = :user_id AND id = :export_id RETURNING filename"),
-        {"user_id": current_user.id, "export_id": export_id}
-    )
-    row = result.first()
-    if row is not None:
-        db_conn.execute(
-            text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->'export_id')::int = :export_id"),
+    with db_conn.engine.begin() as txn:
+        result = txn.execute(
+            text("DELETE FROM user_data_export WHERE user_id = :user_id AND id = :export_id RETURNING filename"),
             {"user_id": current_user.id, "export_id": export_id}
         )
-        db_conn.commit()
-        # file is deleted from disk by cronjob
-        return jsonify({"success": True})
-    else:
+        row = result.first()
+        if row is not None:
+            txn.execute(
+                text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->'export_id')::int = :export_id"),
+                {"user_id": current_user.id, "export_id": export_id}
+            )
+            # file is deleted from disk by cronjob
+            return jsonify({"success": True})
         raise APINotFound("Export not found")

--- a/listenbrainz/webserver/views/import_listens.py
+++ b/listenbrainz/webserver/views/import_listens.py
@@ -108,27 +108,23 @@ def create_import_task():
         if check_existing is not None:
             raise APIBadRequest("An import task is already in progress!")
 
-        result = background.create_import_task(
-            db_conn,
-            user_id=user["id"],
-            service=service,
-            from_date=from_date,
-            to_date=to_date,
-            save_path=save_path,
-            user_timezone=user_timezone,
-            filename=filename
-        )
-        if result is not None:
-            os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
-            uploaded_file.save(save_path)
+        with db_conn.begin():
+            result = background.create_import_task(
+                db_conn,
+                user_id=user["id"],
+                service=service,
+                from_date=from_date,
+                to_date=to_date,
+                save_path=save_path,
+                user_timezone=user_timezone,
+                filename=filename
+            )
+            if result is not None:
+                os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
+                uploaded_file.save(save_path)
+                return jsonify(result)
 
-            db_conn.commit()
-
-            return jsonify(result)
-
-        # task already exists in queue, rollback new entry
-        db_conn.rollback()
-        raise APIBadRequest(message="Data import already requested.")
+            raise APIBadRequest(message="Data import already requested.")
 
     except DatabaseError:
         current_app.logger.error("Error while creating import user data task: %s", user["musicbrainz_id"], exc_info=True)
@@ -188,18 +184,17 @@ def list_import_tasks():
 def delete_import_task(import_id):
     """ Cancel the specified import in progress """
     user = validate_auth_header()
-    result = db_conn.execute(
-        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
-        {"user_id": user["id"], "import_id": import_id}
-    )
-    row = result.first()
-    if row is not None:
-        db_conn.execute(
-            text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
+    with db_conn.begin():
+        result = db_conn.execute(
+            text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
             {"user_id": user["id"], "import_id": import_id}
         )
-        Path(row.file_path).unlink(missing_ok=True)
-        db_conn.commit()
-        return jsonify({"success": True})
-    else:
-        raise APINotFound("Import not found or is already being processed.")
+        row = result.first()
+        if row is not None:
+            db_conn.execute(
+                text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
+                {"user_id": user["id"], "import_id": import_id}
+            )
+            Path(row.file_path).unlink(missing_ok=True)
+            return jsonify({"success": True})
+    raise APINotFound("Import not found or is already being processed.")

--- a/listenbrainz/webserver/views/import_listens.py
+++ b/listenbrainz/webserver/views/import_listens.py
@@ -108,27 +108,23 @@ def create_import_task():
         if check_existing is not None:
             raise APIBadRequest("An import task is already in progress!")
 
-        result = background.create_import_task(
-            db_conn,
-            user_id=user["id"],
-            service=service,
-            from_date=from_date,
-            to_date=to_date,
-            save_path=save_path,
-            user_timezone=user_timezone,
-            filename=filename
-        )
-        if result is not None:
-            os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
-            uploaded_file.save(save_path)
+        with db_conn.engine.begin() as txn:
+            result = background.create_import_task(
+                txn,
+                user_id=user["id"],
+                service=service,
+                from_date=from_date,
+                to_date=to_date,
+                save_path=save_path,
+                user_timezone=user_timezone,
+                filename=filename
+            )
+            if result is not None:
+                os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
+                uploaded_file.save(save_path)
+                return jsonify(result)
 
-            db_conn.commit()
-
-            return jsonify(result)
-
-        # task already exists in queue, rollback new entry
-        db_conn.rollback()
-        raise APIBadRequest(message="Data import already requested.")
+            raise APIBadRequest(message="Data import already requested.")
 
     except DatabaseError:
         current_app.logger.error("Error while creating import user data task: %s", user["musicbrainz_id"], exc_info=True)
@@ -188,18 +184,18 @@ def list_import_tasks():
 def delete_import_task(import_id):
     """ Cancel the specified import in progress """
     user = validate_auth_header()
-    result = db_conn.execute(
-        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
-        {"user_id": user["id"], "import_id": import_id}
-    )
-    row = result.first()
-    if row is not None:
-        db_conn.execute(
-            text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
+    with db_conn.engine.begin() as txn:
+        result = txn.execute(
+            text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
             {"user_id": user["id"], "import_id": import_id}
         )
+        row = result.first()
+        if row is not None:
+            txn.execute(
+                text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
+                {"user_id": user["id"], "import_id": import_id}
+            )
+    if row is not None:
         Path(row.file_path).unlink(missing_ok=True)
-        db_conn.commit()
         return jsonify({"success": True})
-    else:
-        raise APINotFound("Import not found or is already being processed.")
+    raise APINotFound("Import not found or is already being processed.")

--- a/listenbrainz/webserver/views/import_listens.py
+++ b/listenbrainz/webserver/views/import_listens.py
@@ -108,23 +108,27 @@ def create_import_task():
         if check_existing is not None:
             raise APIBadRequest("An import task is already in progress!")
 
-        with db_conn.begin():
-            result = background.create_import_task(
-                db_conn,
-                user_id=user["id"],
-                service=service,
-                from_date=from_date,
-                to_date=to_date,
-                save_path=save_path,
-                user_timezone=user_timezone,
-                filename=filename
-            )
-            if result is not None:
-                os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
-                uploaded_file.save(save_path)
-                return jsonify(result)
+        result = background.create_import_task(
+            db_conn,
+            user_id=user["id"],
+            service=service,
+            from_date=from_date,
+            to_date=to_date,
+            save_path=save_path,
+            user_timezone=user_timezone,
+            filename=filename
+        )
+        if result is not None:
+            os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
+            uploaded_file.save(save_path)
 
-            raise APIBadRequest(message="Data import already requested.")
+            db_conn.commit()
+
+            return jsonify(result)
+
+        # task already exists in queue, rollback new entry
+        db_conn.rollback()
+        raise APIBadRequest(message="Data import already requested.")
 
     except DatabaseError:
         current_app.logger.error("Error while creating import user data task: %s", user["musicbrainz_id"], exc_info=True)
@@ -184,17 +188,18 @@ def list_import_tasks():
 def delete_import_task(import_id):
     """ Cancel the specified import in progress """
     user = validate_auth_header()
-    with db_conn.begin():
-        result = db_conn.execute(
-            text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
+    result = db_conn.execute(
+        text("DELETE FROM user_data_import WHERE user_id = :user_id AND id = :import_id AND metadata->>'status' IN ('waiting') RETURNING file_path"),
+        {"user_id": user["id"], "import_id": import_id}
+    )
+    row = result.first()
+    if row is not None:
+        db_conn.execute(
+            text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
             {"user_id": user["id"], "import_id": import_id}
         )
-        row = result.first()
-        if row is not None:
-            db_conn.execute(
-                text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
-                {"user_id": user["id"], "import_id": import_id}
-            )
-            Path(row.file_path).unlink(missing_ok=True)
-            return jsonify({"success": True})
-    raise APINotFound("Import not found or is already being processed.")
+        Path(row.file_path).unlink(missing_ok=True)
+        db_conn.commit()
+        return jsonify({"success": True})
+    else:
+        raise APINotFound("Import not found or is already being processed.")

--- a/listenbrainz/webserver/views/test/test_user.py
+++ b/listenbrainz/webserver/views/test/test_user.py
@@ -38,7 +38,7 @@ class UserViewsTestCase(IntegrationTestCase):
 
         abuser = db_user.get_or_create(self.db_conn, 3, 'abuser')
         self.abuser = User.from_dbrow(abuser)
-        self.ts_conn = timescale.engine.connect()
+        self.ts_conn = timescale.engine.connect().execution_options(isolation_level="AUTOCOMMIT")
 
     def tearDown(self):
         self.ts_conn.close()

--- a/test.sh
+++ b/test.sh
@@ -256,10 +256,6 @@ if [ $DB_RUNNING -eq 1 ] ; then
     echo "Running tests"
     docker_compose_run listenbrainz pytest "$@"
     RET=$?
-    if [ $RET -ne 0 ]; then
-        echo "Tests failed; background task worker logs follow"
-        invoke_docker_compose logs --no-color background_tasks
-    fi
     exit $RET
 else
     # Else, we have containers, just run tests

--- a/test.sh
+++ b/test.sh
@@ -256,6 +256,10 @@ if [ $DB_RUNNING -eq 1 ] ; then
     echo "Running tests"
     docker_compose_run listenbrainz pytest "$@"
     RET=$?
+    if [ $RET -ne 0 ]; then
+        echo "Tests failed; background task worker logs follow"
+        invoke_docker_compose logs --no-color background_tasks
+    fi
     exit $RET
 else
     # Else, we have containers, just run tests


### PR DESCRIPTION
# Problem

## What is the issue?
Per-request database connections sit idle-in-transaction for the entire request lifetime, causing connection pool exhaustion and a 100x p95 latency cliff (p50=1.3ms vs p95=382ms on user table PK lookups).

## Why does it happen?
SQLAlchemy's `Connection.execute()` implicitly opens a PostgreSQL transaction (autobegin). The per-request connection proxies (`db_conn`, `ts_conn`, `meb_conn`) hold this transaction open until `teardown_appcontext` calls `.close()`. During non-DB work (Redis, template rendering, external calls), the connection sits idle-in-transaction, blocking autovacuum and consuming pool slots.

# Solution

Set `AUTOCOMMIT` isolation level on all three per-request connection proxies. In AUTOCOMMIT mode, each `execute()` auto-commits immediately at the database level, eliminating idle-in-transaction connections.

Multi-statement write functions that need atomicity (DELETE+INSERT, UPDATE+INSERT, etc.) are wrapped in `with conn.engine.begin() as txn:` blocks. This checks out a separate short-lived connection with a real PostgreSQL transaction -- commits on block exit, rolls back on exception. The per-request connection stays in AUTOCOMMIT mode throughout.

Functions wrapped with `engine.begin()`:
- `feedback.insert()` -- DELETE + INSERT
- `pinned_recording.pin()` -- UPDATE + INSERT
- `external_service_oauth.save_token()` -- INSERT + conditional INSERT
- `external_service_oauth.delete_token()` -- DELETE + conditional DELETE
- `playlist.create()`, `update_playlist()`, `delete_recordings_from_playlist()`, `add_recordings_to_playlist()`, `delete_playlists_by_user_id()`
- `export.create_export_task()`, `delete_export_archive()`
- `import_listens.create_import_task()`, `delete_import_task()`

Single-statement writes keep their existing `commit()` calls, which are harmless no-ops in AUTOCOMMIT mode.

Test connections are also set to AUTOCOMMIT to match production behavior.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR