### PR TITLE
fix: Handle Typesense errors in recording search endpoint

### DIFF
--- a/listenbrainz/labs_api/labs/api/recording_search.py
+++ b/listenbrainz/labs_api/labs/api/recording_search.py
@@ -69,7 +69,10 @@ class RecordingSearchQuery(Query):
             'num_typos': NUM_TYPOS
         }
 
-        hits = self.client.collections[COLLECTION_NAME_WITHOUT_RELEASE].documents.search(search_parameters)
+        try:
+            hits = self.client.collections[COLLECTION_NAME_WITHOUT_RELEASE].documents.search(search_parameters)
+        except typesense.exceptions.TypesenseClientError:
+            return []
 
         output = []
         for hit in hits['hits']:


### PR DESCRIPTION
# Problem

The recording search endpoint (`RecordingSearchQuery.fetch()`) crashes when the Typesense search service is unreachable or times out. The unhandled `TypesenseClientError` propagates up to datasethoster, which then tries to serialize the raw exception object via `jsonify({"error": err})`, causing a secondary `TypeError` (the exception is not JSON-serializable).

This is one of the highest-volume Sentry errors:
- [LISTENBRAINZ-BP](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-BP/) (TypeError from serialization, ~41K total events)
- [LISTENBRAINZ-BN](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-BN/) (ReadTimeout from Typesense)

# Solution

Wrap the Typesense search call in a try/except for `TypesenseClientError` (the base class for all Typesense exceptions including `ReadTimeout`). On failure, return an empty list, which is a graceful degradation: the caller gets no search results rather than a 500 error.

This fixes both the primary timeout error and the secondary serialization crash.

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR