### PR TITLE
Fix generic Exception for invalid user in playlist creation

### DIFF
--- a/listenbrainz/db/exceptions.py
+++ b/listenbrainz/db/exceptions.py
@@ -11,3 +11,8 @@ class NoDataFoundException(DatabaseException):
 class BadDataException(DatabaseException):
     """Should be used when incorrect data is being submitted."""
     pass
+
+
+class InvalidUser(DatabaseException):
+    """Should be used when an invalid user ID is provided."""
+    pass

--- a/listenbrainz/db/playlist.py
+++ b/listenbrainz/db/playlist.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 
 from listenbrainz.db.model import playlist as model_playlist
 from listenbrainz.db import user as db_user
+from listenbrainz.db.exceptions import InvalidUser
 from listenbrainz.db.model.playlist import Playlist
 from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects
 from listenbrainz.db.year_in_music import LAST_FM_FOUNDING_YEAR, MAX_YEAR_IN_MUSIC_YEAR
@@ -724,7 +725,7 @@ def create(db_conn, ts_conn, playlist: model_playlist.WritablePlaylist) -> model
     # TODO: These two gets should be done in a single query
     creator = db_user.get(db_conn, playlist.creator_id)
     if creator is None:
-        raise Exception("TODO: Custom exception")
+        raise InvalidUser("Invalid creator user ID")
 
     # TODO: In a way this is less than ideal -- the caller must take the string name and find the ID,
     # and then the name is fetched for verification again. Should we accept created_for here and do
@@ -732,7 +733,7 @@ def create(db_conn, ts_conn, playlist: model_playlist.WritablePlaylist) -> model
     if playlist.created_for_id:
         created_for = db_user.get(db_conn, playlist.created_for_id)
         if created_for is None:
-            raise Exception("TODO: Custom exception")
+            raise InvalidUser("Invalid created_for user ID")
 
     query = text("""
         INSERT INTO playlist.playlist (creator_id

--- a/listenbrainz/db/tests/test_playlist.py
+++ b/listenbrainz/db/tests/test_playlist.py
@@ -9,6 +9,7 @@ from listenbrainz.db.playlist import TROI_BOT_USER_ID
 
 from listenbrainz.tests.integration import IntegrationTestCase, TIMESCALE_SQL_DIR
 from listenbrainz.db import timescale
+from listenbrainz.db.exceptions import InvalidUser
 from listenbrainz.db.model.playlist import WritablePlaylist, WritablePlaylistRecording
 
 
@@ -376,3 +377,30 @@ class PlaylistTestCase(IntegrationTestCase):
         )
         self.assertIsNotNone(updated_playlist)
         self.assertNotIn(self.user_1["id"], updated_playlist.collaborator_ids)
+
+    def test_create_playlist_invalid_user(self):
+        """db_playlist.create raises InvalidUser when creator or created_for user does not exist"""
+        playlist_invalid_creator = WritablePlaylist(
+            name="Invalid Creator Playlist",
+            creator_id=9999999,
+            description="Testing invalid creator",
+            collaborator_ids=[],
+            collaborators=[],
+            public=True,
+            additional_metadata={},
+        )
+        with self.assertRaises(InvalidUser):
+            db_playlist.create(self.db_conn, self.ts_conn, playlist_invalid_creator)
+
+        playlist_invalid_created_for = WritablePlaylist(
+            name="Invalid Created For Playlist",
+            creator_id=self.user_1["id"],
+            created_for_id=9999999,
+            description="Testing invalid created_for",
+            collaborator_ids=[],
+            collaborators=[],
+            public=True,
+            additional_metadata={},
+        )
+        with self.assertRaises(InvalidUser):
+            db_playlist.create(self.db_conn, self.ts_conn, playlist_invalid_created_for)

--- a/listenbrainz/tests/integration/test_playlist_api.py
+++ b/listenbrainz/tests/integration/test_playlist_api.py
@@ -10,6 +10,7 @@ from listenbrainz.domain.spotify import OAUTH_TOKEN_URL
 from listenbrainz.tests.integration import IntegrationTestCase
 import listenbrainz.db.user as db_user
 import listenbrainz.db.external_service_oauth as db_oauth
+from listenbrainz.db.exceptions import InvalidUser
 from listenbrainz.webserver.views.api import DEFAULT_NUMBER_OF_PLAYLISTS_PER_CALL
 from listenbrainz.webserver.views import playlist_api
 from listenbrainz.webserver.views.playlist_api import PLAYLIST_TRACK_URI_PREFIX, PLAYLIST_URI_PREFIX, PLAYLIST_EXTENSION_URI
@@ -204,6 +205,20 @@ class PlaylistAPITestCase(IntegrationTestCase):
 
         # Make sure the return playlist id is valid
         UUID(response.json["playlist_mbid"])
+
+    @mock.patch("listenbrainz.db.playlist.create")
+    def test_playlist_create_invalid_user(self, mock_create):
+        """ Test to ensure InvalidUser exception in playlist creation returns 400 """
+        mock_create.side_effect = InvalidUser("Invalid creator user ID")
+        playlist = get_test_data()
+
+        response = self.client.post(
+            self.custom_url_for("playlist_api_v1.create_playlist"),
+            json=playlist,
+            headers={"Authorization": "Token {}".format(self.user["auth_token"])}
+        )
+        self.assert400(response)
+        self.assertEqual(response.json["error"], "Invalid creator user ID")
 
     def test_playlist_xspf_additional_metadata(self):
         """ Test for checking that additional meta data field is properly constructed and not causing a crash """

--- a/listenbrainz/webserver/views/playlist_api.py
+++ b/listenbrainz/webserver/views/playlist_api.py
@@ -10,6 +10,7 @@ from psycopg2.extras import DictCursor
 
 import listenbrainz.db.playlist as db_playlist
 import listenbrainz.db.user as db_user
+from listenbrainz.db.exceptions import InvalidUser
 from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_PLAYLIST_PERMISSIONS
 from listenbrainz.domain.apple import AppleService
 from listenbrainz.domain.soundcloud import SoundCloudService
@@ -399,6 +400,8 @@ def create_playlist():
 
     try:
         playlist = db_playlist.create(db_conn, ts_conn, playlist)
+    except InvalidUser as e:
+        log_raise_400(str(e))
     except Exception as e:
         current_app.logger.error("Error while creating new playlist: {}".format(e))
         raise APIInternalServerError("Failed to create the playlist. Please try again.")
@@ -851,6 +854,8 @@ def copy_playlist(playlist_mbid):
 
     try:
         new_playlist = db_playlist.copy_playlist(db_conn, ts_conn, playlist, user["id"])
+    except InvalidUser as e:
+        log_raise_400(str(e))
     except Exception as e:
         current_app.logger.error("Error copying playlist: {}".format(e))
         raise APIInternalServerError("Failed to copy the playlist. Please try again.")


### PR DESCRIPTION
# Problem

The `create_playlist` function in `listenbrainz/db/playlist.py` was raising a generic `Exception("TODO: Custom exception")` when an invalid user ID was provided. While the docstring documented that it should raise `InvalidUser`, this exception was never actually implemented or used.

# Solution

- Created the `InvalidUser` exception in `listenbrainz/db/exceptions.py` inheriting from `DatabaseException`.
- Imported `InvalidUser` into `listenbrainz/db/playlist.py`.
- Replaced the generic `Exception` with `InvalidUser` to improve error handling and fulfill the existing TODO.

* [x] I have run the code and manually tested the changes

# AI usage
* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

# Action
None required.
