### PR TITLE
fix: Catch SQLAlchemy-wrapped OperationalError in timescale writer

### DIFF
--- a/listenbrainz/timescale_writer/timescale_writer.py
+++ b/listenbrainz/timescale_writer/timescale_writer.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from time import monotonic
 
 import psycopg2
+import sqlalchemy.exc
 import orjson
 from brainzutils import metrics
 from flask import current_app
@@ -70,7 +71,7 @@ class TimescaleWriterSubscriber(ConsumerProducerMixin):
 
             submit = [Listen.from_json(listen) for listen in msb_listens]
             self.insert_to_listenstore(submit)
-        except psycopg2.OperationalError:
+        except (psycopg2.OperationalError, sqlalchemy.exc.OperationalError):
             current_app.logger.error("Error processing listens due to database issues:", exc_info=True)
             time.sleep(self.ERROR_RETRY_DELAY)
             raise


### PR DESCRIPTION
# Problem

The timescale writer's listen processing loop catches `psycopg2.OperationalError` for database connection issues (disconnects, timeouts), but SQLAlchemy sometimes wraps these in its own `sqlalchemy.exc.OperationalError`. When that happens, the exception escapes the handler and the worker crashes instead of retrying gracefully.

Sentry issues:
- [LISTENBRAINZ-1DW](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-1DW/)
- [LISTENBRAINZ-1E0](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-1E0/)

# Solution

Add `sqlalchemy.exc.OperationalError` to the existing except clause alongside `psycopg2.OperationalError`. Both exception types now trigger the same retry-with-delay logic.

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR