### PR TITLE
Add GIN trigram indexes for playlist similarity search

### DIFF
--- a/admin/timescale/create_indexes.sql
+++ b/admin/timescale/create_indexes.sql
@@ -26,6 +26,8 @@ CREATE INDEX collaborator_id_playlist_collaborator ON playlist.playlist_collabor
 CREATE INDEX playlist_id_collaborator_id_playlist_collaborator
     ON playlist.playlist_collaborator (playlist_id, collaborator_id);
 CREATE INDEX public_playlist_idx ON playlist.playlist (creator_id, created_for_id) WHERE public = true;
+CREATE INDEX playlist_name_trgm_gin ON playlist.playlist USING GIN (name gin_trgm_ops);
+CREATE INDEX playlist_description_trgm_gin ON playlist.playlist USING GIN (description gin_trgm_ops);
 
 -- MBID Mapping
 

--- a/admin/timescale/updates/2026-08-21-add-playlist-search-gin-index.sql
+++ b/admin/timescale/updates/2026-08-21-add-playlist-search-gin-index.sql
@@ -1,0 +1,4 @@
+-- GIN trigram index for playlist similarity search.
+-- Without this, similarity() queries do sequential scans (~126s avg).
+CREATE INDEX CONCURRENTLY playlist_name_trgm_gin ON playlist.playlist USING GIN (name gin_trgm_ops);
+CREATE INDEX CONCURRENTLY playlist_description_trgm_gin ON playlist.playlist USING GIN (description gin_trgm_ops);


### PR DESCRIPTION
# Problem

## What is the issue?
Playlist similarity search queries (`similarity()` on `name` and `description`) perform sequential scans on the `playlist.playlist` table, averaging ~126s per query and consuming ~347 server-hours/week.

## Why does it happen?
The `pg_trgm` extension is installed but there are no GIN trigram indexes on the `name` and `description` columns, so PostgreSQL falls back to sequential scans for `similarity()` calls.

# Solution

Add GIN trigram indexes (`gin_trgm_ops`) on `playlist.playlist.name` and `playlist.playlist.description`:

- Migration script (`admin/timescale/updates/2026-08-21-add-playlist-search-gin-index.sql`) uses `CREATE INDEX CONCURRENTLY` for zero-downtime deployment on production
- Base `create_indexes.sql` includes the same indexes (without `CONCURRENTLY`) for fresh deployments and tests

Note: `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block, so the migration script intentionally has no `BEGIN`/`COMMIT` wrapper.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR