### PR TITLE
feat: dual-write listens to partitioned database

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -110,14 +110,16 @@ SQLALCHEMY_BINDS = {}
 {{end}}
 
 
-# New listens database (plain postgres, listens partitioned by user_id). Currently only used as the
-# target of listenbrainz/listenstore/migrate_listens.py while listens are migrated away from timescale.
+# New listens database (plain postgres, listens partitioned by user_id). During migration, new
+# listens and deletes are mirrored here while Timescale remains the read store.
 {{if service "listenbrainz-user-listenstore"}}
 {{with index (service "listenbrainz-user-listenstore") 0}}
 SQLALCHEMY_LISTENS_URI = """postgresql://{{template "KEY" "listens_db_user"}}:{{template "KEY" "listens_db_password"}}@{{.Address}}:{{.Port}}/{{template "KEY" "listens_db_name"}}"""
+LISTENS_ADMIN_URI = """postgresql://postgres:{{template "KEY" "listens_admin_password"}}@{{.Address}}:{{.Port}}/postgres"""
 {{end}}
 {{else}}
 SQLALCHEMY_LISTENS_URI = "SERVICEDOESNOTEXIST_listenbrainz-user-listenstore"
+LISTENS_ADMIN_URI = "SERVICEDOESNOTEXIST_listenbrainz-user-listenstore"
 {{end}}
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents
 
    users/api/index
    users/api-usage
+   users/connect-music-services
    users/json
    users/widgets
    users/clients

--- a/docs/users/connect-music-services.rst
+++ b/docs/users/connect-music-services.rst
@@ -1,0 +1,138 @@
+Connecting music services from another application
+==================================================
+
+ListenBrainz can import a user's listening history from music services such as Spotify. The
+connection to those services is made with OAuth, and one of the security measures in OAuth
+is the session state protecting the authorization request. That state can only be created
+on the domain that initiates the request, in this case ``listenbrainz.org``, so another
+application cannot start the flow on ListenBrainz's behalf.
+
+Instead, a third party application sends the user to ListenBrainz, ListenBrainz creates the
+session state and runs the whole OAuth dance with the music service, stores the resulting
+tokens and then sends the user back to the application that started the flow::
+
+    your app  ──▶  listenbrainz.org/connect/spotify/  ──▶  accounts.spotify.com
+                       (confirmation page)                          │
+    your app  ◀──  listenbrainz.org/settings/…/callback/  ◀─────────┘
+
+The user is never logged in to ListenBrainz along the way — you tell us who they are in
+advance with a MetaBrainz OAuth access token. Because of that, ListenBrainz shows them one
+page before handing them on to the music service: it names your application and the host
+they will be returned to, names the ListenBrainz account the music service would be
+connected to, and asks them to confirm. That page is the only point in the flow where they are told which account this
+is for, so it cannot be skipped. Everything after it is a plain redirect.
+
+Getting access
+--------------
+
+There is nothing to register with ListenBrainz. The ``listenbrainz:connect-services``
+scope is only granted to applications MetaBrainz has approved for it, and an access token
+carrying that scope is the whole of the authorization — there is no separate ListenBrainz
+``client_id`` or ``client_secret``. Apply to MetaBrainz for the scope.
+
+The name shown to your users on the confirmation page is the one your application is
+registered under with MetaBrainz, so make sure it is a name they will recognise.
+
+Because there is no registered list of redirect uris to match against, ``redirect_uri`` is
+whatever you send, as long as it is an absolute ``https`` url (``http`` is accepted only
+for ``localhost``, for local development).
+
+Starting the flow
+-----------------
+
+Ask your user for a MetaBrainz OAuth access token with the
+``listenbrainz:connect-services`` scope, then post it from your backend:
+
+.. code-block:: none
+
+    POST https://listenbrainz.org/connect/<service>/
+    Authorization: Bearer <MetaBrainz OAuth access token>
+    Content-Type: application/json
+
+    {
+        "redirect_uri": "https://your.app/listenbrainz/connected",
+        "state": "...",
+        "permissions": "import"
+    }
+
+``<service>`` is ``spotify``. It is the only service this flow supports at the moment;
+anything else is rejected with a ``400``.
+
+:json redirect_uri: **(required)** Where the user is sent once the flow finishes. It has
+    to be an absolute ``https`` url. Its host is shown to the user on the confirmation
+    page next to your application's name, so use one they will recognise.
+:json state: An opaque value that is returned to you unchanged. Use it to protect against
+    cross site request forgery and to identify the user the flow belongs to. It cannot be
+    longer than 255 characters.
+:json permissions: What ListenBrainz should be able to do with the account: ``import``
+    (read listening history, the default), ``listen`` (play music in the ListenBrainz
+    player) or ``both``.
+:json force: By default, a user who has already granted ListenBrainz the requested
+    permissions is sent straight back to your application without seeing the music service
+    again. Set this to ``true`` to always show the authorization screen.
+
+We introspect the token, check that it carries the ``listenbrainz:connect-services`` scope
+and resolve the ListenBrainz account it belongs to. ListenBrainz user tokens (the ones on
+the settings page) are **not** accepted here — connecting a music service on someone's
+behalf has to be granted explicitly.
+
+The response contains a single use url:
+
+.. code-block:: json
+
+    {
+        "url": "https://listenbrainz.org/connect/spotify/?ticket=...",
+        "expires_in": 600
+    }
+
+Redirect the user's browser to that url within ``expires_in`` seconds. ListenBrainz shows
+them the confirmation page there; once they confirm, it sends them on to the music service
+and returns them to your ``redirect_uri`` as described below. The url can only be used once
+— it is spent when the user answers the confirmation, either way — and it does **not** log
+the user in to ListenBrainz. A url that has expired or has already been used results in a
+``400 Bad Request``.
+
+Errors from the POST are returned as JSON with a ``4xx``/``5xx`` status: ``401`` if the
+access token is missing, invalid, expired or lacks the scope, ``400`` if the request itself
+is malformed and ``503`` if we could not reach the MetaBrainz introspection endpoint.
+
+Returning to your application
+-----------------------------
+
+Once the flow finishes, the user is redirected to your ``redirect_uri`` with these query
+parameters added:
+
+:query service: The service that was being connected.
+:query status: ``connected`` if the account is now connected, ``error`` otherwise.
+:query state: The ``state`` you sent, if any.
+:query error: Present when ``status`` is ``error``. One of:
+
+    ``invalid_request``
+        The music service returned an authorization that we could not match to the request
+        that started the flow, or the single use url was opened by a browser logged in to
+        a different ListenBrainz account than the one it was created for.
+    ``access_denied``
+        The user declined — either on the ListenBrainz confirmation page, because the
+        account named there was not theirs, or on the music service itself.
+    ``email_required``
+        The user's MetaBrainz account does not have a verified email address, which
+        ListenBrainz requires before connecting a music service. The user has to verify
+        their email on their MetaBrainz profile and start the flow again.
+    ``expired_request``
+        The user took too long to authorize ListenBrainz.
+    ``server_error``
+        Something went wrong on the ListenBrainz side, or the music service refused the
+        authorization for a reason other than the user declining. ``error_description``
+        carries the reason the music service gave.
+
+:query error_description: A human readable description of ``error``.
+
+For example, a successful Spotify connection returns the user to:
+
+.. code-block:: none
+
+    https://your.app/listenbrainz/connected?service=spotify&status=connected&state=<your state>
+
+Note that ``status=connected`` tells you the ListenBrainz user connected the service, it
+does not tell you which ListenBrainz user that was. If you need to know that, ask the user
+for their ListenBrainz user token as you would otherwise.

--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -449,6 +449,7 @@ export default function MusicServices() {
     const navidromeError = params.get("navidrome_error");
     const navidromeSuccess = params.get("navidrome_success");
     const soundcloudError = params.get("soundcloud_error");
+    const serviceError = params.get("service_error");
 
     if (funkwhaleSuccess === "Successfully connected to Funkwhale") {
       toast.success(
@@ -493,13 +494,23 @@ export default function MusicServices() {
       );
     }
 
+    if (serviceError) {
+      toast.error(
+        <ToastMsg
+          title="Connection Error"
+          message={decodeURIComponent(serviceError)}
+        />
+      );
+    }
+
     // Clear the query parameters from the URL for both success and error cases
     if (
       funkwhaleSuccess ||
       funkwhaleError ||
       navidromeSuccess ||
       navidromeError ||
-      soundcloudError
+      soundcloudError ||
+      serviceError
     ) {
       window.history.replaceState(
         {},

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -23,8 +23,9 @@ SQLALCHEMY_TIMESCALE_PGBOUNCER_URI = SQLALCHEMY_TIMESCALE_URI
 TIMESCALE_ADMIN_URI = "postgresql://postgres:postgres@lb_db/postgres"
 TIMESCALE_ADMIN_LB_URI = "postgresql://postgres:postgres@lb_db/listenbrainz_ts"
 
-# Listens (postgres, user_id partitioned) - target of listenbrainz/listenstore/migrate_listens.py
-SQLALCHEMY_LISTENS_URI = ""
+# Listens (postgres, user_id partitioned) - migration target and dual-write store
+SQLALCHEMY_LISTENS_URI = "postgresql://listenbrainz_listens:listenbrainz_listens@lb_db/listenbrainz_listens"
+LISTENS_ADMIN_URI = "postgresql://postgres:postgres@lb_db/postgres"
 
 # Server address
 # SERVER_NAME = "localhost:8100"

--- a/listenbrainz/db/listens.py
+++ b/listenbrainz/db/listens.py
@@ -1,0 +1,142 @@
+"""Database helpers for the user-partitioned listens database."""
+
+import logging
+import time
+from typing import Optional, Sequence
+
+import psycopg2
+import sqlalchemy
+from psycopg2.extras import execute_values
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
+
+
+logger = logging.getLogger(__name__)
+
+engine: Optional[sqlalchemy.engine.Engine] = None
+
+
+INSERT_LISTENS_QUERY = """
+    INSERT INTO listen (listened_at, created, user_id, recording_msid, data)
+         VALUES %s
+    ON CONFLICT (user_id, listened_at, recording_msid)
+      DO UPDATE
+            SET created = excluded.created
+              , data = excluded.data
+          WHERE excluded.created > listen.created
+"""
+
+DELETE_LISTENS_QUERY = """
+    DELETE FROM listen l
+     USING (VALUES %s) AS deleted (user_id, listened_at, recording_msid)
+     WHERE l.user_id = deleted.user_id
+       AND l.listened_at = deleted.listened_at
+       AND l.recording_msid = deleted.recording_msid
+"""
+
+DELETE_USER_LISTENS_QUERY = "DELETE FROM listen WHERE user_id = %s AND created <= %s"
+
+
+def create_test_listens_connect_strings():
+    db_name = "listenbrainz_listens_test"
+    db_user = "listenbrainz_listens_test"
+    return {
+        "DB_CONNECT": f"postgresql://{db_user}:listenbrainz_listens@lb_db/{db_name}",
+        "DB_CONNECT_ADMIN": "postgresql://postgres:postgres@lb_db/postgres",
+        "DB_CONNECT_ADMIN_LB": f"postgresql://postgres:postgres@lb_db/{db_name}",
+        "DB_NAME": db_name,
+        "DB_USER": db_user,
+    }
+
+
+def _is_configured(connect_str: Optional[str]) -> bool:
+    """Return whether a rendered config value points at the listens database."""
+    return bool(
+        connect_str
+        and not connect_str.startswith("SERVICEDOESNOTEXIST")
+        and "KEYDOESNOTEXIST" not in connect_str
+    )
+
+
+def init_db_connection(connect_str, poolclass=NullPool, **engine_kwargs):
+    """Initialize the connection to the user-partitioned listens database.
+
+    A missing or unrendered connect string leaves `engine` as None, which makes every write here
+    a no-op. Warn, since in a deployment that silently stops the dual write.
+    """
+    global engine
+    engine = None
+    if not _is_configured(connect_str):
+        logger.warning("Listens database is not configured, listens will NOT be mirrored to the"
+                       " partitioned database.")
+        return
+
+    while True:
+        try:
+            engine = create_engine(connect_str, poolclass=poolclass, **engine_kwargs)
+            break
+        except psycopg2.OperationalError as e:
+            print("Couldn't establish connection to listens database: {}".format(str(e)))
+            print("Sleeping 2 seconds and trying again...")
+            time.sleep(2)
+
+
+def insert(rows: Sequence[tuple]):
+    """Idempotently mirror Timescale listen rows into the partitioned database."""
+    if not rows or engine is None:
+        return
+
+    connection = engine.raw_connection()
+    try:
+        with connection.cursor() as cursor:
+            execute_values(
+                cursor,
+                INSERT_LISTENS_QUERY,
+                rows,
+                template="(%s::timestamptz, %s::timestamptz, %s::integer, %s::uuid, %s::jsonb)",
+            )
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def delete(deletes: Sequence[tuple]):
+    """Delete logical listens from the partitioned database."""
+    if not deletes or engine is None:
+        return
+
+    connection = engine.raw_connection()
+    try:
+        with connection.cursor() as cursor:
+            execute_values(
+                cursor,
+                DELETE_LISTENS_QUERY,
+                deletes,
+                template="(%s::integer, %s::timestamptz, %s::uuid)",
+            )
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def delete_user(user_id: int, created):
+    """Delete a user's listens up to the same cutoff used by Timescale."""
+    if engine is None:
+        return
+
+    connection = engine.raw_connection()
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(DELETE_USER_LISTENS_QUERY, (user_id, created))
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()

--- a/listenbrainz/db/oauth_client.py
+++ b/listenbrainz/db/oauth_client.py
@@ -1,0 +1,28 @@
+""" Read only access to the OAuth applications registered with MetaBrainz.
+
+The table lives in the MetaBrainz database (see metabrainz.org, ``metabrainz/model/oauth/
+client.py``), so everything here goes through ``meb_conn`` rather than the ListenBrainz
+connection, and is only usable when SQLALCHEMY_METABRAINZ_URI is configured.
+"""
+
+from typing import Optional
+
+import sqlalchemy
+
+
+def get_client_name(meb_conn, client_id: str) -> Optional[str]:
+    """ Return the name the owner of an OAuth client registered it under.
+
+    Args:
+        meb_conn: a connection to the MetaBrainz database
+        client_id: the client id, as returned by the introspection endpoint
+
+    Returns: the name of the application, or None if there is no such client.
+    """
+    result = meb_conn.execute(sqlalchemy.text("""
+        SELECT name
+          FROM oauth.client
+         WHERE client_id = :client_id
+    """), {"client_id": client_id})
+    row = result.fetchone()
+    return row.name if row else None

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -76,6 +76,18 @@ class TimescaleTestCase(unittest.TestCase):
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))
 
     def reset_listens_db(self):
+        expected_db_name = create_test_listens_connect_strings()["DB_NAME"]
+        if not expected_db_name.endswith("_test"):
+            raise RuntimeError(f"Refusing to reset non-test listens database {expected_db_name!r}")
+
         with listens_db.engine.connect() as connection:
+            actual_db_name = connection.execute(
+                sqlalchemy.text("SELECT current_database()")
+            ).scalar_one()
+            if actual_db_name != expected_db_name:
+                raise RuntimeError(
+                    f"Refusing to reset listens database {actual_db_name!r}; "
+                    f"expected {expected_db_name!r}"
+                )
             connection.execute(sqlalchemy.text("TRUNCATE TABLE listen"))
             connection.commit()

--- a/listenbrainz/db/testing.py
+++ b/listenbrainz/db/testing.py
@@ -7,7 +7,8 @@ import uuid
 
 from listenbrainz import config
 from listenbrainz import db
-from listenbrainz.db import timescale as ts, create_test_database_connect_strings
+from listenbrainz.db import listens as listens_db, timescale as ts, create_test_database_connect_strings
+from listenbrainz.db.listens import create_test_listens_connect_strings
 from listenbrainz.db.timescale import create_test_timescale_connect_strings
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'admin', 'sql')
@@ -63,8 +64,18 @@ class TimescaleTestCase(unittest.TestCase):
         self.reset_timescale_db()
         self.ts_conn = ts.engine.connect()
 
+        # listens are dual written, so reset the partitioned database alongside timescale
+        listens_connect = create_test_listens_connect_strings()
+        listens_db.init_db_connection(listens_connect["DB_CONNECT"])
+        self.reset_listens_db()
+
     def tearDown(self):
         self.ts_conn.close()
 
     def reset_timescale_db(self):
         ts.run_sql_script(os.path.join(TIMESCALE_SQL_DIR, 'reset_tables.sql'))
+
+    def reset_listens_db(self):
+        with listens_db.engine.connect() as connection:
+            connection.execute(sqlalchemy.text("TRUNCATE TABLE listen"))
+            connection.commit()

--- a/listenbrainz/domain/external_connect.py
+++ b/listenbrainz/domain/external_connect.py
@@ -1,0 +1,545 @@
+""" Support for third party applications that want their users to connect an external
+music service to ListenBrainz. Only Spotify is offered for now, see CONNECTABLE_SERVICES.
+
+OAuth requires the session state protecting the authorization request to be created on the
+same domain that initiates it, so a partner application cannot start the flow on our behalf.
+Instead the partner sends the user to ListenBrainz, ListenBrainz creates the session state
+and runs the entire OAuth dance with the music service, stores the resulting tokens and
+finally sends the user back to the partner application.
+
+The partner has to know which MetaBrainz account the user has before it can start the flow,
+which it proves by sending us a MetaBrainz OAuth access token the user granted it:
+
+1. the partner posts the access token to ``/connect/<service>/`` from its backend.
+   ListenBrainz introspects the token, checks that it carries the
+   ``listenbrainz:connect-services`` scope, looks up the name of the application it was
+   issued to in the MetaBrainz OAuth client registry and hands back a single use url. The
+   user is never logged in to ListenBrainz, neither here nor anywhere else in the flow.
+2. the partner sends the user's browser to that url. ListenBrainz shows a confirmation page
+   naming the partner and the ListenBrainz account the music service would be connected to.
+3. the user confirms. ListenBrainz generates the OAuth state, remembers the request in the
+   user's session and redirects the user to the music service
+4. the user authorizes ListenBrainz on the music service
+5. the music service redirects back to the usual ListenBrainz callback, which stores the
+   tokens
+6. ListenBrainz redirects the user back to ``redirect_uri`` with ``status`` (and ``error``
+   if the flow failed) plus the ``state`` the partner sent when it started the flow
+
+The confirmation page in step 2 is what keeps the ticket from being a bearer capability that
+silently says "whoever opens this link is user U". Nothing else in the flow ever asks the
+person in front of the browser whether that is true: they are not logged in to ListenBrainz,
+and the authorization screen they see afterwards belongs to the music service and only names
+ListenBrainz. Without the confirmation, anybody able to mint a ticket could mint one for
+their own account, send the link to somebody else and end up with that person's music
+service connected to the attacker's ListenBrainz account.
+"""
+
+import base64
+import os
+import secrets
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
+
+from brainzutils import cache
+from flask import current_app, session, url_for
+
+import listenbrainz.db.oauth_client as db_oauth_client
+import listenbrainz.db.user as db_user
+from listenbrainz.domain.musicbrainz import MusicBrainzService
+from listenbrainz.domain.soundcloud import SoundCloudService
+from listenbrainz.domain.spotify import SPOTIFY_IMPORT_PERMISSIONS, SPOTIFY_LISTEN_PERMISSIONS
+from listenbrainz.webserver import db_conn, meb_conn
+
+# the key under which the in-progress request is stored in the user's ListenBrainz session
+SESSION_KEY = "external_connect_request"
+
+# the key under which the confirmation page remembers what it was shown for, see
+# start_confirmation
+CONFIRM_SESSION_KEY = "external_connect_confirm"
+
+# the prefix of the keys under which the OAuth state of an authorization started from the
+# ListenBrainz settings page is stored in the user's session, see settings_oauth_state_key
+SETTINGS_OAUTH_STATE_SESSION_KEY_PREFIX = "music_service_oauth_state"
+
+# an authorization the user does not finish within this duration is abandoned
+REQUEST_TTL = timedelta(minutes=30)
+
+# the partner state is stored in the (cookie backed) session and echoed back verbatim, so
+# cap it to keep the session cookie small
+MAX_CLIENT_STATE_LENGTH = 255
+
+# the scope a MetaBrainz OAuth access token must carry for a partner application to be
+# allowed to connect music services on behalf of its owner
+CONNECT_SERVICES_SCOPE = "listenbrainz:connect-services"
+
+# MetaBrainz OAuth access tokens are prefixed with this, ListenBrainz user tokens are not
+METABRAINZ_TOKEN_PREFIX = "meba_"
+
+# how long the partner has to send the user to the url returned by the token endpoint. It
+# is only the time between the partner's backend call and the browser redirect, so it can
+# be short.
+TICKET_TTL = timedelta(minutes=10)
+TICKET_CACHE_NAMESPACE = "external_connect_ticket"
+
+# values of the error parameter ListenBrainz sends back to the partner application
+ERROR_INVALID_REQUEST = "invalid_request"
+ERROR_ACCESS_DENIED = "access_denied"
+ERROR_EMAIL_REQUIRED = "email_required"
+ERROR_EXPIRED_REQUEST = "expired_request"
+ERROR_SERVER_ERROR = "server_error"
+
+STATUS_CONNECTED = "connected"
+STATUS_ERROR = "error"
+
+# Query parameters whose values are owned by this flow. A partner may include unrelated
+# parameters in its redirect URI, but these must be replaced rather than duplicated when
+# the result is returned.
+RETURN_QUERY_PARAMETERS = {"service", "status", "error", "error_description", "state"}
+
+
+@dataclass(frozen=True)
+class ConnectableService:
+    """ A music service that can be connected through a pure browser redirect OAuth flow.
+
+    Only Spotify is offered for now. Adding SoundCloud or CritiqueBrainz is a matter of
+    listing them below, everything else in this module is service agnostic. Services needing
+    input from the user before the authorization request can be made (a Funkwhale instance
+    url, a Last.fm username, Navidrome credentials) or needing javascript on a ListenBrainz
+    page (Apple Music) cannot be part of this flow at all.
+
+    Args:
+        name: the name of the service, as used in urls
+        permissions: maps the permission names a partner may ask for to the OAuth scopes
+            they translate to. The names match the ones used by the ListenBrainz settings
+            page so that both flows stay consistent.
+        default_permission: the permission used when the partner does not ask for one
+        label: the name of the service as shown to the user
+        permission_descriptions: what each permission lets ListenBrainz do, in words the
+            user can act on. Shown on the confirmation page.
+    """
+    name: str
+    permissions: dict[str, frozenset[str]]
+    default_permission: str
+    label: str
+    permission_descriptions: dict[str, str]
+
+    def describe_permission(self, permission: str) -> str:
+        return self.permission_descriptions.get(permission, f"access your {self.label} account")
+
+
+CONNECTABLE_SERVICES = {
+    service.name: service
+    for service in [
+        ConnectableService(
+            name="spotify",
+            permissions={
+                "import": frozenset(SPOTIFY_IMPORT_PERMISSIONS),
+                "listen": frozenset(SPOTIFY_LISTEN_PERMISSIONS),
+                "both": frozenset(SPOTIFY_IMPORT_PERMISSIONS | SPOTIFY_LISTEN_PERMISSIONS),
+            },
+            default_permission="import",
+            label="Spotify",
+            permission_descriptions={
+                "import": "read your Spotify listening history",
+                "listen": "play music from Spotify in the ListenBrainz player",
+                "both": "read your Spotify listening history and play music from Spotify in"
+                        " the ListenBrainz player",
+            },
+        ),
+    ]
+}
+
+
+@dataclass
+class ExternalConnectRequest:
+    """ An in-progress request by a partner application to connect a music service. """
+    redirect_uri: str
+    service: str
+    permission: str
+    oauth_state: str
+    client_state: Optional[str] = None
+    # the name the application the access token was issued to is registered under with
+    # MetaBrainz, if we could look it up. Only used to name it on the confirmation page.
+    client_name: Optional[str] = None
+    # the ListenBrainz user the music service is connected for. It is set as soon as we know
+    # who the user is, either from the access token the partner sent us or from the session
+    # of the logged in user.
+    user_id: Optional[int] = None
+    # whether to send the user to the music service even if the account is already connected
+    # with the requested permissions
+    force: bool = False
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def has_expired(self) -> bool:
+        try:
+            created_at = datetime.fromisoformat(self.created_at)
+        except (TypeError, ValueError):
+            return True
+        return datetime.now(timezone.utc) - created_at > REQUEST_TTL
+
+    def redirect_host(self) -> str:
+        """ The host the user will be sent back to, shown on the confirmation page. """
+        return urlparse(self.redirect_uri).netloc
+
+    def describe_client(self) -> str:
+        """ How the application is named to the user on the confirmation page.
+
+        The registered name is what the user is likely to recognise, but it is chosen by
+        the application's owner, so the host they are going to be returned to is shown
+        alongside it. When there is no name to be had, the host stands on its own.
+        """
+        if self.client_name:
+            return f"{self.client_name} ({self.redirect_host()})"
+        return self.redirect_host()
+
+
+class ExternalConnectValidationError(Exception):
+    """ Raised when a partner request is malformed in a way that stops us from redirecting
+    the user back to the partner application. """
+    pass
+
+
+class ExternalConnectAuthError(Exception):
+    """ Raised when the access token a partner application sent us does not allow it to
+    connect music services for its owner. """
+    pass
+
+
+def _get_string(args, key: str) -> Optional[str]:
+    """ Return a value a partner application sent us that has to be a string, if any.
+
+    The values come straight out of a json body, so anything could be in there.
+    """
+    value = args.get(key)
+    if value is None or isinstance(value, str):
+        return value
+    raise ExternalConnectValidationError(f"{key} must be a string.")
+
+
+def settings_oauth_state_key(service_name: str) -> str:
+    """ Return the session key holding the OAuth state of an authorization the user started
+    from the ListenBrainz settings page.
+
+    There is one key per service so that a user connecting two services at the same time
+    does not have the second authorization clobber the state of the first one.
+    """
+    return f"{SETTINGS_OAUTH_STATE_SESSION_KEY_PREFIX}_{service_name.lower()}"
+
+
+def get_connectable_service(service_name: str) -> Optional[ConnectableService]:
+    """ Return the service with the given name if it can be connected by a partner app. """
+    return CONNECTABLE_SERVICES.get(service_name.lower())
+
+
+def validate_redirect_uri(redirect_uri: Optional[str]) -> str:
+    """ Check the url a partner application wants the user sent back to.
+
+    There is no registry of partner applications, so there is no allow list to match this
+    against: the access token is what says the caller is allowed to be here at all. All we
+    can do is make sure it is an absolute url the browser can be redirected to, so that this
+    endpoint cannot be pointed at a javascript: or data: url.
+
+    Raises:
+        ExternalConnectValidationError: if it is missing or not such a url.
+    """
+    if not redirect_uri:
+        raise ExternalConnectValidationError("Missing redirect_uri.")
+
+    parsed = urlparse(redirect_uri)
+    if not parsed.netloc or parsed.scheme not in ("http", "https"):
+        raise ExternalConnectValidationError("redirect_uri must be an absolute http or https url.")
+    # a partner running on localhost is developing against us, everybody else is sending a
+    # user's browser across the internet and has no excuse for doing it in the clear
+    if parsed.scheme != "https" and parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
+        raise ExternalConnectValidationError("redirect_uri must use https.")
+    return redirect_uri
+
+
+def resolve_token(access_token: Optional[str]) -> tuple[dict, dict]:
+    """ Return the ListenBrainz user a MetaBrainz OAuth access token was issued for, along
+    with the introspection response it came from.
+
+    Only MetaBrainz OAuth access tokens carrying the connect services scope are accepted.
+    ListenBrainz user tokens are deliberately not accepted here because connecting a music
+    service on someone's behalf is something the user has to grant explicitly.
+
+    Raises:
+        ExternalConnectAuthError: if the token is missing, invalid, expired, lacks the scope
+            or belongs to somebody without a ListenBrainz account.
+        requests.RequestException: if the introspection endpoint could not be reached.
+    """
+    if not access_token or not access_token.startswith(METABRAINZ_TOKEN_PREFIX):
+        raise ExternalConnectAuthError("A MetaBrainz OAuth access token is required.")
+
+    token = MusicBrainzService().get_user_info(access_token)
+
+    if not token.get("active"):
+        raise ExternalConnectAuthError("Invalid access token.")
+
+    expires_at = token.get("expires_at")
+    if expires_at is not None and datetime.fromtimestamp(expires_at, timezone.utc) < datetime.now(timezone.utc):
+        raise ExternalConnectAuthError("Invalid access token.")
+
+    scopes = token.get("scope") or []
+    if isinstance(scopes, str):
+        # Accept the space-delimited representation too, since older introspection
+        # implementations and test doubles may still return it.
+        scopes = scopes.split()
+    if not isinstance(scopes, list) or CONNECT_SERVICES_SCOPE not in scopes:
+        raise ExternalConnectAuthError(f"The access token needs the {CONNECT_SERVICES_SCOPE} scope.")
+
+    user = _get_user_from_introspection(token)
+    if user is None:
+        raise ExternalConnectAuthError("The owner of the access token does not have a ListenBrainz account.")
+    return user, token
+
+
+def get_client_name(client_id: Optional[str]) -> Optional[str]:
+    """ Return the name the application an access token was issued to is registered under.
+
+    The registry is MetaBrainz's, so this needs the MetaBrainz database. It is only used to
+    put a name on the confirmation page, so a deployment without that database configured
+    (or a hiccup reaching it) falls back to naming the application by the host the user is
+    going to be sent back to rather than failing the flow.
+    """
+    # meb_conn is a proxy around a connection that only exists when the MetaBrainz database
+    # is configured, so the config is what has to be checked, not the proxy
+    if not client_id or not current_app.config.get("SQLALCHEMY_METABRAINZ_URI"):
+        return None
+    try:
+        return db_oauth_client.get_client_name(meb_conn, client_id)
+    except Exception:
+        current_app.logger.error("Could not look up the name of OAuth client %s:", client_id, exc_info=True)
+        return None
+
+
+def _get_user_from_introspection(token: dict) -> Optional[dict]:
+    """ Look up the ListenBrainz user an introspected access token belongs to.
+
+    The introspection response identifies the user by their MusicBrainz row id in ``sub``,
+    with their MusicBrainz username in ``username`` used as a fallback for the accounts we
+    do not have a row id for yet. A token issued through the client credentials grant has no
+    user behind it at all and carries the sentinel ``-1``.
+    """
+    try:
+        musicbrainz_row_id = int(token.get("sub"))
+    except (TypeError, ValueError):
+        return None
+    if musicbrainz_row_id < 0:
+        return None
+    return db_user.get_by_mb_row_id(db_conn, musicbrainz_row_id,
+                                    musicbrainz_id=token.get("username"), fetch_email=True)
+
+
+def create_ticket(connect_request: ExternalConnectRequest) -> str:
+    """ Store a validated request and return the single use ticket identifying it.
+
+    The ticket is what lets the user's browser start the authorization without logging in to
+    ListenBrainz, so it is stored server side and can only be used once.
+    """
+    ticket = secrets.token_urlsafe(32)
+    cache.set(ticket, asdict(connect_request), int(TICKET_TTL.total_seconds()),
+              namespace=TICKET_CACHE_NAMESPACE)
+    return ticket
+
+
+def _load_ticket(ticket: Optional[str], service_name: str) -> Optional[ExternalConnectRequest]:
+    if not ticket:
+        return None
+
+    stored = cache.get(ticket, namespace=TICKET_CACHE_NAMESPACE)
+    if not stored:
+        return None
+
+    try:
+        connect_request = ExternalConnectRequest(**stored)
+    except TypeError:
+        return None
+    return connect_request if connect_request.service == service_name.lower() else None
+
+
+def peek_ticket(ticket: Optional[str], service_name: str) -> Optional[ExternalConnectRequest]:
+    """ Return the request a ticket was created for without spending the ticket.
+
+    This is what the confirmation page is rendered from. The ticket is only spent once the
+    user confirms, so reloading the page or going back to it does not lose the request.
+    """
+    return _load_ticket(ticket, service_name)
+
+
+def consume_ticket(ticket: Optional[str], service_name: str) -> Optional[ExternalConnectRequest]:
+    """ Return the request a ticket was created for and invalidate the ticket. """
+    connect_request = _load_ticket(ticket, service_name)
+    if connect_request is None:
+        return None
+
+    # deleting the ticket is what makes it single use, only carry on if this request is the
+    # one that actually removed it
+    if cache.delete(ticket, namespace=TICKET_CACHE_NAMESPACE) != 1:
+        return None
+    return connect_request
+
+
+def start_confirmation(ticket: str) -> str:
+    """ Remember that this browser was served the confirmation page for the given ticket and
+    return the nonce the confirmation has to be submitted with.
+
+    The nonce is what stops the partner application from submitting the confirmation itself:
+    it is only ever written into the page handed to the browser that asked for it and into a
+    cookie, neither of which the partner can read.
+    """
+    nonce = secrets.token_urlsafe(32)
+    session[CONFIRM_SESSION_KEY] = {"ticket": ticket, "nonce": nonce}
+    return nonce
+
+
+def check_confirmation(ticket: Optional[str], nonce: Optional[str]) -> bool:
+    """ Check that this browser was served the confirmation page for the given ticket. """
+    stored = session.pop(CONFIRM_SESSION_KEY, None)
+    if not isinstance(stored, dict) or not ticket or not nonce:
+        return False
+    return (secrets.compare_digest(stored.get("ticket") or "", ticket)
+            and secrets.compare_digest(stored.get("nonce") or "", nonce))
+
+
+def build_ticket_url(connect_request: ExternalConnectRequest, ticket: str) -> str:
+    """ Return the url the partner application has to send the user's browser to. """
+    return url_for("external_connect.connect", service_name=connect_request.service,
+                   ticket=ticket, _external=True)
+
+
+def validate_request_args(service_name: str, args) -> ExternalConnectRequest:
+    """ Validate what a partner application sent us and turn it into an
+    :class:`ExternalConnectRequest`.
+
+    The returned request has no user attached and has not been stored anywhere yet, see
+    :func:`create_ticket`.
+
+    Args:
+        service_name: the music service the user wants to connect
+        args: the json body of the incoming request
+
+    Raises:
+        ExternalConnectValidationError: if anything about the request is invalid.
+    """
+    connectable = get_connectable_service(service_name)
+    if connectable is None:
+        raise ExternalConnectValidationError(f"{service_name} cannot be connected from another application.")
+
+    redirect_uri = validate_redirect_uri(_get_string(args, "redirect_uri"))
+
+    client_state = _get_string(args, "state")
+    if client_state is not None and len(client_state) > MAX_CLIENT_STATE_LENGTH:
+        raise ExternalConnectValidationError(
+            f"state cannot be longer than {MAX_CLIENT_STATE_LENGTH} characters."
+        )
+
+    permission = _get_string(args, "permissions") or connectable.default_permission
+    if permission not in connectable.permissions:
+        raise ExternalConnectValidationError(
+            f"'{permission}' is not a valid value of permissions for {connectable.name}, "
+            f"use one of: {', '.join(sorted(connectable.permissions))}."
+        )
+
+    return ExternalConnectRequest(
+        redirect_uri=redirect_uri,
+        service=connectable.name,
+        permission=permission,
+        oauth_state=base64.b64encode(os.urandom(32)).decode("utf-8"),
+        client_state=client_state,
+    )
+
+
+def store_request(connect_request: ExternalConnectRequest):
+    """ Remember the in-progress request for the duration of the OAuth dance. """
+    session[SESSION_KEY] = asdict(connect_request)
+    # this authorization is tracked by the stored request, drop the state of any
+    # authorization of the same service the user started from the settings page
+    session.pop(settings_oauth_state_key(connect_request.service), None)
+
+
+def get_request(service_name: str) -> Optional[ExternalConnectRequest]:
+    """ Return the in-progress request for the given service without forgetting it.
+
+    The callback has to inspect the request to find the expected OAuth state, but must not
+    consume it until that state has been validated. Otherwise an unrelated request to the
+    callback could cancel a real authorization that is still in flight.
+    """
+    stored = session.get(SESSION_KEY)
+    if not stored:
+        return None
+
+    try:
+        connect_request = ExternalConnectRequest(**stored)
+    except TypeError:
+        session.pop(SESSION_KEY, None)
+        return None
+
+    if connect_request.service != service_name.lower():
+        return None
+
+    return connect_request
+
+
+def pop_request(service_name: str) -> Optional[ExternalConnectRequest]:
+    """ Return and forget the in-progress request for the given service, if any. """
+    connect_request = get_request(service_name)
+    if connect_request is None:
+        return None
+
+    session.pop(SESSION_KEY, None)
+    return connect_request
+
+
+def build_return_url(connect_request: ExternalConnectRequest, error: Optional[str] = None,
+                     error_description: Optional[str] = None) -> str:
+    """ Build the url to send the user back to once the flow has finished.
+
+    Args:
+        connect_request: the request the partner application started
+        error: the error that made the flow fail, if it did
+        error_description: a human readable description of the error
+    """
+    params = [
+        ("service", connect_request.service),
+        ("status", STATUS_ERROR if error else STATUS_CONNECTED),
+    ]
+    if error:
+        params.append(("error", error))
+    if error_description:
+        params.append(("error_description", error_description))
+    if connect_request.client_state is not None:
+        params.append(("state", connect_request.client_state))
+
+    parsed = urlparse(connect_request.redirect_uri)
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key not in RETURN_QUERY_PARAMETERS
+    ] + params
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+def build_authorize_url(service, permissions, state: str) -> str:
+    """ Build the url of the music service the user has to be sent to for authorizing us.
+
+    Also stores whatever else the callback will need to complete the authorization, for
+    instance the PKCE code verifier for SoundCloud.
+
+    Args:
+        service: the :class:`~listenbrainz.domain.external_service.ExternalService` instance
+        permissions: the OAuth scopes to ask the service for
+        state: the OAuth state protecting the authorization request
+    """
+    if isinstance(service, SoundCloudService):
+        code_verifier, code_challenge = SoundCloudService.generate_pkce_pair()
+        session["soundcloud_code_verifier"] = code_verifier
+        return service.get_authorize_url(
+            list(permissions),
+            state=state,
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+        )
+    return service.get_authorize_url(list(permissions), state=state)

--- a/listenbrainz/domain/spotify.py
+++ b/listenbrainz/domain/spotify.py
@@ -164,15 +164,17 @@ class SpotifyService(ImporterService):
                                           refresh_token_expires=get_refresh_token_expires())
         return True
 
-    def get_authorize_url(self, permissions: Sequence[str]):
+    def get_authorize_url(self, permissions: Sequence[str], state: str | None = None):
         """ Returns a spotipy OAuth instance that can be used to authenticate with spotify.
         Args:
             permissions: List of permissions needed by the OAuth instance
+            state: opaque value used to protect the authorization request, it is returned
+                unchanged by Spotify in the callback
         """
         scope = ' '.join(permissions)
         return SpotifyOAuth(self.client_id, self.client_secret,
                             redirect_uri=self.redirect_url,
-                            scope=scope).get_authorize_url()
+                            scope=scope).get_authorize_url(state=state)
 
     def fetch_access_token(self, code: str):
         """ Get a valid Spotify Access token given the code.

--- a/listenbrainz/listenstore/migrate_listens.py
+++ b/listenbrainz/listenstore/migrate_listens.py
@@ -15,10 +15,11 @@ Its logged --since-id / --since-history-id already include an overlap of DELETE_
 because rows whose id was allocated but not committed yet when the checkpoint was read would
 otherwise be skipped forever. Replays are idempotent so re-applying them is harmless.
 
-Each cycle should run replay-deletes before incremental. Deletes committed in timescale after the
-last replay-deletes are never applied to the target, so before the final cycle stop writes to
-timescale (and let the delete_listens cron drain) and then run replay-deletes + incremental one
-last time.
+Before runtime dual writes are deployed, each cycle should run replay-deletes before incremental.
+After dual writes are active, new listen and user deletes are applied directly to both databases;
+replay-deletes remains necessary for historical deletes and any gap from before that deployment.
+A listen re-submitted while delete_listens is mid-run can end up in timescale only, so keep
+running incremental after dual writes are live.
 """
 import os
 import re

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -214,8 +214,11 @@ class TimescaleListenStore:
                 return
 
             for result in results:
+                listened_at = result[0]
+                user_id = result[2]
+                recording_msid = result[3]
                 # keyed so the partitioned upsert can never affect a row twice
-                source_rows[(result[0], result[2], result[3])] = result
+                source_rows[(listened_at, user_id, recording_msid)] = result
 
             # If this raises an OperationalError, the Timescale transaction is rolled back and
             # RabbitMQ requeues the batch. Both writes are idempotent, so retrying also handles the

--- a/listenbrainz/listenstore/timescale_listenstore.py
+++ b/listenbrainz/listenstore/timescale_listenstore.py
@@ -13,7 +13,7 @@ from psycopg2.errors import UntranslatableCharacter
 from psycopg2.extras import execute_values
 from sqlalchemy import text
 
-from listenbrainz.db import timescale
+from listenbrainz.db import listens as listens_db, timescale
 from listenbrainz.dumps import DUMP_DEFAULT_THREAD_COUNT
 from listenbrainz.dumps.exceptions import SchemaMismatchException
 from listenbrainz.listen import Listen
@@ -159,21 +159,26 @@ class TimescaleListenStore:
 
     def insert(self, listens):
         """
-            Insert a batch of listens. Returns a list of (listened_at, track_name, user_name, user_id) that indicates
-            which rows were inserted into the DB. If the row is not listed in the return values, it was a duplicate.
+            Insert a batch of listens. Returns a list of (listened_at, user_id, recording_msid)
+            identifying rows inserted into Timescale. Rows absent from the result were duplicates.
         """
+
+        if not listens:
+            return []
 
         submit = []
         for listen in listens:
             submit.append(listen.to_timescale())
 
+        # Only newly inserted rows are mirrored. A duplicate was already mirrored by the insert
+        # that first put it in timescale, so fetching and re-upserting it would be pure overhead.
         query = """
             WITH inserted_listens AS (
                 INSERT INTO listen (listened_at, user_id, recording_msid, data)
                      VALUES %s
                 ON CONFLICT (listened_at, user_id, recording_msid)
                  DO NOTHING
-                  RETURNING listened_at, user_id, recording_msid
+                  RETURNING listened_at, created, user_id, recording_msid, data
             ), metadata AS (
                 INSERT INTO listen_user_metadata AS lum (user_id, count, min_listened_at, max_listened_at, created)
                      SELECT user_id, count(*), min(listened_at), max(listened_at), NOW()
@@ -185,26 +190,46 @@ class TimescaleListenStore:
                           , min_listened_at = least(lum.min_listened_at, excluded.min_listened_at)
                           , max_listened_at = greatest(lum.max_listened_at, excluded.max_listened_at)
                           , created = excluded.created
-            ) SELECT * FROM inserted_listens
+            )
+            SELECT listened_at, created, user_id, recording_msid, data::text
+              FROM inserted_listens
         """
 
-        inserted_rows = []
+        source_rows = {}
         conn = timescale.engine.raw_connection()
-        with conn.cursor() as curs:
+        try:
+            # this handler drops the batch instead of retrying it, only acceptable for an
+            # encoding error from timescale itself, so keep it off the partitioned write below
             try:
-                execute_values(curs, query, submit, template=None)
-                while True:
-                    result = curs.fetchone()
-                    if not result:
-                        break
-                    inserted_rows.append((result[0], result[1], result[2]))
+                with conn.cursor() as curs:
+                    results = execute_values(
+                        curs,
+                        query,
+                        submit,
+                        template="(%s::timestamptz, %s::integer, %s::uuid, %s::jsonb)",
+                        fetch=True,
+                    )
             except UntranslatableCharacter:
                 conn.rollback()
                 return
 
-        conn.commit()
+            for result in results:
+                # keyed so the partitioned upsert can never affect a row twice
+                source_rows[(result[0], result[2], result[3])] = result
 
-        return inserted_rows
+            # If this raises an OperationalError, the Timescale transaction is rolled back and
+            # RabbitMQ requeues the batch. Both writes are idempotent, so retrying also handles the
+            # case where this commit fails after the partitioned transaction committed.
+            listens_db.insert(list(source_rows.values()))
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        return [(listened_at, user_id, recording_msid)
+                for listened_at, _, user_id, recording_msid, _ in source_rows.values()]
 
     def fetch_listens(self, user: Dict, from_ts: datetime = None, to_ts: datetime = None, limit: int = DEFAULT_LISTENS_PER_FETCH):
         """ The timestamps are stored as UTC in the postgres datebase while on retrieving
@@ -704,13 +729,13 @@ class TimescaleListenStore:
     def delete(self, user_id, created=None):
         """ Delete all listens for user with specified user ID.
 
-        Note: this method tries to delete the user 5 times before giving up.
-
         Args:
             user_id: the listenbrainz row id of the user
             created: delete listens created before this timestamp
 
-        Raises: Exception if unable to delete the user in 5 retries
+        Raises: Exception if either store rejects the delete. Callers do not retry, so a
+            timescale commit that fails after the partitioned delete committed leaves the listens
+            in timescale only, which the incremental migration copies back.
         """
         if created is None:
             created = datetime.now(tz=timezone.utc)
@@ -727,9 +752,16 @@ class TimescaleListenStore:
             ts_conn.execute(sqlalchemy.text(query1), {"user_id": user_id})
             ts_conn.execute(sqlalchemy.text(query2), {"user_id": user_id, "created": created})
             ts_conn.execute(sqlalchemy.text(query3), {"user_id": user_id, "created": created})
+            # As with inserts, do not commit the authoritative Timescale mutation until the
+            # partitioned store has accepted the matching delete. Retrying either delete is safe.
+            listens_db.delete_user(user_id, created)
             ts_conn.commit()
-        except psycopg2.OperationalError as e:
+        except (psycopg2.OperationalError, sqlalchemy.exc.OperationalError) as e:
+            ts_conn.rollback()
             self.log.error("Cannot delete listens for user: %s" % str(e))
+            raise
+        except Exception:
+            ts_conn.rollback()
             raise
 
     def delete_listen(self, listened_at: datetime, user_id: int, recording_msid: str):

--- a/listenbrainz/listenstore/timescale_utils.py
+++ b/listenbrainz/listenstore/timescale_utils.py
@@ -8,7 +8,7 @@ from psycopg2.extras import execute_values
 from sqlalchemy import text
 
 from listenbrainz import db
-from listenbrainz.db import timescale
+from listenbrainz.db import listens as listens_db, timescale
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,13 @@ def delete_listens():
     # select the maximum id in the table till now, we are only to process
     # deletes with row id earlier than this.
     select_max_id = "SELECT max(id) AS max_id FROM listen_delete_metadata"
+
+    select_pending_deletes = """
+        SELECT user_id, listened_at, recording_msid
+          FROM listen_delete_metadata
+         WHERE id <= :max_id
+           AND status = 'pending'
+    """
 
     # count deleted listens, checked created and update listen counts
     delete_listens_and_update_listen_counts = """
@@ -204,12 +211,17 @@ def delete_listens():
         result = connection.execute(text(select_max_id))
         row = result.fetchone()
 
-        if not row:
+        if not row or row.max_id is None:
             logger.info("No pending deletes")
             return
 
         max_id = row.max_id
         logger.info("Found max id in listen_delete_metadata table: %s", max_id)
+
+        # collected before the statements below mark them invalid, so target-only rows are
+        # cleaned up too. applied at the end of the block, see the comment there.
+        result = connection.execute(text(select_pending_deletes), {"max_id": max_id})
+        pending_deletes = [(row.user_id, row.listened_at, row.recording_msid) for row in result]
 
         logger.info("Deleting Listens and updating affected listens counts")
         connection.execute(text(delete_listens_and_update_listen_counts), {"max_id": max_id})
@@ -222,6 +234,13 @@ def delete_listens():
 
         logger.info("Cleanup listen delete metadata table")
         connection.execute(text(mark_invalid_rows_query), {"max_id": max_id})
+
+        # Applied last so this commit sits next to the timescale one instead of being separated
+        # by the heavy statements above. Applying it first instead leaves a listen re-submitted
+        # in between in the partitioned store only, which only replay-deletes repairs; this way
+        # it is in timescale only, which incremental repairs. Raising rolls back timescale too.
+        logger.info("Deleting listens from the partitioned database")
+        listens_db.delete(pending_deletes)
 
         logger.info("Completed deleting listens and updating affected metadata")
 

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -8,7 +8,7 @@ import sqlalchemy
 from listenbrainz import db
 from listenbrainz import webserver
 from listenbrainz.background import export
-from listenbrainz.db import timescale as ts, do_not_recommend
+from listenbrainz.db import listens as listens_db, timescale as ts, do_not_recommend
 
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data, \
     update_user_listen_data as ts_update_user_listen_data, \
@@ -105,7 +105,78 @@ def init_db(force, create_db):
         print('PG: Creating indexes...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
 
-        print("Done!")\
+        print("Done!")
+
+
+# routing behaves the same with a handful of partitions, without the catalog churn
+TEST_LISTENS_PARTITION_COUNT = 4
+
+
+@cli.command(name="init_listens_db")
+@click.option("--force", "-f", is_flag=True, help="Drop existing database and user.")
+@click.option("--create-db", is_flag=True, help="Create the database and user.")
+@click.option("--partitions", type=click.IntRange(min=1), default=None,
+              help="number of hash partitions to create, defaults to the production count "
+                   "(the test count when running tests)")
+def init_listens_db(force, create_db, partitions):
+    """Initializes the user-partitioned listens database.
+
+    Creates the listen table, its hash partitions and its indexes.
+    """
+    import psycopg2
+    from listenbrainz import config
+    from listenbrainz.listenstore.migrate_listens import PARTITION_COUNT, create_indexes, create_schema
+
+    testing = "PYTHON_TESTS_RUNNING" in os.environ
+    if testing:
+        listens_connect = listens_db.create_test_listens_connect_strings()
+        admin_uri = listens_connect["DB_CONNECT_ADMIN"]
+        config.PYTHON_TESTS_RUNNING = True
+        if partitions is None:
+            partitions = TEST_LISTENS_PARTITION_COUNT
+    else:
+        listens_connect = {"DB_NAME": "listenbrainz_listens", "DB_USER": "listenbrainz_listens"}
+        admin_uri = getattr(config, "LISTENS_ADMIN_URI", None)
+    if partitions is None:
+        partitions = PARTITION_COUNT
+
+    def run_as_admin(uri, queries):
+        if not uri:
+            raise click.UsageError("LISTENS_ADMIN_URI is not set in the config")
+        connection = psycopg2.connect(uri)
+        connection.autocommit = True
+        try:
+            with connection.cursor() as cursor:
+                for query in queries:
+                    cursor.execute(query)
+        finally:
+            connection.close()
+
+    if force:
+        run_as_admin(admin_uri, [
+            f"DROP DATABASE IF EXISTS {listens_connect['DB_NAME']}",
+            f"DROP USER IF EXISTS {listens_connect['DB_USER']}",
+        ])
+
+    if create_db or force:
+        print("LISTENS: Creating user and a database...")
+        run_as_admin(admin_uri, [
+            f"CREATE USER {listens_connect['DB_USER']} NOCREATEDB NOSUPERUSER",
+            f"ALTER USER {listens_connect['DB_USER']} WITH PASSWORD 'listenbrainz_listens'",
+            f"CREATE DATABASE {listens_connect['DB_NAME']} WITH OWNER = {listens_connect['DB_USER']}"
+            " TEMPLATE template0 ENCODING = 'UNICODE'",
+        ])
+
+    application = webserver.create_app()
+    with application.app_context():
+        print("LISTENS: Creating table and partitions...")
+        create_schema(partitions)
+
+        print("LISTENS: Creating indexes...")
+        create_indexes()
+
+        print("Done!")
+
 
 @cli.command(name="update_db")
 @click.argument('filename', type=click.Path(exists=True, dir_okay=False))

--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -5,6 +5,7 @@ from time import monotonic
 
 import psycopg2
 import orjson
+import sqlalchemy
 from brainzutils import metrics
 from flask import current_app
 from kombu import Exchange, Queue, Consumer, Message
@@ -70,7 +71,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
 
             submit = [Listen.from_json(listen) for listen in msb_listens]
             self.insert_to_listenstore(submit)
-        except psycopg2.OperationalError:
+        except (psycopg2.OperationalError, sqlalchemy.exc.OperationalError):
             current_app.logger.error("Error processing listens due to database issues:", exc_info=True)
             time.sleep(self.ERROR_RETRY_DELAY)
             raise
@@ -213,7 +214,18 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
 
 
 if __name__ == "__main__":
-    app = create_app(bypass_pgbouncer=True)
+    # The consul sizes are per uwsgi worker and bypass_pgbouncer makes them direct backends.
+    # This consumer is single threaded and never touches db / meb, so one connection each.
+    app = create_app(
+        bypass_pgbouncer=True,
+        use_pool=True,
+        pool_size_overrides={
+            "db": (1, 1),
+            "ts": (1, 1),
+            "listens": (1, 1),
+            "meb": (1, 1),
+        },
+    )
     with app.app_context():
         rc = TimescaleWriterSubscriber()
         rc.start()

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -13,7 +13,8 @@ from werkzeug.local import LocalProxy
 from flask_htmx import HTMX
 
 from listenbrainz import db
-from listenbrainz.db import create_test_database_connect_strings, timescale, donation
+from listenbrainz.db import create_test_database_connect_strings, timescale, donation, listens
+from listenbrainz.db.listens import create_test_listens_connect_strings
 from listenbrainz.db.timescale import create_test_timescale_connect_strings
 from listenbrainz.webserver.converters import NotApiPathConverter, UsernameConverter
 
@@ -104,16 +105,16 @@ def create_app(
     When `bypass_pgbouncer` is True, the timescale engine connects directly to the
     timescale database instead of going through pgbouncer.
 
-    When `use_pool` is True, the LB postgres, timescale, and metabrainz engines
-    use SQLAlchemy QueuePools sized from config. This is intended for the uwsgi
-    entry points (webserver, api_compat) where many requests share a worker.
+    When `use_pool` is True, the LB postgres, timescale, partitioned listens, and
+    metabrainz engines use SQLAlchemy QueuePools sized from config. This is
+    intended for long-running entry points where connections can be reused.
     Other callers (manage.py, mbid_mapping_writer, background_tasks, etc.) keep
     the NullPool default since they're single-purpose, often short-lived, and
     don't benefit from a long-lived pool.
 
     `pool_size_overrides` (only used when `use_pool=True`) lets entry points
     shrink the per-worker pool below the consul-configured size. Keys: "db",
-    "ts", "meb". Each value is a (pool_size, max_overflow) tuple.
+    "ts", "listens", "meb". Each value is a (pool_size, max_overflow) tuple.
     """
 
     app = CustomFlask(import_name=__name__)
@@ -148,8 +149,12 @@ def create_app(
     if "PYTHON_TESTS_RUNNING" in os.environ:
         db_connect = create_test_database_connect_strings()
         ts_connect = create_test_timescale_connect_strings()
+        listens_connect = create_test_listens_connect_strings()
         db.init_db_connection(db_connect["DB_CONNECT"])
         timescale.init_db_connection(ts_connect["DB_CONNECT"])
+        # tests exercise the dual write too, `manage.py init_listens_db` creates this database
+        listens.init_db_connection(listens_connect["DB_CONNECT"])
+        app.config["SQLALCHEMY_LISTENS_URI"] = listens_connect["DB_CONNECT"]
     elif use_pool:
         overrides = pool_size_overrides or {}
         db_size, db_overflow = overrides.get(
@@ -159,6 +164,10 @@ def create_app(
         ts_size, ts_overflow = overrides.get(
             "ts",
             (app.config.get("TIMESCALE_POOL_SIZE"), app.config.get("TIMESCALE_POOL_MAX_OVERFLOW"))
+        )
+        listens_size, listens_overflow = overrides.get(
+            "listens",
+            (ts_size, ts_overflow),
         )
         meb_size, meb_overflow = overrides.get(
             "meb",
@@ -180,6 +189,13 @@ def create_app(
             max_overflow=ts_overflow,
             pool_pre_ping=True,
         )
+        listens.init_db_connection(
+            app.config.get("SQLALCHEMY_LISTENS_URI"),
+            poolclass=QueuePool,
+            pool_size=listens_size,
+            max_overflow=listens_overflow,
+            pool_pre_ping=True,
+        )
         if app.config.get("SQLALCHEMY_METABRAINZ_URI", None):
             donation.init_meb_db_connection(
                 app.config["SQLALCHEMY_METABRAINZ_URI"],
@@ -192,6 +208,7 @@ def create_app(
         db.init_db_connection(app.config["SQLALCHEMY_DATABASE_URI"])
         timescale_uri_config = "SQLALCHEMY_TIMESCALE_URI" if bypass_pgbouncer else "SQLALCHEMY_TIMESCALE_PGBOUNCER_URI"
         timescale.init_db_connection(app.config[timescale_uri_config])
+        listens.init_db_connection(app.config.get("SQLALCHEMY_LISTENS_URI"))
         if app.config.get("SQLALCHEMY_METABRAINZ_URI", None):
             donation.init_meb_db_connection(app.config["SQLALCHEMY_METABRAINZ_URI"])
 
@@ -385,6 +402,7 @@ def create_api_compat_app(debug=None):
         pool_size_overrides={
             "db": (1, 1),
             "ts": (1, 1),
+            "listens": (1, 1),
             "meb": (1, 1),
         },
     )

--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -453,6 +453,9 @@ def _register_blueprints(app):
     # Retro-compatible 'profile' endpoint
     app.register_blueprint(settings_bp, url_prefix='/profile', name='profile')
 
+    from listenbrainz.webserver.views.external_connect import external_connect_bp
+    app.register_blueprint(external_connect_bp, url_prefix='/connect')
+
     from listenbrainz.webserver.views.export import export_bp
     app.register_blueprint(export_bp, url_prefix='/export')
 

--- a/listenbrainz/webserver/templates/external_connect/confirm.html
+++ b/listenbrainz/webserver/templates/external_connect/confirm.html
@@ -1,0 +1,68 @@
+{% extends 'base.html' %}
+
+{% block title %}Connect {{ service_label }} - ListenBrainz{% endblock %}
+
+{% block head %}
+  {{ super() }}
+  <style>
+    /* this page is a single dialog rather than a page of content, so centre it in the
+       viewport instead of letting it sit in the top left of the grid */
+    .connect-confirm {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 70vh;
+      padding: 2rem 1rem;
+    }
+    .connect-confirm .card {
+      width: 100%;
+      max-width: 34rem;
+    }
+    .connect-confirm .card-title {
+      margin: 0;
+    }
+    .connect-confirm .connect-actions {
+      display: flex;
+      gap: .6rem;
+      flex-wrap: wrap;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+<div class="connect-confirm">
+  <div class="card">
+    <div class="card-header">
+      <h3 class="card-title">Connect {{ service_label }}</h3>
+    </div>
+    <div class="card-body">
+      <p>
+        <strong>{{ connect_request.describe_client() }}</strong> would like to connect a
+        {{ service_label }} account to the ListenBrainz account
+        <strong>{{ musicbrainz_id }}</strong>.
+      </p>
+      <p>
+        If you continue, {{ service_label }} will ask you to authorize ListenBrainz. We
+        will then be able to {{ permission_description }}, and you will be sent back to
+        {{ connect_request.redirect_host() }}.
+      </p>
+      <div class="alert alert-warning">
+        Only continue if <strong>{{ musicbrainz_id }}</strong> is your ListenBrainz
+        account. If it is not, the {{ service_label }} account you authorize will be
+        connected to somebody else's ListenBrainz account.
+      </div>
+      <form method="post" class="connect-actions"
+            action="{{ url_for('external_connect.confirm', service_name=connect_request.service) }}">
+        <input type="hidden" name="ticket" value="{{ ticket }}" />
+        <input type="hidden" name="nonce" value="{{ nonce }}" />
+        <button type="submit" name="action" value="continue" class="btn btn-success">
+          Yes, that's my account
+        </button>
+        <button type="submit" name="action" value="cancel" class="btn btn-outline-secondary">
+          Cancel
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/listenbrainz/webserver/views/external_connect.py
+++ b/listenbrainz/webserver/views/external_connect.py
@@ -1,0 +1,228 @@
+""" Entry points of the flow that lets a third party application send a user to ListenBrainz
+to connect an external music service. See :mod:`listenbrainz.domain.external_connect` for a
+description of the whole flow.
+"""
+
+import requests
+from flask import Blueprint, current_app, jsonify, redirect, render_template, request
+from flask_login import current_user
+from werkzeug.exceptions import BadRequest
+
+import listenbrainz.db.user as db_user
+from listenbrainz.domain import external_connect
+from listenbrainz.domain.external_connect import ExternalConnectAuthError, ExternalConnectValidationError
+from listenbrainz.webserver import db_conn
+from listenbrainz.webserver.errors import APIBadRequest, APIServiceUnavailable, APIUnauthorized
+from listenbrainz.webserver.utils import CONNECT_SERVICES_WITHOUT_EMAIL_ERROR
+from listenbrainz.webserver.views.settings import _get_service_or_raise_404, _user_has_verified_email, \
+    _user_id_has_verified_email
+
+external_connect_bp = Blueprint("external_connect", __name__)
+
+# shown when the ticket a browser arrives with is unknown, expired or already spent
+STALE_TICKET_ERROR = "This link has already been used or has expired, please start again."
+
+
+@external_connect_bp.post("/<service_name>/")
+def create_connect_session(service_name: str):
+    """ Start connecting a music service for the owner of a MetaBrainz OAuth access token.
+
+    This is meant to be called by the backend of a partner application that already knows
+    which MetaBrainz account the user has. It does not involve the user's browser, so it
+    cannot redirect them anywhere. Instead it returns a single use url the partner has to
+    send the user's browser to, which is where the user confirms the account and the
+    redirect to the music service happens, see :func:`connect`.
+
+    The access token is read from the Authorization header and has to be a MetaBrainz OAuth
+    access token carrying the ``listenbrainz:connect-services`` scope. That scope is only
+    granted to applications MetaBrainz has approved for it, so it is the whole of the
+    authorization here: ListenBrainz keeps no registry of partner applications of its own.
+
+    JSON body:
+        redirect_uri: **(required)** where to send the user once the flow finishes, see
+            :func:`connect`.
+        state: an opaque value returned unchanged to the partner application.
+        permissions: what the partner wants ListenBrainz to be able to do with the account.
+        force: set to true to always send the user through the authorization screen of the
+            music service even if the account is already connected.
+
+    Returns:
+        ``{"url": ..., "expires_in": ...}`` where url is the single use url to send the
+        user's browser to and expires_in is how long it stays valid, in seconds.
+    """
+    access_token = _get_access_token()
+
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        raise APIBadRequest("The request body must be a json object.")
+
+    try:
+        connect_request = external_connect.validate_request_args(service_name, data)
+    except ExternalConnectValidationError as error:
+        raise APIBadRequest(str(error))
+
+    try:
+        user, token = external_connect.resolve_token(access_token)
+    except ExternalConnectAuthError as error:
+        raise APIUnauthorized(str(error))
+    except requests.RequestException:
+        current_app.logger.error("Error while introspecting access token:", exc_info=True)
+        raise APIServiceUnavailable("Something went wrong. Please try again later.")
+
+    if not _user_has_verified_email(user):
+        raise APIUnauthorized(CONNECT_SERVICES_WITHOUT_EMAIL_ERROR)
+
+    connect_request.user_id = user["id"]
+    connect_request.client_name = external_connect.get_client_name(token.get("client_id"))
+    if _is_true(data.get("force")):
+        connect_request.force = True
+
+    ticket = external_connect.create_ticket(connect_request)
+    return jsonify({
+        "url": external_connect.build_ticket_url(connect_request, ticket),
+        "expires_in": int(external_connect.TICKET_TTL.total_seconds()),
+    })
+
+
+@external_connect_bp.get("/<service_name>/")
+def connect(service_name: str):
+    """ Ask the user to confirm the ListenBrainz account before starting the authorization.
+
+    This is the url :func:`create_connect_session` returns and the partner application has
+    to send the user's browser to. The request it belongs to was already validated when the
+    ticket was created, so the ticket is the only query argument that is read.
+
+    The page it renders is the only point in the flow where the person in front of the
+    browser is told which ListenBrainz account the music service is about to be connected
+    to. They are not logged in to ListenBrainz, and the authorization screen the music
+    service shows afterwards only names ListenBrainz, so without this page a ticket minted
+    for one account could be handed to somebody else's browser unnoticed.
+
+    Query arguments:
+        ticket: **(required)** the single use ticket obtained from the token endpoint.
+    """
+    ticket = request.args.get("ticket")
+    connect_request = external_connect.peek_ticket(ticket, service_name)
+    if connect_request is None:
+        raise BadRequest(STALE_TICKET_ERROR)
+
+    wrong_user = _reject_wrong_user(connect_request)
+    if wrong_user is not None:
+        return wrong_user
+
+    user = db_user.get(db_conn, connect_request.user_id)
+    if user is None:
+        current_app.logger.error("External connect ticket for unknown user %s", connect_request.user_id)
+        return _return_to_client(
+            connect_request, external_connect.ERROR_SERVER_ERROR,
+            "The ListenBrainz account this link was created for no longer exists."
+        )
+
+    connectable = external_connect.get_connectable_service(connect_request.service)
+    return render_template(
+        "external_connect/confirm.html",
+        connect_request=connect_request,
+        ticket=ticket,
+        nonce=external_connect.start_confirmation(ticket),
+        musicbrainz_id=user["musicbrainz_id"],
+        service_label=connectable.label,
+        permission_description=connectable.describe_permission(connect_request.permission),
+        hide_navbar_user_menu=True,
+    )
+
+
+@external_connect_bp.post("/<service_name>/confirm/")
+def confirm(service_name: str):
+    """ Act on the confirmation page: start the authorization or send the user back.
+
+    The nonce has to be the one :func:`connect` put into the page it served this browser.
+    Without it the partner application could post this form itself and skip the page it is
+    supposed to show the user, which is the whole point of the confirmation.
+    """
+    ticket = request.form.get("ticket")
+    if not external_connect.check_confirmation(ticket, request.form.get("nonce")):
+        raise BadRequest("Please open the connect link again to confirm.")
+
+    connect_request = external_connect.consume_ticket(ticket, service_name)
+    if connect_request is None:
+        raise BadRequest(STALE_TICKET_ERROR)
+
+    wrong_user = _reject_wrong_user(connect_request)
+    if wrong_user is not None:
+        return wrong_user
+
+    if request.form.get("action") != "continue":
+        return _return_to_client(
+            connect_request, external_connect.ERROR_ACCESS_DENIED,
+            "The user did not confirm the ListenBrainz account."
+        )
+
+    return _authorize(connect_request)
+
+
+def _reject_wrong_user(connect_request):
+    """ Refuse a request whose account is not the one this browser is logged in as, if any.
+
+    Being logged in is not required anywhere in this flow, but when the browser does have a
+    ListenBrainz session we know for a fact who is using it, so a mismatch is an answer and
+    not a question to put to the user.
+    """
+    if not current_user.is_authenticated or current_user.id == connect_request.user_id:
+        return None
+    current_app.logger.error("%s connect link for user %s opened by user %s",
+                             connect_request.service, connect_request.user_id, current_user.id)
+    return _return_to_client(
+        connect_request, external_connect.ERROR_INVALID_REQUEST,
+        "This link was not created for the current ListenBrainz user."
+    )
+
+
+def _authorize(connect_request):
+    """ Redirect the user to the music service to authorize a validated request. """
+    connectable = external_connect.get_connectable_service(connect_request.service)
+    permissions = connectable.permissions[connect_request.permission]
+
+    if not _user_id_has_verified_email(connect_request.user_id):
+        return _return_to_client(
+            connect_request, external_connect.ERROR_EMAIL_REQUIRED, CONNECT_SERVICES_WITHOUT_EMAIL_ERROR
+        )
+
+    service = _get_service_or_raise_404(connectable.name)
+
+    existing_user = service.get_user(connect_request.user_id)
+    has_requested_permissions = bool(existing_user) and set(existing_user.get("scopes") or []) >= permissions
+    # nothing to do if the user already gave us everything the partner asked for
+    if has_requested_permissions and not connect_request.force:
+        return _return_to_client(connect_request)
+
+    try:
+        authorize_url = external_connect.build_authorize_url(service, permissions, connect_request.oauth_state)
+    except Exception:
+        current_app.logger.error("Could not build the %s authorize url for user %s:",
+                                 connectable.name, connect_request.user_id, exc_info=True)
+        return _return_to_client(
+            connect_request, external_connect.ERROR_SERVER_ERROR,
+            f"Could not start the {connectable.name} authorization."
+        )
+
+    external_connect.store_request(connect_request)
+    return redirect(authorize_url)
+
+
+def _return_to_client(connect_request, error: str = None, error_description: str = None):
+    return redirect(external_connect.build_return_url(connect_request, error, error_description))
+
+
+def _get_access_token():
+    """ Return the access token from the Authorization header of the current request. """
+    header = request.headers.get("Authorization")
+    if not header:
+        raise APIUnauthorized("You need to provide an Authorization header.")
+    parts = header.split(" ")
+    if len(parts) != 2:
+        raise APIUnauthorized("Provided Authorization header is invalid.")
+    return parts[1]
+
+
+def _is_true(value) -> bool:
+    return str(value).lower() in {"true", "1"}

--- a/listenbrainz/webserver/views/login.py
+++ b/listenbrainz/webserver/views/login.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from flask import Blueprint, request, redirect, url_for, session, current_app
 from flask_login import login_user, logout_user, login_required
 from markupsafe import Markup
@@ -14,12 +16,31 @@ from listenbrainz.webserver.utils import EMAIL_REQUIRED_BLOG_URL, METABRAINZ_PRO
 login_bp = Blueprint('login', __name__)
 
 
+def _sanitize_next_url(next_url):
+    """ Only allow redirecting to urls on this server after login, otherwise the login
+    endpoint could be used to send users to another site. """
+    if not next_url:
+        return None
+    parsed = urlparse(next_url)
+    if parsed.netloc:
+        if parsed.scheme and parsed.scheme not in ("http", "https"):
+            return None
+        allowed_hosts = {urlparse(request.host_url).netloc, urlparse(current_app.config["SERVER_ROOT_URL"]).netloc}
+        return next_url if parsed.netloc in allowed_hosts else None
+    # urlparse finds no netloc in "//evil.com", "////evil.com" or "/\evil.com" but browsers
+    # normalize backslashes to slashes and collapse the leading slashes, so all three send
+    # the user to another host. Only a single leading slash is safe.
+    if not next_url.startswith("/") or next_url[1:2] in ("/", "\\"):
+        return None
+    return next_url
+
+
 @login_bp.get('/musicbrainz/')
 @web_musicbrainz_needed
 @web_listenstore_needed
 @login_forbidden
 def musicbrainz():
-    session["next"] = request.args.get("next")
+    session["next"] = _sanitize_next_url(request.args.get("next"))
     login_hint = request.args.get("login_hint")
     return redirect(provider.get_authentication_uri(login_hint=login_hint))
 
@@ -50,7 +71,7 @@ def musicbrainz_post():
             login_user(User.from_dbrow(user),
                        remember=True,
                        duration=datetime.timedelta(current_app.config['SESSION_REMEMBER_ME_DURATION']))
-            next = session.get('next')
+            next = _sanitize_next_url(session.get('next'))
             if next:
                 return redirect(next)
         except MusicBrainzAuthSessionError:

--- a/listenbrainz/webserver/views/settings.py
+++ b/listenbrainz/webserver/views/settings.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import secrets
 from datetime import datetime
 from typing import Any
 
@@ -19,6 +20,7 @@ from listenbrainz.db.exceptions import DatabaseException
 from listenbrainz.db.missing_musicbrainz_data import get_user_missing_musicbrainz_data
 from listenbrainz.domain.apple import AppleService
 from listenbrainz.domain.critiquebrainz import CritiqueBrainzService, CRITIQUEBRAINZ_SCOPES
+from listenbrainz.domain import external_connect
 from listenbrainz.domain.external_service import ExternalService, ExternalServiceInvalidGrantError, ExternalServiceError, ExternalServiceAPIError
 from listenbrainz.domain.lastfm import LastfmService
 from listenbrainz.domain.librefm import LibrefmService
@@ -75,14 +77,37 @@ def _user_has_verified_email(user: dict[str, Any] | None) -> bool:
     return bool(user and user["email"])
 
 
+def _user_id_has_verified_email(user_id: int) -> bool:
+    return _user_has_verified_email(db_user.get(db_conn, user_id, fetch_email=True))
+
+
 def _current_user_has_verified_email() -> bool:
-    user = db_user.get(db_conn, current_user.id, fetch_email=True)
-    return _user_has_verified_email(user)
+    return _user_id_has_verified_email(current_user.id)
 
 
 def _require_current_user_verified_email() -> None:
     if not _current_user_has_verified_email():
         raise APIUnauthorized(CONNECT_SERVICES_WITHOUT_EMAIL_ERROR)
+
+
+def _start_service_authorization(service: ExternalService, permissions) -> str:
+    """ Start authorizing a music service from the ListenBrainz settings page.
+
+    Generates the OAuth state protecting the authorization request, stores it in the
+    session so that the callback can verify it and returns the url of the music service
+    the user has to be sent to.
+    """
+    state = base64.b64encode(os.urandom(32)).decode("utf-8")
+    session[external_connect.settings_oauth_state_key(service.service.value)] = state
+    # this authorization was not started by a third party application, make sure the user
+    # is not sent to one that they abandoned earlier
+    session.pop(external_connect.SESSION_KEY, None)
+    return external_connect.build_authorize_url(service, permissions, state)
+
+
+def _return_to_client(connect_request, error: str | None = None, error_description: str | None = None):
+    """ Send the user back to the third party application that started the flow. """
+    return redirect(external_connect.build_return_url(connect_request, error, error_description))
 
 
 @settings_bp.post("/resettoken/")
@@ -287,30 +312,44 @@ def music_services_details():
 
 
 @settings_bp.get('/music-services/<service_name>/callback/')
-@login_required
 def music_services_callback(service_name: str):
     service = _get_service_or_raise_404(service_name, exclude_apple=True, exclude_navidrome=True)
-    if not _current_user_has_verified_email():
+
+    # if a third party application started this authorization, the user is sent back to it
+    # instead of to the ListenBrainz settings page once we are done here. Merely finding the
+    # request must not consume it: first the callback has to prove it knows the OAuth state.
+    connect_request = external_connect.get_request(service_name)
+
+    # a request started by a third party application carries the user it was authorized for,
+    # those users are not logged in to ListenBrainz and must not become logged in either
+    if connect_request is not None:
+        user_id = connect_request.user_id
+    elif current_user.is_authenticated:
+        user_id = current_user.id
+    else:
+        return current_app.login_manager.unauthorized()
+
+    # Preserve the settings-page behavior for logged-in users. External-connect callbacks
+    # defer this check until after state validation so an untrusted callback cannot consume
+    # their pending request.
+    if connect_request is None and not _user_id_has_verified_email(user_id):
         return redirect(url_for("settings.index", path="music-services/details", email_required="1"))
 
-    # Check for error parameter first
-    error = request.args.get("error")
-    if error:
-        if isinstance(service, SoundCloudService):
-            session.pop("soundcloud_code_verifier", None)
-            session.pop("soundcloud_state", None)
+    # Funkwhale has a separate, instance-specific OAuth flow and cannot be started through
+    # external connect. Keep its existing state and callback handling independent.
+    if isinstance(service, FunkwhaleService):
+        error = request.args.get("error")
+        if error:
             return redirect(url_for(
                 "settings.index",
                 path="music-services/details",
-                soundcloud_error="SoundCloud authorization was denied"
+                service_error=f"{service_name.capitalize()} authorization was denied"
             ))
-        return redirect(url_for("settings.index", path="music-services/details"))
 
-    code = request.args.get("code")
-    if not code:
-        raise BadRequest("missing code")
+        code = request.args.get("code")
+        if not code:
+            raise BadRequest("missing code")
 
-    if isinstance(service, FunkwhaleService):
         state = request.args.get("state")
         if not state:
             current_app.logger.error("No state parameter in callback")
@@ -339,7 +378,7 @@ def music_services_callback(service_name: str):
             server = db_funkwhale.get_server_by_host_url(db_conn, host_url)
             if not server:
                 raise Exception("No Funkwhale server found for host_url")
-            service.add_new_user(current_user.id, server['id'], token)
+            service.add_new_user(user_id, server['id'], token)
 
             return redirect(url_for("settings.index", path="music-services/details", _anchor="funkwhale",
                                     success="Successfully connected to Funkwhale"))
@@ -352,40 +391,158 @@ def music_services_callback(service_name: str):
             session.pop("funkwhale_host_url", None)
             session.pop("funkwhale_user_id", None)
 
-    if isinstance(service, SoundCloudService):
-        state = request.args.get("state")
-        stored_state = session.pop("soundcloud_state", None)
-        if not state or state != stored_state:
-            current_app.logger.error("SoundCloud OAuth state mismatch. Expected: %s, Got: %s", stored_state, state)
-            session.pop("soundcloud_code_verifier", None)
+    # Historically an otherwise empty settings callback is a bad request. There is no
+    # pending partner request to protect in this branch.
+    if connect_request is None and not request.args.get("error") and not request.args.get("code"):
+        raise BadRequest("missing code")
+
+    # the state is created either by the settings page or by the third party application
+    # flow, in both cases the music service must hand it back to us unchanged. A missing
+    # state is a failure too, otherwise anyone could hand us an authorization code of their
+    # own and have the account it belongs to connected to whoever opens the callback.
+    expected_state = connect_request.oauth_state if connect_request is not None \
+        else session.get(external_connect.settings_oauth_state_key(service_name))
+    if not expected_state or not secrets.compare_digest(request.args.get("state") or "", expected_state):
+        current_app.logger.error("%s OAuth state mismatch for user %s", service_name, user_id)
+        if connect_request is not None:
+            return _return_to_client(
+                connect_request, external_connect.ERROR_INVALID_REQUEST,
+                f"{service_name.capitalize()} authorization failed: invalid state"
+            )
+        if isinstance(service, SoundCloudService):
             return redirect(url_for(
                 "settings.index",
                 path="music-services/details",
                 soundcloud_error="SoundCloud authorization failed: invalid state"
             ))
+        # without this the user is dropped back on the settings page with the service simply
+        # not connected and no explanation, which is what happens whenever two authorizations
+        # are started at the same time or the first one is finished twice
+        return redirect(url_for(
+            "settings.index",
+            path="music-services/details",
+            service_error=f"{service_name.capitalize()} authorization failed: invalid state, please try again"
+        ))
 
-        code_verifier = session.pop("soundcloud_code_verifier", None)
-        if not code_verifier:
-            current_app.logger.error("SoundCloud PKCE code verifier missing from session for user %s", current_user.id)
+    # State has been validated, so this callback is now authoritative and the pending
+    # authorization can be consumed. Invalid callbacks above deliberately leave all of the
+    # session material intact for the genuine callback.
+    if connect_request is not None:
+        external_connect.pop_request(service_name)
+    else:
+        session.pop(external_connect.settings_oauth_state_key(service_name), None)
+
+    if connect_request is not None and connect_request.has_expired():
+        session.pop("soundcloud_code_verifier", None)
+        return _return_to_client(
+            connect_request, external_connect.ERROR_EXPIRED_REQUEST,
+            "The authorization took too long to complete, please try again."
+        )
+
+    if (connect_request is not None and current_user.is_authenticated
+            and current_user.id != connect_request.user_id):
+        # the user switched accounts halfway through, we have no idea which of the two
+        # this authorization is for anymore
+        current_app.logger.error("%s callback for user %s does not match the pending request for user %s",
+                                 service_name, current_user.id, connect_request.user_id)
+        session.pop("soundcloud_code_verifier", None)
+        return _return_to_client(
+            connect_request, external_connect.ERROR_INVALID_REQUEST,
+            "The authorization does not belong to the current ListenBrainz user"
+        )
+
+    if not _user_id_has_verified_email(user_id):
+        session.pop("soundcloud_code_verifier", None)
+        if connect_request is not None:
+            return _return_to_client(
+                connect_request, external_connect.ERROR_EMAIL_REQUIRED, CONNECT_SERVICES_WITHOUT_EMAIL_ERROR
+            )
+        return redirect(url_for("settings.index", path="music-services/details", email_required="1"))
+
+    error = request.args.get("error")
+    if error:
+        session.pop("soundcloud_code_verifier", None)
+        if connect_request is not None:
+            if error == "access_denied":
+                partner_error = external_connect.ERROR_ACCESS_DENIED
+                description = f"{service_name.capitalize()} authorization was denied"
+            else:
+                # the music service refused for a reason of its own, telling the partner
+                # application the user declined would be a lie
+                partner_error = external_connect.ERROR_SERVER_ERROR
+                description = f"{service_name.capitalize()} authorization failed: {error}"
+            return _return_to_client(connect_request, partner_error, description)
+        if isinstance(service, SoundCloudService):
             return redirect(url_for(
                 "settings.index",
                 path="music-services/details",
-                soundcloud_error="SoundCloud authorization failed: please try again"
+                soundcloud_error="SoundCloud authorization was denied"
             ))
+        return redirect(url_for(
+            "settings.index",
+            path="music-services/details",
+            service_error=f"{service_name.capitalize()} authorization was denied"
+        ))
 
-        try:
+    code = request.args.get("code")
+    if not code:
+        session.pop("soundcloud_code_verifier", None)
+        if connect_request is not None:
+            return _return_to_client(
+                connect_request, external_connect.ERROR_INVALID_REQUEST,
+                f"{service_name.capitalize()} did not return an authorization code"
+            )
+        raise BadRequest("missing code")
+
+    try:
+        if isinstance(service, SoundCloudService):
+            code_verifier = session.pop("soundcloud_code_verifier", None)
+            if not code_verifier:
+                current_app.logger.error("SoundCloud PKCE code verifier missing from session for user %s",
+                                         user_id)
+                if connect_request is not None:
+                    return _return_to_client(
+                        connect_request, external_connect.ERROR_SERVER_ERROR,
+                        "SoundCloud authorization failed: please try again"
+                    )
+                return redirect(url_for(
+                    "settings.index",
+                    path="music-services/details",
+                    soundcloud_error="SoundCloud authorization failed: please try again"
+                ))
             token = service.fetch_access_token(code, code_verifier=code_verifier)
-        except Exception:
-            current_app.logger.error("SoundCloud token exchange failed for user %s", current_user.id, exc_info=True)
+        else:
+            token = service.fetch_access_token(code)
+
+        if connect_request is not None:
+            connectable = external_connect.get_connectable_service(connect_request.service)
+            permissions = connectable.permissions[connect_request.permission]
+            existing_user = service.get_user(user_id)
+            if existing_user and not set(existing_user.get("scopes") or []) >= permissions:
+                # The replacement token has now been exchanged successfully. Remove the old
+                # connection only at this point so abandoning, denying or failing the OAuth
+                # flow cannot disconnect an otherwise working account. Removal is still
+                # needed before saving a narrower token so its listens importer is dropped.
+                service.remove_user(user_id)
+
+        service.add_new_user(user_id, token)
+    except Exception:
+        current_app.logger.error("%s token exchange failed for user %s", service_name, user_id, exc_info=True)
+        if connect_request is not None:
+            return _return_to_client(
+                connect_request, external_connect.ERROR_SERVER_ERROR,
+                f"{service_name.capitalize()} authorization failed: could not exchange token"
+            )
+        if isinstance(service, SoundCloudService):
             return redirect(url_for(
                 "settings.index",
                 path="music-services/details",
                 soundcloud_error="SoundCloud authorization failed: could not exchange token"
             ))
-    else:
-        token = service.fetch_access_token(code)
+        raise
 
-    service.add_new_user(current_user.id, token)
+    if connect_request is not None:
+        return _return_to_client(connect_request)
     return redirect(url_for("settings.index", path="music-services/details"))
 
 
@@ -609,21 +766,12 @@ def music_services_disconnect(service_name: str):
             elif action == 'listen':
                 permissions = SPOTIFY_LISTEN_PERMISSIONS
             if permissions:
-                return jsonify({"url": service.get_authorize_url(permissions)})
+                return jsonify({"url": _start_service_authorization(service, permissions)})
         elif service_name == 'soundcloud':
-            code_verifier, code_challenge = SoundCloudService.generate_pkce_pair()
-            state = base64.b64encode(os.urandom(32)).decode("utf-8")
-            session["soundcloud_code_verifier"] = code_verifier
-            session["soundcloud_state"] = state
-            return jsonify({"url": service.get_authorize_url(
-                [],
-                state=state,
-                code_challenge=code_challenge,
-                code_challenge_method="S256"
-            )})
+            return jsonify({"url": _start_service_authorization(service, [])})
         elif service_name == 'critiquebrainz':
             if action:
-                return jsonify({"url": service.get_authorize_url(CRITIQUEBRAINZ_SCOPES)})
+                return jsonify({"url": _start_service_authorization(service, CRITIQUEBRAINZ_SCOPES)})
         elif service_name == 'apple':
             service.add_new_user(user_id=current_user.id)
             return jsonify({"success": True})

--- a/listenbrainz/webserver/views/test/test_external_connect.py
+++ b/listenbrainz/webserver/views/test/test_external_connect.py
@@ -1,0 +1,606 @@
+import re
+import time
+from unittest.mock import patch
+from urllib.parse import urlparse, parse_qs
+
+import spotipy
+
+import listenbrainz.db.user as db_user
+from data.model.external_service import ExternalServiceType
+from listenbrainz.db import external_service_oauth as db_oauth
+from listenbrainz.domain import external_connect
+from listenbrainz.domain.spotify import SpotifyService, SPOTIFY_IMPORT_PERMISSIONS, SPOTIFY_LISTEN_PERMISSIONS
+from listenbrainz.tests.integration import IntegrationTestCase
+
+REDIRECT_URI = "https://fankee.example/listenbrainz/connected"
+OTHER_REDIRECT_URI = "https://partner.example/listenbrainz/connected"
+
+
+class ExternalConnectViewsTestCase(IntegrationTestCase):
+
+    def setUp(self):
+        super(ExternalConnectViewsTestCase, self).setUp()
+        self.user = db_user.get_or_create(self.db_conn, 1, 'iliekcomputers')
+        db_user.agree_to_gdpr(self.db_conn, self.user['musicbrainz_id'])
+        with self.app.app_context():
+            self.service = SpotifyService()
+        # the test client is created once per class, so the session of the previous test
+        # would otherwise leak into this one
+        with self.client.session_transaction() as session:
+            session.clear()
+
+    def introspection_response(self, **kwargs):
+        response = {
+            "active": True,
+            "sub": self.user["musicbrainz_row_id"],
+            "username": self.user["musicbrainz_id"],
+            # This is the shape returned by the real MetaBrainz introspection endpoint.
+            "scope": ["profile", external_connect.CONNECT_SERVICES_SCOPE],
+            "expires_at": int(time.time()) + 3600,
+            "client_id": "fankee-client-id",
+        }
+        response.update(kwargs)
+        return response
+
+    def post_connect(self, service_name="spotify", token="meba_token", **kwargs):
+        """ Make the call a partner application's backend makes to start the flow. """
+        body = {"redirect_uri": REDIRECT_URI, "state": "partner-state"}
+        body.update(kwargs)
+        body = {key: value for key, value in body.items() if value is not None}
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        return self.client.post(
+            self.custom_url_for("external_connect.create_connect_session", service_name=service_name),
+            json=body, headers=headers
+        )
+
+    def post_connect_ok(self, service_name="spotify", **kwargs):
+        """ post_connect with a token the introspection endpoint accepts. """
+        with patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info') as mock_introspect:
+            mock_introspect.return_value = self.introspection_response()
+            return self.post_connect(service_name=service_name, **kwargs)
+
+    def get_ticket(self, service_name="spotify", **kwargs):
+        """ Start the flow with a valid access token and return the ticket we handed out. """
+        response = self.post_connect_ok(service_name=service_name, **kwargs)
+        self.assert200(response)
+        return parse_qs(urlparse(response.json["url"]).query)["ticket"][0]
+
+    def ticket_url(self, ticket, service_name="spotify"):
+        return self.custom_url_for("external_connect.connect", service_name=service_name, ticket=ticket)
+
+    def open_confirmation(self, ticket, service_name="spotify"):
+        """ Open the confirmation page and return it along with the nonce it carries. """
+        response = self.client.get(self.ticket_url(ticket, service_name=service_name))
+        self.assert200(response)
+        nonce = re.search(rb'name="nonce" value="([^"]+)"', response.data)
+        return response, nonce.group(1).decode() if nonce else None
+
+    def submit_confirmation(self, ticket, service_name="spotify", action="continue", nonce=None):
+        """ Submit the confirmation page the way the user's browser would. """
+        if nonce is None:
+            _, nonce = self.open_confirmation(ticket, service_name=service_name)
+        return self.client.post(
+            self.custom_url_for("external_connect.confirm", service_name=service_name),
+            data={"ticket": ticket, "nonce": nonce, "action": action}
+        )
+
+    def connect(self, service_name="spotify", **kwargs):
+        """ Run the whole partner side of the flow up to the redirect to the music service. """
+        ticket = self.get_ticket(service_name=service_name, **kwargs)
+        return self.submit_confirmation(ticket, service_name=service_name)
+
+    def assert_returned_to_client(self, response, redirect_uri=REDIRECT_URI, **expected):
+        """ Assert the user was redirected to the partner app with the given query params. """
+        self.assertStatus(response, 302)
+        location = urlparse(response.location)
+        self.assertEqual(location._replace(query="").geturl(), redirect_uri)
+        params = {key: value[0] for key, value in parse_qs(location.query).items()}
+        for key, value in expected.items():
+            self.assertEqual(params.get(key), value, f"unexpected value of '{key}' in {params}")
+        return params
+
+    def test_connect_redirects_to_service(self):
+        r = self.connect()
+
+        self.assertStatus(r, 302)
+        location = urlparse(r.location)
+        self.assertEqual(location.netloc, "accounts.spotify.com")
+
+        params = parse_qs(location.query)
+        self.assertEqual(set(params["scope"][0].split()), SPOTIFY_IMPORT_PERMISSIONS)
+
+        with self.client.session_transaction() as session:
+            stored = session[external_connect.SESSION_KEY]
+            # the flow must not log the user in to ListenBrainz
+            self.assertNotIn("_user_id", session)
+        self.assertEqual(stored["user_id"], self.user["id"])
+        self.assertEqual(stored["redirect_uri"], REDIRECT_URI)
+        self.assertEqual(stored["client_state"], "partner-state")
+        self.assertEqual(stored["permission"], "import")
+        # the state must reach spotify so that the callback can verify it
+        self.assertEqual(params["state"][0], stored["oauth_state"])
+
+    def test_connect_requires_a_ticket(self):
+        r = self.client.get(self.custom_url_for("external_connect.connect", service_name="spotify",
+                                                redirect_uri=REDIRECT_URI))
+        self.assert400(r)
+
+    def test_connect_rejects_an_unknown_ticket(self):
+        self.assert400(self.client.get(self.ticket_url("not-a-ticket")))
+
+    def test_ticket_is_single_use(self):
+        ticket = self.get_ticket()
+
+        r = self.submit_confirmation(ticket)
+        self.assertStatus(r, 302)
+        self.assertEqual(urlparse(r.location).netloc, "accounts.spotify.com")
+
+        # the ticket is spent by the confirmation, not by merely opening the page
+        self.assert400(self.client.get(self.ticket_url(ticket)))
+
+    def test_opening_the_confirmation_page_does_not_spend_the_ticket(self):
+        ticket = self.get_ticket()
+
+        self.open_confirmation(ticket)
+        self.open_confirmation(ticket)
+
+        r = self.submit_confirmation(ticket)
+        self.assertStatus(r, 302)
+        self.assertEqual(urlparse(r.location).netloc, "accounts.spotify.com")
+
+    def test_ticket_is_bound_to_its_service(self):
+        ticket = self.get_ticket()
+        self.assert400(self.client.get(self.ticket_url(ticket, service_name="soundcloud")))
+
+    def test_confirmation_page_names_the_client_the_account_and_the_permission(self):
+        response, nonce = self.open_confirmation(self.get_ticket())
+
+        self.assertIsNotNone(nonce)
+        page = response.data.decode()
+        # no MetaBrainz database is configured in the tests, so the application is named by
+        # the host the user will be sent back to
+        self.assertIn("fankee.example", page)
+        self.assertIn(self.user["musicbrainz_id"], page)
+        self.assertIn("read your Spotify listening history", page)
+        # the user must not be sent anywhere before they have confirmed
+        self.assertNotIn("accounts.spotify.com", page)
+        with self.client.session_transaction() as session:
+            self.assertNotIn(external_connect.SESSION_KEY, session)
+
+    @patch('listenbrainz.domain.external_connect.db_oauth_client.get_client_name')
+    def test_confirmation_page_names_the_registered_application(self, mock_get_client_name):
+        """ When the MetaBrainz database is available we can put the name the application
+        is registered under next to the host the user is going back to. """
+        mock_get_client_name.return_value = "Fankee"
+        # the app is created once per class, so put the config back for the next test
+        previous = self.app.config["SQLALCHEMY_METABRAINZ_URI"]
+        self.addCleanup(self.app.config.__setitem__, "SQLALCHEMY_METABRAINZ_URI", previous)
+        self.app.config["SQLALCHEMY_METABRAINZ_URI"] = "postgresql://meb"
+
+        response, _ = self.open_confirmation(self.get_ticket())
+
+        mock_get_client_name.assert_called_once()
+        self.assertEqual(mock_get_client_name.call_args.args[1], "fankee-client-id")
+        self.assertIn("Fankee (fankee.example)", response.data.decode())
+
+    def test_confirmation_requires_the_nonce_from_the_page(self):
+        ticket = self.get_ticket()
+        self.open_confirmation(ticket)
+
+        # a partner that posts the form itself never saw the nonce
+        self.assert400(self.submit_confirmation(ticket, nonce="not-the-nonce"))
+        with self.client.session_transaction() as session:
+            self.assertNotIn(external_connect.SESSION_KEY, session)
+
+    def test_confirmation_cannot_be_submitted_without_opening_the_page(self):
+        ticket = self.get_ticket()
+        r = self.client.post(
+            self.custom_url_for("external_connect.confirm", service_name="spotify"),
+            data={"ticket": ticket, "nonce": "guessed", "action": "continue"}
+        )
+        self.assert400(r)
+
+    def test_confirmation_nonce_is_single_use(self):
+        ticket = self.get_ticket()
+        _, nonce = self.open_confirmation(ticket)
+
+        self.assertStatus(self.submit_confirmation(ticket, nonce=nonce), 302)
+        self.assert400(self.submit_confirmation(ticket, nonce=nonce))
+
+    def test_cancelling_the_confirmation_returns_to_the_client(self):
+        ticket = self.get_ticket()
+
+        r = self.submit_confirmation(ticket, action="cancel")
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_ACCESS_DENIED,
+                                       state="partner-state")
+        with self.client.session_transaction() as session:
+            self.assertNotIn(external_connect.SESSION_KEY, session)
+        # cancelling spends the ticket too
+        self.assert400(self.client.get(self.ticket_url(ticket)))
+
+    def test_confirmation_page_rejects_a_different_logged_in_user(self):
+        other_user = db_user.get_or_create(self.db_conn, 2, 'someone-else')
+        db_user.agree_to_gdpr(self.db_conn, other_user['musicbrainz_id'])
+        ticket = self.get_ticket()
+
+        self.temporary_login(other_user['login_id'])
+        r = self.client.get(self.ticket_url(ticket))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_INVALID_REQUEST)
+
+    def test_connect_uses_requested_permissions(self):
+        r = self.connect(permissions="both")
+
+        self.assertStatus(r, 302)
+        params = parse_qs(urlparse(r.location).query)
+        self.assertIn("streaming", params["scope"][0].split())
+        self.assertIn("user-read-recently-played", params["scope"][0].split())
+
+    def test_connect_returns_immediately_if_already_connected(self):
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='token', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+
+        r = self.connect()
+        self.assert_returned_to_client(r, status="connected", state="partner-state", service="spotify")
+
+        # unless the partner explicitly asks us to authorize again
+        r = self.connect(force=True)
+        self.assertStatus(r, 302)
+        self.assertEqual(urlparse(r.location).netloc, "accounts.spotify.com")
+
+    def test_connect_reauthorizes_if_scopes_are_insufficient(self):
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='token', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+
+        r = self.connect(permissions="both")
+        self.assertStatus(r, 302)
+        self.assertEqual(urlparse(r.location).netloc, "accounts.spotify.com")
+
+    def test_connect_returns_to_the_requested_redirect_uri(self):
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='token', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+
+        r = self.connect(redirect_uri=OTHER_REDIRECT_URI)
+        self.assert_returned_to_client(r, OTHER_REDIRECT_URI, status="connected")
+
+    def test_connect_replaces_reserved_redirect_uri_parameters(self):
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='token', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+        redirect_uri = (
+            f"{REDIRECT_URI}?keep=this&service=old&status=old&state=old"
+            "&error=old&error_description=old"
+        )
+
+        r = self.connect(redirect_uri=redirect_uri)
+
+        params = parse_qs(urlparse(r.location).query)
+        self.assertEqual(params, {
+            "keep": ["this"],
+            "service": ["spotify"],
+            "status": ["connected"],
+            "state": ["partner-state"],
+        })
+
+    def test_connect_requires_redirect_uri(self):
+        self.assert400(self.post_connect(redirect_uri=None))
+
+    def test_connect_rejects_a_redirect_uri_that_is_not_an_https_url(self):
+        """ There is no allow list to match against, so all we can do is make sure the
+        browser can actually be redirected there. http is only allowed for local
+        development. """
+        for redirect_uri in ["javascript:alert(1)", "data:text/html,x", "/listenbrainz/connected",
+                             "https:///connected", "http://partner.example/connected"]:
+            with self.subTest(redirect_uri=redirect_uri):
+                self.assert400(self.post_connect(redirect_uri=redirect_uri))
+
+        self.assert200(self.post_connect_ok(redirect_uri="http://localhost:3000/connected"))
+
+    def test_connect_only_supports_spotify(self):
+        """ Spotify is the only service offered through this flow for now. Soundcloud and
+        critiquebrainz can be connected from the settings page but not from here. """
+        for service_name in ["soundcloud", "critiquebrainz", "funkwhale", "apple"]:
+            with self.subTest(service=service_name):
+                self.assert400(self.post_connect(service_name=service_name))
+
+    def test_connect_rejects_invalid_permissions(self):
+        self.assert400(self.post_connect(permissions="everything"))
+
+    def test_connect_rejects_overlong_state(self):
+        self.assert400(self.post_connect(state="x" * (external_connect.MAX_CLIENT_STATE_LENGTH + 1)))
+
+    def test_connect_rejects_values_that_are_not_strings(self):
+        """ The body is json, so a partner can put anything in it. """
+        for key, value in [("redirect_uri", [REDIRECT_URI]),
+                           ("state", 123), ("permissions", ["import"])]:
+            with self.subTest(key=key):
+                self.assert400(self.post_connect(**{key: value}))
+
+    def test_connect_rejects_a_ticket_for_a_different_logged_in_user(self):
+        other_user = db_user.get_or_create(self.db_conn, 2, 'someone-else')
+        db_user.agree_to_gdpr(self.db_conn, other_user['musicbrainz_id'])
+        ticket = self.get_ticket()
+
+        self.temporary_login(other_user['login_id'])
+        r = self.client.get(self.ticket_url(ticket))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_INVALID_REQUEST)
+        with self.client.session_transaction() as session:
+            self.assertNotIn(external_connect.SESSION_KEY, session)
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_connect_validates_the_request_before_introspecting_the_token(self, mock_introspect):
+        self.assert400(self.post_connect(redirect_uri="javascript:alert(1)"))
+        mock_introspect.assert_not_called()
+
+    @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
+    @patch.object(spotipy.Spotify, 'current_user')
+    def test_callback_returns_to_client(self, mock_current_user, mock_fetch_access_token):
+        mock_current_user.return_value = {"id": "test-id"}
+        mock_fetch_access_token.return_value = {
+            'access_token': 'token',
+            'refresh_token': 'refresh',
+            'expires_in': 3600,
+            'scope': ' '.join(SPOTIFY_IMPORT_PERMISSIONS),
+        }
+        self.connect()
+        with self.client.session_transaction() as session:
+            oauth_state = session[external_connect.SESSION_KEY]["oauth_state"]
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='code', state=oauth_state
+        ))
+        self.assert_returned_to_client(r, status="connected", service="spotify", state="partner-state")
+
+        # the tokens are stored for the owner of the access token the partner sent us
+        with self.app.app_context():
+            user = self.service.get_user(self.user['id'])
+        self.assertEqual(self.user['id'], user['user_id'])
+        self.assertEqual('token', user['access_token'])
+
+        # the request is single use, a second callback goes to the settings page instead
+        with self.client.session_transaction() as session:
+            self.assertNotIn(external_connect.SESSION_KEY, session)
+            self.assertNotIn("_user_id", session)
+
+    @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
+    @patch.object(spotipy.Spotify, 'current_user')
+    def test_callback_replaces_the_old_connection_after_token_exchange(self, mock_current_user,
+                                                                        mock_fetch_access_token):
+        """ Narrowing the permissions must not leave the listens importer behind. """
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='old', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+        mock_current_user.return_value = {"id": "test-id"}
+        mock_fetch_access_token.return_value = {
+            'access_token': 'token', 'refresh_token': 'refresh', 'expires_in': 3600,
+            'scope': ' '.join(SPOTIFY_LISTEN_PERMISSIONS),
+        }
+
+        self.connect(permissions="listen", force=True)
+        with self.client.session_transaction() as session:
+            oauth_state = session[external_connect.SESSION_KEY]["oauth_state"]
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='code', state=oauth_state
+        ))
+        self.assert_returned_to_client(r, status="connected")
+
+        with self.app.app_context():
+            self.assertEqual('token', self.service.get_user(self.user['id'])['access_token'])
+            self.assertIsNone(self.service.get_user_connection_details(self.user['id']))
+
+    def test_callback_returns_error_to_client_when_denied(self):
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='old', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+        self.connect(force=True)
+        with self.client.session_transaction() as session:
+            oauth_state = session[external_connect.SESSION_KEY]["oauth_state"]
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', error='access_denied', state=oauth_state
+        ))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_ACCESS_DENIED,
+                                       state="partner-state")
+        with self.app.app_context():
+            self.assertEqual('old', self.service.get_user(self.user['id'])['access_token'])
+            self.assertIsNotNone(self.service.get_user_connection_details(self.user['id']))
+
+    def test_callback_does_not_report_a_service_side_error_as_a_denial(self):
+        self.connect()
+        with self.client.session_transaction() as session:
+            oauth_state = session[external_connect.SESSION_KEY]["oauth_state"]
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', error='invalid_scope', state=oauth_state
+        ))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_SERVER_ERROR)
+
+    def test_callback_error_with_invalid_state_does_not_cancel_pending_request(self):
+        self.connect()
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify',
+            error='access_denied', state='not-the-state'
+        ))
+
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_INVALID_REQUEST)
+        with self.client.session_transaction() as session:
+            self.assertIn(external_connect.SESSION_KEY, session)
+
+    def test_callback_error_does_not_clear_the_pending_oauth_state(self):
+        """ Otherwise it could be used to strip the state off an authorization in flight. """
+        self.temporary_login(self.user['login_id'])
+        self.client.post(self.custom_url_for('settings.music_services_disconnect', service_name='spotify'),
+                         json={"action": "import"})
+        with self.client.session_transaction() as session:
+            state = session[external_connect.settings_oauth_state_key("spotify")]
+
+        self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', error='access_denied'
+        ))
+        with self.client.session_transaction() as session:
+            self.assertEqual(session[external_connect.settings_oauth_state_key("spotify")], state)
+
+    @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
+    def test_callback_without_a_pending_state_is_rejected(self, mock_fetch_access_token):
+        """ A code we never asked for must not be exchanged, it could belong to anyone. """
+        self.temporary_login(self.user['login_id'])
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='attacker-code'
+        ))
+        self.assertStatus(r, 302)
+        self.assertNotIn("accounts.spotify.com", r.location)
+        mock_fetch_access_token.assert_not_called()
+        with self.app.app_context():
+            self.assertIsNone(self.service.get_user(self.user['id']))
+
+    def test_authorizations_of_two_services_do_not_clobber_each_other(self):
+        self.temporary_login(self.user['login_id'])
+        self.client.post(self.custom_url_for('settings.music_services_disconnect', service_name='spotify'),
+                         json={"action": "import"})
+        self.client.post(self.custom_url_for('settings.music_services_disconnect', service_name='critiquebrainz'),
+                         json={"action": "review"})
+
+        with self.client.session_transaction() as session:
+            self.assertIn(external_connect.settings_oauth_state_key("spotify"), session)
+            self.assertNotEqual(session[external_connect.settings_oauth_state_key("spotify")],
+                                session[external_connect.settings_oauth_state_key("critiquebrainz")])
+
+    @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
+    def test_callback_rejects_mismatched_state(self, mock_fetch_access_token):
+        self.connect()
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='code', state='not-the-state'
+        ))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_INVALID_REQUEST)
+        mock_fetch_access_token.assert_not_called()
+        with self.client.session_transaction() as session:
+            self.assertIn(external_connect.SESSION_KEY, session)
+
+    @patch('listenbrainz.domain.spotify.SpotifyService.fetch_access_token')
+    def test_callback_returns_error_to_client_on_token_exchange_failure(self, mock_fetch_access_token):
+        db_oauth.save_token(self.db_conn, user_id=self.user['id'], service=ExternalServiceType.SPOTIFY,
+                            access_token='old', refresh_token='refresh', token_expires_ts=int(time.time()) + 3600,
+                            record_listens=True, scopes=list(SPOTIFY_IMPORT_PERMISSIONS))
+        mock_fetch_access_token.side_effect = Exception("boom")
+        self.connect(permissions="listen", force=True)
+        # Merely starting a replacement authorization must leave the working connection in
+        # place in case the user abandons the flow.
+        with self.app.app_context():
+            self.assertEqual('old', self.service.get_user(self.user['id'])['access_token'])
+            self.assertIsNotNone(self.service.get_user_connection_details(self.user['id']))
+        with self.client.session_transaction() as session:
+            oauth_state = session[external_connect.SESSION_KEY]["oauth_state"]
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='code', state=oauth_state
+        ))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_SERVER_ERROR)
+        with self.app.app_context():
+            self.assertEqual('old', self.service.get_user(self.user['id'])['access_token'])
+            self.assertIsNotNone(self.service.get_user_connection_details(self.user['id']))
+
+    def test_callback_rejects_a_different_logged_in_user(self):
+        other_user = db_user.get_or_create(self.db_conn, 2, 'someone-else')
+        db_user.agree_to_gdpr(self.db_conn, other_user['musicbrainz_id'])
+
+        self.connect()
+        with self.client.session_transaction() as session:
+            oauth_state = session[external_connect.SESSION_KEY]["oauth_state"]
+
+        self.temporary_login(other_user['login_id'])
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='code', state=oauth_state
+        ))
+        self.assert_returned_to_client(r, status="error", error=external_connect.ERROR_INVALID_REQUEST)
+        with self.app.app_context():
+            self.assertIsNone(self.service.get_user(self.user['id']))
+            self.assertIsNone(self.service.get_user(other_user['id']))
+
+    def test_callback_requires_login_without_a_pending_request(self):
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='spotify', code='code'
+        ))
+        self.assertStatus(r, 302)
+        self.assertIn("/login/musicbrainz/", r.location)
+
+    def test_callback_for_another_service_is_not_returned_to_client(self):
+        """ A pending request for spotify must not hijack a soundcloud callback. """
+        self.connect()
+        self.temporary_login(self.user['login_id'])
+
+        r = self.client.get(self.custom_url_for(
+            'settings.music_services_callback', service_name='soundcloud', error='access_denied'
+        ))
+        self.assertStatus(r, 302)
+        self.assertNotIn("fankee.example", r.location)
+        with self.client.session_transaction() as session:
+            self.assertIn(external_connect.SESSION_KEY, session)
+
+    def test_token_flow_returns_single_use_url(self):
+        with patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info') as mock_introspect:
+            mock_introspect.return_value = self.introspection_response()
+            r = self.post_connect()
+            mock_introspect.assert_called_once_with("meba_token")
+
+        self.assert200(r)
+        self.assertEqual(r.json["expires_in"], int(external_connect.TICKET_TTL.total_seconds()))
+        self.assertIn("/connect/spotify/", r.json["url"])
+
+    def test_token_flow_requires_authorization_header(self):
+        self.assert401(self.post_connect(token=None))
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_rejects_listenbrainz_user_token(self, mock_introspect):
+        r = self.post_connect(token=self.user["auth_token"])
+        self.assert401(r)
+        mock_introspect.assert_not_called()
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_requires_connect_services_scope(self, mock_introspect):
+        for scope in [["profile", "email"], "profile email", [], None]:
+            with self.subTest(scope=scope):
+                mock_introspect.return_value = self.introspection_response(scope=scope)
+                r = self.post_connect()
+                self.assert401(r)
+                self.assertIn(external_connect.CONNECT_SERVICES_SCOPE, r.json["error"])
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_accepts_space_delimited_scope_for_compatibility(self, mock_introspect):
+        mock_introspect.return_value = self.introspection_response(
+            scope=f"profile {external_connect.CONNECT_SERVICES_SCOPE}"
+        )
+        self.assert200(self.post_connect())
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_rejects_inactive_token(self, mock_introspect):
+        mock_introspect.return_value = self.introspection_response(active=False)
+        self.assert401(self.post_connect())
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_rejects_expired_token(self, mock_introspect):
+        mock_introspect.return_value = self.introspection_response(expires_at=int(time.time()) - 10)
+        self.assert401(self.post_connect())
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_rejects_user_without_listenbrainz_account(self, mock_introspect):
+        mock_introspect.return_value = self.introspection_response(sub=99999, username="nosuchuser")
+        self.assert401(self.post_connect())
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_rejects_a_client_credentials_token(self, mock_introspect):
+        """ A client credentials grant has no user behind it, MetaBrainz reports it as the
+        sentinel subject -1. There is nobody to connect a music service for. """
+        mock_introspect.return_value = self.introspection_response(sub="-1", username=None)
+        self.assert401(self.post_connect())
+
+    @patch('listenbrainz.domain.musicbrainz.MusicBrainzService.get_user_info')
+    def test_token_flow_needs_no_credentials_beyond_the_token(self, mock_introspect):
+        """ The scope is only granted to applications MetaBrainz approved, so the token is
+        the whole of the authorization. ListenBrainz keeps no client registry. """
+        mock_introspect.return_value = self.introspection_response()
+        self.assert200(self.post_connect(client_id="anything", client_secret="anything"))

--- a/listenbrainz/webserver/views/test/test_login.py
+++ b/listenbrainz/webserver/views/test/test_login.py
@@ -46,6 +46,27 @@ class LoginViewsTestCase(ServerTestCase):
         query = parse_qs(urlparse(response.location).query)
         self.assertNotIn("login_hint", query)
 
+    def test_login_musicbrainz_only_remembers_a_next_url_on_this_server(self):
+        """ Anything else would turn the login endpoint into an open redirect. Browsers
+        normalize backslashes to slashes and collapse leading slashes, so those forms have
+        to be rejected too even though urlparse finds no host in them. """
+        for next_url in ["https://evil.example/", "//evil.example/", "////evil.example/",
+                         "/\\evil.example/", "https://listenbrainz.org@evil.example/",
+                         "javascript:alert(1)"]:
+            with self.subTest(next=next_url):
+                self.client.get(self.custom_url_for('login.musicbrainz', next=next_url))
+                with self.client.session_transaction() as session:
+                    self.assertIsNone(session["next"])
+
+        # flask_login sends us an absolute url, so those have to keep working
+        allowed = ["/settings/music-services/details/", "/",
+                   self.app.config["SERVER_ROOT_URL"] + "/settings/"]
+        for next_url in allowed:
+            with self.subTest(next=next_url):
+                self.client.get(self.custom_url_for('login.musicbrainz', next=next_url))
+                with self.client.session_transaction() as session:
+                    self.assertEqual(session["next"], next_url)
+
 
 class LoginProviderTestCase(IntegrationTestCase):
 

--- a/listenbrainz/webserver/views/test/test_settings.py
+++ b/listenbrainz/webserver/views/test/test_settings.py
@@ -9,6 +9,7 @@ import listenbrainz.db.navidrome as db_navidrome
 import time
 
 from data.model.external_service import ExternalServiceType
+from listenbrainz.domain import external_connect
 from listenbrainz.webserver.utils import CONNECT_SERVICES_WITHOUT_EMAIL_ERROR
 from listenbrainz.domain.spotify import SpotifyService, OAUTH_TOKEN_URL
 from listenbrainz.tests.integration import IntegrationTestCase
@@ -221,8 +222,12 @@ class SettingsViewsTestCase(IntegrationTestCase):
             'scope': '',
         }
         self.temporary_login(self.user['login_id'])
+        # the callback only accepts the state created when the authorization was started
+        with self.client.session_transaction() as session:
+            session[external_connect.settings_oauth_state_key('spotify')] = 'oauth-state'
 
-        r = self.client.get(self.custom_url_for('settings.music_services_callback', service_name='spotify', code='code'))
+        r = self.client.get(self.custom_url_for('settings.music_services_callback', service_name='spotify',
+                                                code='code', state='oauth-state'))
 
         self.assertStatus(r, 302)
         mock_fetch_access_token.assert_called_once_with('code')

--- a/test.sh
+++ b/test.sh
@@ -99,7 +99,8 @@ function unit_setup {
                   -wait tcp://rabbitmq:5672 -timeout 60s \
                   -wait tcp://couchdb:5984 -timeout 60s \
                 bash -c "python3 manage.py init_db --create-db && \
-                         python3 manage.py init_ts_db --create-db"
+                         python3 manage.py init_ts_db --create-db && \
+                         python3 manage.py init_listens_db --create-db"
 }
 
 function is_unit_db_running {


### PR DESCRIPTION
Write listen inserts and deletes to both Timescale and the user-partitioned PostgreSQL database.

Commit Timescale only after the partitioned write succeeds so database connection failures leave RabbitMQ messages available for retry. Make the writes idempotent and use pooled connections in long-running services.

* [X] I have used AI in this PR to generate some of the code.