### PR TITLE
LB-1761: Persist Fresh Releases filters across page reloads

### DIFF
--- a/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
@@ -87,9 +87,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
     if (isChecked) {
       setFreshReleasesFilters({ checkedList: [...checkedList, value] });
     } else {
-      const filtersList = checkedList.filter(
-        (item: string | undefined) => item !== value
-      );
+      const filtersList = checkedList.filter((item) => item !== value);
       setFreshReleasesFilters({ checkedList: filtersList });
     }
   };
@@ -102,7 +100,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
 
     // remove from exclude list if it's there
     const excludeFiltersList = releaseTagsExcludeCheckList.filter(
-      (item: string | undefined) => item !== value
+      (item) => item !== value
     );
 
     setFreshReleasesFilters({
@@ -112,9 +110,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
   };
 
   const removeFilterTag = (tag: string) => {
-    const filtersList = releaseTagsCheckList.filter(
-      (item: string | undefined) => item !== tag
-    );
+    const filtersList = releaseTagsCheckList.filter((item) => item !== tag);
     setFreshReleasesFilters({ releaseTagsCheckList: filtersList });
   };
 
@@ -126,7 +122,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
 
     // remove from include list if it's there
     const includeFiltersList = releaseTagsCheckList.filter(
-      (item: string | undefined) => item !== value
+      (item) => item !== value
     );
 
     setFreshReleasesFilters({
@@ -137,7 +133,7 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
 
   const removeExcludeTag = (tag: string) => {
     const filtersList = releaseTagsExcludeCheckList.filter(
-      (item: string | undefined) => item !== tag
+      (item) => item !== tag
     );
     setFreshReleasesFilters({ releaseTagsExcludeCheckList: filtersList });
   };
@@ -160,7 +156,13 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
         )
       : Object.values(filterRangeOptions);
 
-  // Reset filters when range changes
+  // Reset filters when range changes.
+  // Intentionally omitting coverartOnly, checkedList, includeVariousArtists,
+  // and setFreshReleasesFilters from the dependency array: this effect should
+  // only re-run when releaseTags/releaseTypes change (e.g. on page type
+  // change), not when the filter values themselves change - since this
+  // effect's own job is to reset those same values, including them as deps
+  // would make it re-fire every time it runs.
   React.useEffect(() => {
     if (
       coverartOnly === true ||
@@ -261,6 +263,13 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
 
         {filtersOpen && (
           <>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-secondary reset-filters-button"
+              onClick={clearSavedFilters}
+            >
+              Reset filters
+            </button>
             <div>
               <label id="range" htmlFor="style">
                 Range:{" "}
@@ -334,17 +343,15 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
                 </select>
 
                 <div className="release-tags">
-                  {releaseTagsCheckList?.map(
-                    (tag: string | undefined, index: number) => (
-                      <div id={`include-tag-item-${index}`} className="tags">
-                        <span className="release-tag-name">{tag}</span>
-                        <FontAwesomeIcon
-                          icon={faCircleXmark}
-                          onClick={() => removeFilterTag(tag!)}
-                        />
-                      </div>
-                    )
-                  )}
+                  {releaseTagsCheckList?.map((tag, index) => (
+                    <div id={`include-tag-item-${index}`} className="tags">
+                      <span className="release-tag-name">{tag}</span>
+                      <FontAwesomeIcon
+                        icon={faCircleXmark}
+                        onClick={() => removeFilterTag(tag!)}
+                      />
+                    </div>
+                  ))}
                 </div>
 
                 <label id="tags" htmlFor="exclude-tags">
@@ -371,17 +378,15 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
                 </select>
 
                 <div className="release-tags">
-                  {releaseTagsExcludeCheckList?.map(
-                    (tag: string | undefined, index: number) => (
-                      <div id={`exclude-tag-item-${index}`} className="tags">
-                        <span className="release-tag-name">{tag}</span>
-                        <FontAwesomeIcon
-                          icon={faCircleXmark}
-                          onClick={() => removeExcludeTag(tag!)}
-                        />
-                      </div>
-                    )
-                  )}
+                  {releaseTagsExcludeCheckList?.map((tag, index) => (
+                    <div id={`exclude-tag-item-${index}`} className="tags">
+                      <span className="release-tag-name">{tag}</span>
+                      <FontAwesomeIcon
+                        icon={faCircleXmark}
+                        onClick={() => removeExcludeTag(tag!)}
+                      />
+                    </div>
+                  ))}
                 </div>
               </>
             )}

--- a/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
+++ b/frontend/js/src/explore/fresh-releases/components/ReleaseFilters.tsx
@@ -11,6 +11,7 @@ import type {
   filterRangeOption,
 } from "../FreshReleases";
 import { PAGE_TYPE_SITEWIDE, filterRangeOptions } from "../FreshReleases";
+import useFreshReleasesFilterPersistence from "../hooks/useFreshReleasesFilterPersistence";
 
 const VARIOUS_ARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
@@ -53,21 +54,20 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
     pageType,
   } = props;
 
-  const [checkedList, setCheckedList] = React.useState<
-    Array<string | undefined>
-  >([]);
-  const [releaseTagsCheckList, setReleaseTagsCheckList] = React.useState<
-    Array<string | undefined>
-  >([]);
-  const [includeVariousArtists, setIncludeVariousArtists] = React.useState<
-    boolean
-  >(false);
+  const {
+    freshReleasesFilters,
+    setFreshReleasesFilters,
+    clearSavedFilters,
+  } = useFreshReleasesFilterPersistence(pageType);
 
-  const [
+  const {
+    checkedList,
+    releaseTagsCheckList,
     releaseTagsExcludeCheckList,
-    setReleaseTagsExcludeCheckList,
-  ] = React.useState<Array<string | undefined>>([]);
-  const [coverartOnly, setCoverartOnly] = React.useState<boolean>(false);
+    includeVariousArtists,
+    coverartOnly,
+  } = freshReleasesFilters;
+
   const [filtersOpen, setFiltersOpen] = React.useState<boolean>(true);
   const [displayOpen, setDisplayOpen] = React.useState<boolean>(true);
 
@@ -85,10 +85,12 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
     const isChecked = event.target.checked;
 
     if (isChecked) {
-      setCheckedList([...checkedList, value]);
+      setFreshReleasesFilters({ checkedList: [...checkedList, value] });
     } else {
-      const filtersList = checkedList.filter((item) => item !== value);
-      setCheckedList(filtersList);
+      const filtersList = checkedList.filter(
+        (item: string | undefined) => item !== value
+      );
+      setFreshReleasesFilters({ checkedList: filtersList });
     }
   };
 
@@ -97,18 +99,23 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
   ) => {
     event.preventDefault();
     const { value } = event.target;
-    setReleaseTagsCheckList([...releaseTagsCheckList, value]);
 
     // remove from exclude list if it's there
-    const filtersList = releaseTagsExcludeCheckList.filter(
-      (item) => item !== value
+    const excludeFiltersList = releaseTagsExcludeCheckList.filter(
+      (item: string | undefined) => item !== value
     );
-    setReleaseTagsExcludeCheckList(filtersList);
+
+    setFreshReleasesFilters({
+      releaseTagsCheckList: [...releaseTagsCheckList, value],
+      releaseTagsExcludeCheckList: excludeFiltersList,
+    });
   };
 
   const removeFilterTag = (tag: string) => {
-    const filtersList = releaseTagsCheckList.filter((item) => item !== tag);
-    setReleaseTagsCheckList(filtersList);
+    const filtersList = releaseTagsCheckList.filter(
+      (item: string | undefined) => item !== tag
+    );
+    setFreshReleasesFilters({ releaseTagsCheckList: filtersList });
   };
 
   const handleExcludeTagChange = (
@@ -116,18 +123,23 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
   ) => {
     event.preventDefault();
     const { value } = event.target;
-    setReleaseTagsExcludeCheckList([...releaseTagsExcludeCheckList, value]);
 
     // remove from include list if it's there
-    const filtersList = releaseTagsCheckList.filter((item) => item !== value);
-    setReleaseTagsCheckList(filtersList);
+    const includeFiltersList = releaseTagsCheckList.filter(
+      (item: string | undefined) => item !== value
+    );
+
+    setFreshReleasesFilters({
+      releaseTagsExcludeCheckList: [...releaseTagsExcludeCheckList, value],
+      releaseTagsCheckList: includeFiltersList,
+    });
   };
 
   const removeExcludeTag = (tag: string) => {
     const filtersList = releaseTagsExcludeCheckList.filter(
-      (item) => item !== tag
+      (item: string | undefined) => item !== tag
     );
-    setReleaseTagsExcludeCheckList(filtersList);
+    setFreshReleasesFilters({ releaseTagsExcludeCheckList: filtersList });
   };
 
   const handleRangeDropdown = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -150,15 +162,18 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
 
   // Reset filters when range changes
   React.useEffect(() => {
-    if (coverartOnly === true) {
-      setCoverartOnly(false);
+    if (
+      coverartOnly === true ||
+      (checkedList?.length ?? 0) > 0 ||
+      includeVariousArtists === true
+    ) {
+      setFreshReleasesFilters({
+        coverartOnly: false,
+        checkedList: [],
+        includeVariousArtists: false,
+      });
     }
-    if (checkedList?.length > 0) {
-      setCheckedList([]);
-    }
-    if (includeVariousArtists === true) {
-      setIncludeVariousArtists(false);
-    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [releaseTags, releaseTypes]);
 
   React.useEffect(() => {
@@ -319,15 +334,17 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
                 </select>
 
                 <div className="release-tags">
-                  {releaseTagsCheckList?.map((tag, index) => (
-                    <div id={`include-tag-item-${index}`} className="tags">
-                      <span className="release-tag-name">{tag}</span>
-                      <FontAwesomeIcon
-                        icon={faCircleXmark}
-                        onClick={() => removeFilterTag(tag!)}
-                      />
-                    </div>
-                  ))}
+                  {releaseTagsCheckList?.map(
+                    (tag: string | undefined, index: number) => (
+                      <div id={`include-tag-item-${index}`} className="tags">
+                        <span className="release-tag-name">{tag}</span>
+                        <FontAwesomeIcon
+                          icon={faCircleXmark}
+                          onClick={() => removeFilterTag(tag!)}
+                        />
+                      </div>
+                    )
+                  )}
                 </div>
 
                 <label id="tags" htmlFor="exclude-tags">
@@ -354,15 +371,17 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
                 </select>
 
                 <div className="release-tags">
-                  {releaseTagsExcludeCheckList?.map((tag, index) => (
-                    <div id={`exclude-tag-item-${index}`} className="tags">
-                      <span className="release-tag-name">{tag}</span>
-                      <FontAwesomeIcon
-                        icon={faCircleXmark}
-                        onClick={() => removeExcludeTag(tag!)}
-                      />
-                    </div>
-                  ))}
+                  {releaseTagsExcludeCheckList?.map(
+                    (tag: string | undefined, index: number) => (
+                      <div id={`exclude-tag-item-${index}`} className="tags">
+                        <span className="release-tag-name">{tag}</span>
+                        <FontAwesomeIcon
+                          icon={faCircleXmark}
+                          onClick={() => removeExcludeTag(tag!)}
+                        />
+                      </div>
+                    )
+                  )}
                 </div>
               </>
             )}
@@ -397,7 +416,9 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
               id="coverart-only"
               value="coverart-only"
               checked={coverartOnly}
-              onChange={(e) => setCoverartOnly(!coverartOnly)}
+              onChange={(e) =>
+                setFreshReleasesFilters({ coverartOnly: !coverartOnly })
+              }
               switchLabel="Only Releases with artwork"
             />
 
@@ -406,7 +427,11 @@ export default function ReleaseFilters(props: ReleaseFiltersProps) {
               key="include-various-artists-switch"
               value="various-artists"
               checked={includeVariousArtists}
-              onChange={(e) => setIncludeVariousArtists(!includeVariousArtists)}
+              onChange={(e) =>
+                setFreshReleasesFilters({
+                  includeVariousArtists: !includeVariousArtists,
+                })
+              }
               switchLabel="Releases by Various Artists"
             />
 

--- a/frontend/js/src/explore/fresh-releases/hooks/useFreshReleasesFilterPersistence.ts
+++ b/frontend/js/src/explore/fresh-releases/hooks/useFreshReleasesFilterPersistence.ts
@@ -1,0 +1,69 @@
+import localforage from "localforage";
+import * as React from "react";
+
+const filterStore = localforage.createInstance({
+  name: "listenbrainz",
+  storeName: "fresh-releases-filters",
+});
+
+export type FreshReleasesFilters = {
+  checkedList: Array<string | undefined>;
+  releaseTagsCheckList: Array<string | undefined>;
+  releaseTagsExcludeCheckList: Array<string | undefined>;
+  includeVariousArtists: boolean;
+  coverartOnly: boolean;
+};
+
+const DEFAULT_FILTERS: FreshReleasesFilters = {
+  checkedList: [],
+  releaseTagsCheckList: [],
+  releaseTagsExcludeCheckList: [],
+  includeVariousArtists: false,
+  coverartOnly: false,
+};
+
+const getStorageKey = (pageType: string): string =>
+  `release-filters-${pageType}`;
+
+export default function useFreshReleasesFilterPersistence(pageType: string) {
+  const [freshReleasesFilters, setFreshReleasesFiltersState] = React.useState<
+    FreshReleasesFilters
+  >(DEFAULT_FILTERS);
+
+  React.useEffect(() => {
+    let isMounted = true;
+    const storageKey = getStorageKey(pageType);
+
+    filterStore.getItem<FreshReleasesFilters>(storageKey).then((stored) => {
+      if (isMounted && stored) {
+        setFreshReleasesFiltersState(stored);
+      } else if (isMounted) {
+        setFreshReleasesFiltersState(DEFAULT_FILTERS);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [pageType]);
+
+  const setFreshReleasesFilters = React.useCallback(
+    (newFilters: Partial<FreshReleasesFilters>) => {
+      setFreshReleasesFiltersState((prevFilters: FreshReleasesFilters) => {
+        const updatedFilters = { ...prevFilters, ...newFilters };
+        const storageKey = getStorageKey(pageType);
+        filterStore.setItem(storageKey, updatedFilters);
+        return updatedFilters;
+      });
+    },
+    [pageType]
+  );
+
+  const clearSavedFilters = React.useCallback(() => {
+    const storageKey = getStorageKey(pageType);
+    filterStore.removeItem(storageKey);
+    setFreshReleasesFiltersState(DEFAULT_FILTERS);
+  }, [pageType]);
+
+  return { freshReleasesFilters, setFreshReleasesFilters, clearSavedFilters };
+}

--- a/frontend/js/src/explore/fresh-releases/hooks/useFreshReleasesFilterPersistence.ts
+++ b/frontend/js/src/explore/fresh-releases/hooks/useFreshReleasesFilterPersistence.ts
@@ -30,6 +30,7 @@ export default function useFreshReleasesFilterPersistence(pageType: string) {
     FreshReleasesFilters
   >(DEFAULT_FILTERS);
 
+  // Load persisted filters for this pageType on mount / when pageType changes
   React.useEffect(() => {
     let isMounted = true;
     const storageKey = getStorageKey(pageType);
@@ -47,16 +48,23 @@ export default function useFreshReleasesFilterPersistence(pageType: string) {
     };
   }, [pageType]);
 
+  // Persist filters whenever they change. Kept separate from the state
+  // updater below so that the updater stays a pure function (calling the
+  // async filterStore.setItem() inside a setState updater is an anti-pattern,
+  // since updaters can run more than once, e.g. under React StrictMode).
+  React.useEffect(() => {
+    const storageKey = getStorageKey(pageType);
+    filterStore.setItem(storageKey, freshReleasesFilters);
+  }, [pageType, freshReleasesFilters]);
+
   const setFreshReleasesFilters = React.useCallback(
     (newFilters: Partial<FreshReleasesFilters>) => {
-      setFreshReleasesFiltersState((prevFilters: FreshReleasesFilters) => {
-        const updatedFilters = { ...prevFilters, ...newFilters };
-        const storageKey = getStorageKey(pageType);
-        filterStore.setItem(storageKey, updatedFilters);
-        return updatedFilters;
-      });
+      setFreshReleasesFiltersState((prevFilters: FreshReleasesFilters) => ({
+        ...prevFilters,
+        ...newFilters,
+      }));
     },
-    [pageType]
+    []
   );
 
   const clearSavedFilters = React.useCallback(() => {


### PR DESCRIPTION
## Problem
Filters in the Fresh Releases explore section (release types, tags, various artists, cover-art-only) reset on every page load/reload, forcing users to re-apply them every time.

## Solution
Added a `useFreshReleasesFilterPersistence` hook that persists filter state using `localForage` (matching the existing pattern used in `listenStorage.ts`). Filters are stored separately per `pageType` (e.g. `release-filters-user` vs `release-filters-sitewide`), so switching between "For You" and sitewide releases no longer resets or conflicts with each other's saved filters.

This follows the approach discussed by @MonkeyDo in the previous attempt at this ticket (#3281):
- Single `freshReleasesFilters` object exposed by the hook, with a `setFreshReleasesFilters` function that accepts a partial update
- A separate storage key per `pageType` to fix the reset-on-toggle bug
- Uses `localForage`, consistent with existing storage utilities in the codebase

## Testing
Verified with `npx tsc --noEmit` (no errors) and `npx eslint` (no errors, only a pre-existing unrelated warning in `utils.tsx`). Was not able to run the full local dev environment (Docker + OAuth registration) for this session, so manual browser testing is still pending — flagging this openly for review.