### PR TITLE
fix: Validate recording MBIDs before database query

### DIFF
--- a/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
+++ b/listenbrainz/labs_api/labs/api/recording_from_recording_mbid.py
@@ -62,7 +62,15 @@ class RecordingFromRecordingMBIDQuery(Query):
         if not current_app.config["MB_DATABASE_URI"]:
             return []
 
-        mbids = [p.recording_mbid for p in params]
+        mbids = []
+        for p in params:
+            try:
+                UUID(p.recording_mbid)
+                mbids.append(p.recording_mbid)
+            except (ValueError, AttributeError):
+                pass
+        if not mbids:
+            return []
         with psycopg2.connect(current_app.config["MB_DATABASE_URI"]) as mb_conn, \
                 closing(timescale.engine.raw_connection()) as ts_conn, \
                 mb_conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as mb_curs, \


### PR DESCRIPTION
# Problem

`RecordingFromRecordingMBIDQuery.fetch()` passes user-supplied recording MBIDs directly into a database query without validating they are valid UUIDs. Invalid MBIDs (malformed strings, empty values, None) cause `psycopg2.DataError` or `InvalidTextRepresentation` errors at the database level.

Sentry issue:
- [LISTENBRAINZ-2VQ](https://metabrainz-foundation-inc.sentry.io/issues/LISTENBRAINZ-2VQ/)

# Solution

Validate each MBID with `UUID()` before including it in the query. Invalid MBIDs are silently skipped. If no valid MBIDs remain after filtering, return an empty list early (avoiding the database roundtrip entirely).

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR