### PR TITLE
fix: redact sensitive config values from startup logs

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -73,7 +73,23 @@ def load_config(app):
     # Output config values and some other info
     if deploy_env in ['prod', 'beta', 'test']:
         print('Configuration values are as follows: ')
-        print(pprint.pformat(app.config, indent=4))
+        sensitive_keys = {
+            'SECRET_KEY', 'SQLALCHEMY_DATABASE_URI', 'POSTGRES_ADMIN_URI',
+            'SQLALCHEMY_TIMESCALE_URI', 'TIMESCALE_ADMIN_URI',
+            'TIMESCALE_ADMIN_LB_URI', 'RABBITMQ_PASSWORD', 'RABBITMQ_USERNAME',
+            'OAUTH_CLIENT_SECRET', 'OAUTH_WEBHOOK_SECRET',
+            'LASTFM_API_KEY', 'LIBREFM_API_KEY', 'TYPESENSE_API_KEY',
+            'COUCHDB_USER', 'COUCHDB_PASSWORD', 'COUCHDB_ADMIN_KEY',
+            'SPOTIFY_CLIENT_SECRET', 'SOUNDCLOUD_CLIENT_SECRET',
+            'APPLE_MUSIC_KEY', 'YOUTUBE_API_KEY',
+            'CRITIQUEBRAINZ_CLIENT_SECRET',
+            'SENTRY_DSN',
+        }
+        filtered_config = {
+            k: ('***REDACTED***' if k in sensitive_keys else v)
+            for k, v in app.config.items()
+        }
+        print(pprint.pformat(filtered_config, indent=4))
 
         try:
             with open('.git-version') as git_version_file:


### PR DESCRIPTION
# Problem

This PR addresses a critical configuration leak vulnerability. Currently, when the server starts in `prod`, `beta`, or `test` environments, it unconditionally prints the entirety of `app.config` to standard output. This inadvertently leaks highly sensitive information (e.g. `SECRET_KEY`, `SQLALCHEMY_DATABASE_URI`, API credentials, passwords) into the application logs.

# Solution

I've implemented a dictionary comprehension that filters and redacts known sensitive keys (replacing their values with `***REDACTED***`) before the configuration is printed to the logs.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

# Action

None.
