### PR TITLE
Fix leading and trailing whitespace issue in Add Listen search modal

### DIFF
--- a/frontend/js/src/user/components/AddAlbumListens.tsx
+++ b/frontend/js/src/user/components/AddAlbumListens.tsx
@@ -119,9 +119,10 @@ const AddAlbumListens = forwardRef(function AddAlbumListens(
   const initialTextRef = useRef(initialText);
   React.useEffect(() => {
     // Trigger search manually if auto-switching from album to recording search
-    if (initialText && initialTextRef.current !== initialText) {
-      searchInputRef.current?.triggerSearch(initialText);
-      initialTextRef.current = initialText;
+    const cleanText = initialText ? initialText.trim() : "";
+    if (cleanText && initialTextRef.current !== cleanText) {
+      searchInputRef.current?.triggerSearch(cleanText);
+      initialTextRef.current = cleanText;
     }
     return () => {
       initialTextRef.current = undefined;

--- a/frontend/js/src/user/components/AddListenModal.tsx
+++ b/frontend/js/src/user/components/AddListenModal.tsx
@@ -234,6 +234,7 @@ export default NiceModal.create(() => {
 
   const switchMode = React.useCallback(
     (pastedURL: string) => {
+      const trimmedURL = pastedURL ? pastedURL.trim() : "";
       if (listenOption === SubmitListenType.track) {
         setListenOption(SubmitListenType.album);
       } else if (listenOption === SubmitListenType.album) {
@@ -242,7 +243,7 @@ export default NiceModal.create(() => {
       setTimeout(() => {
         // Trigger search in the inner (grandchild) search input component by modifying the textToSearch prop in child component
         // Give it some time to allow re-render and trigger search in the correct child component
-        setTextToSearch(pastedURL);
+        setTextToSearch(trimmedURL);
       }, 200);
       setTimeout(() => {
         // Reset text trigger

--- a/frontend/js/src/user/components/AddSingleListen.tsx
+++ b/frontend/js/src/user/components/AddSingleListen.tsx
@@ -46,9 +46,10 @@ const AddSingleListen = forwardRef(function AddSingleListen(
   const initialTextRef = useRef(initialText);
   React.useEffect(() => {
     // Trigger search manually if auto-switching from album to recording search
-    if (initialText && initialTextRef.current !== initialText) {
-      searchInputRef.current?.triggerSearch(initialText);
-      initialTextRef.current = initialText;
+    const cleanText = initialText ? initialText.trim() : "";
+    if (cleanText && initialTextRef.current !== cleanText) {
+      searchInputRef.current?.triggerSearch(cleanText);
+      initialTextRef.current = cleanText;
     }
     return () => {
       initialTextRef.current = undefined;


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz. We appreciate
    your time and interest in helping our project!
-->

# Problem

Leading and trailing whitespaces in user search inputs and pasted URLs caused unnecessary whitespace-only queries and improper search triggers when auto-switching modes in the "Add Listen" modal.

# Solution

- **`AddListenModal.tsx`**: Trimmed `pastedURL` inside `switchMode` before updating search text state to ignore extra spaces.
- **`AddAlbumListens.tsx`**: Added a `.trim()` check to `initialText` inside the `useEffect` hook to prevent unwanted triggers during mode auto-switching.
- **`AddSingleListen.tsx`**: Added a `.trim()` check to `initialText` inside the `useEffect` hook to ensure clean search terms are processed.

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [ ] I used AI tools for coding
* [ ] I understand all the changes made in this PR

# Action

No special post-merge action required.