### PR TITLE
feat: Add cache headers for public API endpoints

### DIFF
--- a/listenbrainz/webserver/__init__.py
+++ b/listenbrainz/webserver/__init__.py
@@ -271,9 +271,11 @@ def create_app(
                 response.cache_control.max_age = hashed_assets_max_age
             elif request.path.startswith('/static/img'):
                 response.cache_control.max_age = image_assets_max_age
-        else:
+        elif not response.cache_control.public:
             response.cache_control.private = True
             response.cache_control.public = False
+            if request.method in ("POST", "PUT", "DELETE", "PATCH"):
+                response.cache_control.no_store = True
         return response
 
     # Template utilities

--- a/listenbrainz/webserver/decorators.py
+++ b/listenbrainz/webserver/decorators.py
@@ -5,6 +5,29 @@ from flask import request, current_app, make_response, redirect, url_for
 from listenbrainz.webserver import timescale_connection
 
 
+def cache_public(s_maxage):
+    """Mark a public API GET as cacheable by shared caches for ``s_maxage`` seconds.
+
+    Sets ``Cache-Control: public, max-age=0, s-maxage=<s_maxage>`` on 200s.
+    ``add_cache_header`` leaves that in place and only defaults other
+    responses to private. Place below ``@crossdomain`` and ``@ratelimit``
+    so OPTIONS/429s never reach this wrapper.
+    """
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            resp = make_response(f(*args, **kwargs))
+            if resp.status_code == 200:
+                resp.cache_control.private = False
+                resp.cache_control.no_store = False
+                resp.cache_control.public = True
+                resp.cache_control.max_age = 0
+                resp.cache_control.s_maxage = s_maxage
+            return resp
+        return wrapper
+    return decorator
+
+
 def crossdomain(f):
     """ Decorator to add CORS headers to flask endpoints.
 

--- a/listenbrainz/webserver/views/entity_pages.py
+++ b/listenbrainz/webserver/views/entity_pages.py
@@ -8,7 +8,7 @@ from listenbrainz.db import popularity, similarity
 from listenbrainz.db.stats import get_entity_listener
 from listenbrainz.db.recording import load_recordings_from_mbids_with_redirects, load_release_groups_for_recordings
 from listenbrainz.webserver import db_conn, ts_conn
-from listenbrainz.webserver.decorators import web_listenstore_needed
+from listenbrainz.webserver.decorators import cache_public, web_listenstore_needed
 from listenbrainz.webserver.utils import number_readable
 from listenbrainz.db.metadata import get_metadata_for_artist
 from listenbrainz.webserver.views.api_tools import is_valid_uuid
@@ -93,6 +93,7 @@ def release_page(path):
 
 @release_bp.post("/<release_mbid>/")
 @web_listenstore_needed
+@cache_public(s_maxage=120)
 def release_redirect(release_mbid):
     if not is_valid_uuid(release_mbid):
         return jsonify({"error": "Provided release mbid is invalid: %s" % release_mbid}), 400
@@ -146,6 +147,7 @@ def artist_page(artist_mbid: str):
 
 @artist_bp.post("/<artist_mbid>/")
 @web_listenstore_needed
+@cache_public(s_maxage=120)
 def artist_entity(artist_mbid: str):
     """ Show a artist page with all their relevant information """
     # VA artist mbid
@@ -283,6 +285,7 @@ def album_page(release_group_mbid: str):
 
 @album_bp.post("/<release_group_mbid>/")
 @web_listenstore_needed
+@cache_public(s_maxage=120)
 def album_entity(release_group_mbid: str):
     """ Show an album page with all their relevant information """
 
@@ -377,6 +380,7 @@ def recording_page(recording_mbid: str):
 
 @track_bp.post("/<recording_mbid>/")
 @web_listenstore_needed
+@cache_public(s_maxage=120)
 def recording_entity(recording_mbid: str):
     """ Show a recording page with all their relevant information """
 

--- a/listenbrainz/webserver/views/explore_api.py
+++ b/listenbrainz/webserver/views/explore_api.py
@@ -6,7 +6,7 @@ from brainzutils.ratelimit import ratelimit
 from brainzutils import cache
 import listenbrainz.db.fresh_releases
 from listenbrainz.webserver import db_conn, ts_conn
-from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.decorators import cache_public, crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError, APIUnauthorized
 from listenbrainz.webserver.views.api_tools import _parse_int_arg, _parse_bool_arg, ensure_user_token_for_expensive_endpoint
 from listenbrainz.db.color import get_releases_for_color
@@ -28,6 +28,7 @@ explore_api_bp = Blueprint('explore_api_v1', __name__)
 @explore_api_bp.get("/fresh-releases/")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_fresh_releases():
     """
     This endpoint fetches upcoming and recently released (fresh) releases and returns a list of:
@@ -101,6 +102,7 @@ def get_fresh_releases():
 @explore_api_bp.get("/color/<color>")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def huesound(color):
     """
     Fetch a list of releases that have cover art that has a predominant

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -13,7 +13,7 @@ from listenbrainz.labs_api.labs.api.mbid_mapping import MBIDMappingQuery, MBIDMa
 from listenbrainz.mbid_mapping_writer.mbid_mapper import MBIDMapper
 from listenbrainz.webserver import ts_conn
 from listenbrainz.webserver.listens_cache import invalidate_user_listen_caches
-from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.decorators import cache_public, crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.utils import parse_boolean_arg
 from listenbrainz.webserver.views.api_tools import is_valid_uuid, validate_auth_header, MAX_ITEMS_PER_GET
@@ -87,6 +87,7 @@ def fetch_release_group_metadata(release_group_mbids, incs):
 @metadata_bp.get("/recording/")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=120)
 def metadata_recording():
     """
     This endpoint takes in a list of recording_mbids and returns an array of dicts that contain
@@ -181,6 +182,7 @@ def metadata_recording_post():
 @metadata_bp.get("/release_group/")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=120)
 def metadata_release_group():
     """
     This endpoint takes in a list of release_group_mbids and returns an array of dicts that contain
@@ -240,6 +242,7 @@ def process_results(match, metadata, incs):
 @metadata_bp.get("/lookup/")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=120)
 def get_mbid_mapping():
     """
     This endpoint looks up mbid metadata for the given artist, recording and optionally a release name.
@@ -541,6 +544,7 @@ def get_manual_mapping():
 @metadata_bp.get("/artist/")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=120)
 def metadata_artist():
     """
     This endpoint takes in a list of artist_mbids and returns an array of dicts that contain

--- a/listenbrainz/webserver/views/popularity_api.py
+++ b/listenbrainz/webserver/views/popularity_api.py
@@ -3,7 +3,7 @@ from flask import Blueprint, request, current_app, jsonify
 
 from listenbrainz.db import popularity
 from listenbrainz.webserver import ts_conn, db_conn
-from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.decorators import cache_public, crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
 from listenbrainz.webserver.views.api_tools import is_valid_uuid, MAX_ITEMS_PER_GET, ensure_user_token_for_expensive_endpoint
 
@@ -13,6 +13,7 @@ popularity_api_bp = Blueprint('popularity_api_v1', __name__)
 @popularity_api_bp.get("/top-recordings-for-artist/<artist_mbid>")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=600)
 def top_recordings_for_artist(artist_mbid):
     """ Get the top recordings by listen count for a given artist. The response is of the following format:
 
@@ -60,6 +61,7 @@ def top_recordings_for_artist(artist_mbid):
 @popularity_api_bp.get("/top-release-groups-for-artist/<artist_mbid>")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=600)
 def top_release_groups_for_artist(artist_mbid):
     """ Get the top release groups by listen count for a given artist. The response is of the following format:
 

--- a/listenbrainz/webserver/views/stats_api.py
+++ b/listenbrainz/webserver/views/stats_api.py
@@ -19,7 +19,7 @@ from data.model.user_artist_evolution_activity import ArtistEvolutionActivityRec
 from listenbrainz.db import year_in_music as db_year_in_music
 from listenbrainz.db.year_in_music import LAST_FM_FOUNDING_YEAR, MAX_YEAR_IN_MUSIC_YEAR
 from listenbrainz.webserver import db_conn, ts_conn
-from listenbrainz.webserver.decorators import crossdomain
+from listenbrainz.webserver.decorators import cache_public, crossdomain
 from listenbrainz.webserver.errors import (APIBadRequest,
                                            APINoContent, APINotFound)
 from listenbrainz.webserver.models import ArtistActivityArtistEntry, ArtistActivityReleaseGroupData
@@ -926,6 +926,7 @@ def get_artist_map(user_name: str):
 @stats_api_bp.get("/artist/<artist_mbid>/listeners")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_artist_listeners(artist_mbid):
     """ Get top listeners for artist ``artist_mbid``. This includes the total listen count for the entity
     and top N listeners with their individual listen count for that artist in a given time range. A sample
@@ -987,6 +988,7 @@ def get_artist_listeners(artist_mbid):
 @stats_api_bp.get("/release-group/<release_group_mbid>/listeners")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_release_group_listeners(release_group_mbid):
     """ Get top listeners for release group ``release_group_mbid``. This includes the total listen count
     for the entity and top N listeners with their individual listen count for that release group in a
@@ -1093,6 +1095,7 @@ def _get_entity_listeners(entity, mbid):
 @stats_api_bp.get("/sitewide/artists")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_artist():
     """
     Get sitewide top artists.
@@ -1151,6 +1154,7 @@ def get_sitewide_artist():
 @stats_api_bp.get("/sitewide/releases")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_release():
     """
     Get sitewide top releases.
@@ -1219,6 +1223,7 @@ def get_sitewide_release():
 @stats_api_bp.get("/sitewide/release-groups")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_release_group():
     """
     Get sitewide top release groups.
@@ -1289,6 +1294,7 @@ def get_sitewide_release_group():
 @stats_api_bp.get("/sitewide/recordings")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_recording():
     """
     Get sitewide top recordings.
@@ -1389,6 +1395,7 @@ def _get_sitewide_stats(entity: str, count_key: str, entire_range: bool = False)
 @stats_api_bp.get("/sitewide/listening-activity")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_listening_activity():
     """
     Get the listening activity for entire site. The listening activity shows the number of listens
@@ -1462,6 +1469,7 @@ def get_sitewide_listening_activity():
 @stats_api_bp.get("/sitewide/artist-activity")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_artist_activity():
     """
     Get the sitewide artist activity. The artist activity shows the total number of listens
@@ -1561,6 +1569,7 @@ def get_sitewide_artist_activity():
 @stats_api_bp.get("/sitewide/era-activity")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_era_activity():
     """
     Get sitewide release-year activity. Each entry represents the number of listens across all users
@@ -1621,6 +1630,7 @@ def get_sitewide_era_activity():
 @stats_api_bp.get("/sitewide/artist-evolution-activity")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_artist_evolution_activity():
     """
     Get the sitewide artist evolution activity. Over the selected time range, this returns raw rows
@@ -1686,6 +1696,7 @@ def get_sitewide_artist_evolution_activity():
 @stats_api_bp.get("/sitewide/artist-map")
 @crossdomain
 @ratelimit()
+@cache_public(s_maxage=300)
 def get_sitewide_artist_map():
     """
     Get the sitewide artist map. The artist map shows the number of artists listened to by users


### PR DESCRIPTION
# Problem

## What is the issue?
ListenBrainz sets `Cache-Control: private` on **all** non-static responses (`webserver/__init__.py:283-285`), preventing any downstream or CDN caching, even for public, non-personal data like sitewide stats and popularity rankings. During bot scraping incidents, every request hits the backend directly.

## Why does it happen?
The `add_cache_header` after_request hook has a blanket `else` branch that marks everything as `private`. This was a safe default, but it also blocks shared caches from absorbing burst/scraper traffic on endpoints that return identical data for all users.

# Solution

Add a `@cache_public(s_maxage=N)` decorator in `listenbrainz/webserver/decorators.py` that views can opt into. It sets `Cache-Control: public, max-age=0, s-maxage=N` on 200 responses, allowing shared caches (nginx, CDN) to serve repeated requests while browsers always revalidate.

The `add_cache_header` hook now checks `response.cache_control.public` before defaulting to `private`, so decorated views keep their headers. Mutating methods (POST/PUT/DELETE/PATCH) get `no-store`.

### Endpoints opted in

| Group | Endpoints | `s-maxage` |
|---|---|---|
| Stats, sitewide | `/1/stats/sitewide/*` (9 endpoints) | 300 (5 min) |
| Stats, entity | `/1/stats/artist/<mbid>/listeners`, `/1/stats/release-group/<mbid>/listeners` | 300 |
| Popularity | `/1/popularity/top-recordings-for-artist/<mbid>`, `/1/popularity/top-release-groups-for-artist/<mbid>` | 600 (10 min) |
| Metadata | `/1/metadata/recording/`, `/1/metadata/release_group/`, `/1/metadata/artist/`, `/1/metadata/lookup/` (GET only) | 120 (2 min) |
| Explore | `/1/explore/fresh-releases/`, `/1/explore/color/<color>` | 300 |
| Entity pages | POST `/artist/<mbid>/`, `/album/<mbid>/`, `/release/<mbid>/`, `/track/<mbid>/` | 120 (2 min) |

Entity page POST endpoints are called by the SPA to fetch props (metadata, popularity, similar artists, etc.). They return the same public data for all users. Note that POST caching requires CDN-side configuration to be effective.

All per-user endpoints, authenticated endpoints, and website HTML routes remain `private`.

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR