### PR TITLE
fix: Add timeouts to external API requests

### DIFF
--- a/listenbrainz/domain/critiquebrainz.py
+++ b/listenbrainz/domain/critiquebrainz.py
@@ -37,7 +37,7 @@ class CritiqueBrainzService(BaseBrainzService):
         payload = review.dict(exclude_none=True)
         payload["is_draft"] = False
         payload["license_choice"] = CRITIQUEBRAINZ_REVIEW_LICENSE
-        return requests.post(CRITIQUEBRAINZ_REVIEW_SUBMIT_URL, json=payload, headers=headers)
+        return requests.post(CRITIQUEBRAINZ_REVIEW_SUBMIT_URL, json=payload, headers=headers, timeout=10)
 
     def submit_review(self, user_id: int, review: CBReviewMetadata) -> str:
         """ Submit a review for the user to CritiqueBrainz.
@@ -76,7 +76,7 @@ class CritiqueBrainzService(BaseBrainzService):
     def fetch_reviews(self, review_ids: Iterable[str]):
         if not review_ids:
             return None
-        response = requests.get(CRITIQUEBRAINZ_REVIEW_FETCH_URL, params={"review_ids": ",".join(review_ids)})
+        response = requests.get(CRITIQUEBRAINZ_REVIEW_FETCH_URL, params={"review_ids": ",".join(review_ids)}, timeout=10)
         if response.status_code != 200:
             return None
         return response.json()["reviews"]

--- a/listenbrainz/domain/musicbrainz.py
+++ b/listenbrainz/domain/musicbrainz.py
@@ -38,6 +38,7 @@ class MusicBrainzService(BaseBrainzService):
                 "token_type_hint": "access_token",
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()
@@ -46,6 +47,7 @@ class MusicBrainzService(BaseBrainzService):
         response = requests.get(
             current_app.config["OAUTH_USERINFO_URL"],
             headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()

--- a/listenbrainz/domain/soundcloud.py
+++ b/listenbrainz/domain/soundcloud.py
@@ -50,6 +50,6 @@ class SoundCloudService(BaseBrainzService):
         )
 
     def get_user_info(self, token: str):
-        response = requests.get(SOUNDCLOUD_USER_INFO_URL, headers={"Authorization": f"OAuth {token}"})
+        response = requests.get(SOUNDCLOUD_USER_INFO_URL, headers={"Authorization": f"OAuth {token}"}, timeout=10)
         response.raise_for_status()
         return response.json()

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -121,8 +121,7 @@ def _get_spotify_token(grant_type: str, token: str) -> requests.Response:
         token_key: token,
         'grant_type': grant_type,
     }
-
-    return requests.post(OAUTH_TOKEN_URL, data=payload, headers=headers, verify=True)
+    return requests.post(OAUTH_TOKEN_URL, data=payload, headers=headers, verify=True, timeout=10)
 
 
 class SpotifyService(ImporterService):


### PR DESCRIPTION
# Problem

Several external API integrations in the `listenbrainz/domain` directory were making outgoing HTTP requests using `requests.get` and `requests.post` without specifying a `timeout` parameter. In Python's `requests` library, if the remote server hangs and doesn't close the connection, the request will block indefinitely. This is a notorious cause of backend worker thread exhaustion and cascading failures.

# Solution

Enforced a strict `timeout=10` on the external API calls across these domain integrations to ensure ListenBrainz processes will gracefully error out (or move on) rather than locking up forever if external services (like MusicBrainz, Spotify, etc.) become unresponsive.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR
