### PR TITLE
LB-1991: Add standalone Spotify import breakdown tool

### DIFF
--- a/listenbrainz/tests/unit/test_spotify_import_breakdown.py
+++ b/listenbrainz/tests/unit/test_spotify_import_breakdown.py
@@ -1,0 +1,164 @@
+import io
+import json
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from listenbrainz.tools.spotify_import_breakdown import (
+    Breakdown, IMPORTED, INCOGNITO, INVALID, NEEDS_LOOKUP, NO_TRACK_LINK,
+    SHORT_PLAY, analyze_path, classify_entry, is_account_data_history,
+    matches_import_filter,
+)
+
+
+def _entry(**overrides):
+    """ A well-formed extended-streaming-history entry that would be imported. """
+    entry = {
+        "ts": "2023-05-04T10:23:45Z",
+        "ms_played": 215000,
+        "master_metadata_track_name": "Immigrant Song",
+        "master_metadata_album_artist_name": "Led Zeppelin",
+        "master_metadata_album_name": "Led Zeppelin III",
+        "spotify_track_uri": "spotify:track:78lgmZwycJ3nzsdgmPPGNx",
+        "reason_start": "clickrow",
+        "reason_end": "trackdone",
+        "skipped": False,
+        "incognito_mode": False,
+    }
+    entry.update(overrides)
+    return entry
+
+
+class ClassifyEntryTestCase(unittest.TestCase):
+    """ The classification must mirror SpotifyListensImporter's skip rules. """
+
+    def test_normal_play_is_imported(self):
+        self.assertEqual(classify_entry(_entry())[0], IMPORTED)
+
+    def test_incognito_is_skipped_even_when_played_fully(self):
+        self.assertEqual(classify_entry(_entry(incognito_mode=True))[0], INCOGNITO)
+
+    def test_short_play_with_skipped_flag(self):
+        category, detail = classify_entry(_entry(ms_played=5000, skipped=True))
+        self.assertEqual(category, SHORT_PLAY)
+        self.assertEqual(detail, "skipped flag")
+
+    def test_short_play_with_skip_reason(self):
+        category, detail = classify_entry(_entry(ms_played=5000, reason_end="fwdbtn"))
+        self.assertEqual(category, SHORT_PLAY)
+        self.assertEqual(detail, "reason_end=fwdbtn")
+
+    def test_short_play_with_null_reason_end_is_skipped(self):
+        # None is part of SKIP_REASONS in the importer
+        self.assertEqual(classify_entry(_entry(ms_played=5000, reason_end=None))[0], SHORT_PLAY)
+
+    def test_short_play_that_ended_normally_is_imported(self):
+        # under 30s but reason_end=trackdone and not skipped -> imported
+        self.assertEqual(classify_entry(_entry(ms_played=15000))[0], IMPORTED)
+
+    def test_long_play_with_skip_reason_is_imported(self):
+        # 30s or more is imported regardless of how it ended
+        self.assertEqual(classify_entry(_entry(ms_played=30000, reason_end="fwdbtn"))[0], IMPORTED)
+
+    def test_podcast_episode_has_no_track_link(self):
+        category, detail = classify_entry(_entry(
+            spotify_track_uri=None,
+            spotify_episode_uri="spotify:episode:4d0dcgoZbnWjcRj4H0nlWc",
+            master_metadata_track_name=None,
+            master_metadata_album_artist_name=None,
+        ))
+        self.assertEqual(category, NO_TRACK_LINK)
+        self.assertEqual(detail, "podcast episode")
+
+    def test_malformed_track_uri_has_no_track_link(self):
+        self.assertEqual(classify_entry(_entry(spotify_track_uri="garbage"))[0], NO_TRACK_LINK)
+
+    def test_missing_names_need_metadata_lookup(self):
+        entry = _entry(master_metadata_track_name=None, master_metadata_album_artist_name=None)
+        self.assertEqual(classify_entry(entry)[0], NEEDS_LOOKUP)
+
+    def test_missing_timestamp_is_invalid(self):
+        entry = _entry()
+        del entry["ts"]
+        self.assertEqual(classify_entry(entry)[0], INVALID)
+
+    def test_malformed_timestamp_is_invalid(self):
+        self.assertEqual(classify_entry(_entry(ts="04/05/2023"))[0], INVALID)
+
+    def test_incognito_wins_over_short_play(self):
+        # same precedence as the importer: incognito is checked first
+        self.assertEqual(classify_entry(_entry(incognito_mode=True, ms_played=5000, skipped=True))[0], INCOGNITO)
+
+
+class FileFilterTestCase(unittest.TestCase):
+    """ The file filter must mirror SpotifyListensImporter.filter_zip_file. """
+
+    def test_extended_history_files_match(self):
+        self.assertTrue(matches_import_filter("Spotify Extended Streaming History/Streaming_History_Audio_2023_1.json"))
+        self.assertTrue(matches_import_filter("endsong_0.json"))
+
+    def test_video_and_misc_files_do_not_match(self):
+        self.assertFalse(matches_import_filter("Streaming_History_Video_2023.json"))
+        self.assertFalse(matches_import_filter("ReadMeFirst_ExtendedStreamingHistory.pdf"))
+
+    def test_account_data_export_detection(self):
+        self.assertTrue(is_account_data_history("StreamingHistory_music_0.json"))
+        self.assertFalse(is_account_data_history("Streaming_History_Audio_2023_1.json"))
+
+
+class AnalyzeZipTestCase(unittest.TestCase):
+
+    def test_zip_breakdown(self):
+        audio_entries = [
+            _entry(),
+            _entry(ms_played=3000, skipped=True),
+            _entry(incognito_mode=True),
+            _entry(spotify_track_uri=None, spotify_episode_uri="spotify:episode:x",
+                   master_metadata_track_name=None, master_metadata_album_artist_name=None),
+        ]
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "my_spotify_data.zip"
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                zf.writestr("Spotify Extended Streaming History/Streaming_History_Audio_2023_1.json",
+                            json.dumps(audio_entries))
+                zf.writestr("Spotify Extended Streaming History/Streaming_History_Video_2023.json",
+                            json.dumps([_entry()]))
+
+            breakdown = Breakdown(max_examples=5)
+            analyze_path(zip_path, breakdown)
+
+        self.assertEqual(breakdown.total, 4)
+        self.assertEqual(breakdown.counts[IMPORTED], 1)
+        self.assertEqual(breakdown.counts[SHORT_PLAY], 1)
+        self.assertEqual(breakdown.counts[INCOGNITO], 1)
+        self.assertEqual(breakdown.counts[NO_TRACK_LINK], 1)
+        self.assertEqual(len(breakdown.files_scanned), 1)
+        # the video file is ignored, exactly like the importer ignores it
+        self.assertEqual(len(breakdown.files_ignored), 1)
+
+    def test_account_data_zip_produces_warning_not_entries(self):
+        with TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "my_data.zip"
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                zf.writestr("MyData/StreamingHistory_music_0.json",
+                            json.dumps([{"endTime": "2023-05-04 10:23", "msPlayed": 215000,
+                                         "artistName": "Led Zeppelin", "trackName": "Immigrant Song"}]))
+
+            breakdown = Breakdown(max_examples=5)
+            analyze_path(zip_path, breakdown)
+
+        self.assertEqual(breakdown.total, 0)
+        self.assertEqual(len(breakdown.account_data_files), 1)
+
+    def test_single_json_file(self):
+        with TemporaryDirectory() as tmp:
+            json_path = Path(tmp) / "Streaming_History_Audio_2024_2.json"
+            json_path.write_text(json.dumps([_entry(), _entry(ms_played=100, reason_end="backbtn")]))
+
+            breakdown = Breakdown(max_examples=5)
+            analyze_path(json_path, breakdown)
+
+        self.assertEqual(breakdown.total, 2)
+        self.assertEqual(breakdown.counts[IMPORTED], 1)
+        self.assertEqual(breakdown.counts[SHORT_PLAY], 1)

--- a/listenbrainz/tools/spotify_import_breakdown.py
+++ b/listenbrainz/tools/spotify_import_breakdown.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+""" Standalone tool to preview a Spotify Extended Streaming History import.
+
+    Given the zip file (or extracted folder) that Spotify provides for the
+    "Extended streaming history" privacy download, this prints a breakdown of
+    which entries ListenBrainz would import and which it would skip, and why.
+
+    It uses only the Python standard library so it can be downloaded and run
+    on its own, without installing ListenBrainz:
+
+        python3 spotify_import_breakdown.py my_spotify_data.zip
+        python3 spotify_import_breakdown.py extracted_folder/
+        python3 spotify_import_breakdown.py Streaming_History_Audio_2023_1.json --show-skipped 5
+
+    The classification rules mirror the actual importer in
+    listenbrainz/background/listens_importer/spotify.py -- keep the two in
+    sync when the import rules change.
+"""
+import argparse
+import json
+import sys
+import zipfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Keep in sync with listenbrainz/background/listens_importer/spotify.py
+SKIP_REASONS = [
+    None, "fwdbtn", "backbtn", "clickrow", "clickside", "endplay", "playbtn", "remote", "logout",
+    "popup", "trackerror", "unexpected-exit", "unexpected-exit-while-paused", "unknown"
+]
+
+# categories, in the order they are reported
+IMPORTED = "imported"
+NEEDS_LOOKUP = "needs_lookup"
+SHORT_PLAY = "short_play"
+INCOGNITO = "incognito"
+NO_TRACK_LINK = "no_track_link"
+INVALID = "invalid"
+
+CATEGORY_LABELS = {
+    IMPORTED: "Would be imported",
+    NEEDS_LOOKUP: "Imported only if Spotify metadata lookup succeeds (no track/artist name in file)",
+    SHORT_PLAY: "Skipped: played under 30 seconds and manually skipped or interrupted",
+    INCOGNITO: "Skipped: played in incognito/private session",
+    NO_TRACK_LINK: "Skipped: no track link (podcast episodes, videos, audiobooks)",
+    INVALID: "Skipped: entry could not be parsed",
+}
+
+
+def matches_import_filter(filename: str) -> bool:
+    """ Same file filter the ListenBrainz importer applies inside the zip. """
+    name = Path(filename).name.lower()
+    return name.endswith(".json") and ("audio" in name or "endsong" in name)
+
+
+def is_account_data_history(filename: str) -> bool:
+    """ Detect files from the *simplified* "Account data" export
+
+        (StreamingHistory_music_0.json etc). Those are a different, reduced
+        format that the ListenBrainz importer does not read at all -- a very
+        common source of "why did nothing import" confusion.
+    """
+    name = Path(filename).name.lower()
+    return name.endswith(".json") and name.startswith("streaminghistory")
+
+
+def classify_entry(item) -> tuple[str, str]:
+    """ Classify one streaming-history entry.
+
+        Returns (category, detail). The checks and their order mirror
+        SpotifyListensImporter (_skip_item, then parse_listen_batch).
+    """
+    if not isinstance(item, dict):
+        return INVALID, "entry is not an object"
+
+    try:
+        datetime.strptime(item["ts"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (KeyError, TypeError, ValueError):
+        return INVALID, "missing or malformed 'ts' timestamp"
+
+    if item.get("incognito_mode", False):
+        return INCOGNITO, ""
+
+    if (
+        item.get("ms_played", 0) < 30000 and
+        (
+            item.get("skipped", False) or
+            ("reason_end" in item and item["reason_end"] in SKIP_REASONS)
+        )
+    ):
+        reason = "skipped flag" if item.get("skipped", False) else f"reason_end={item.get('reason_end')}"
+        return SHORT_PLAY, reason
+
+    uri = item.get("spotify_track_uri")
+    if not isinstance(uri, str) or len(uri.split(":")) < 3:
+        if item.get("spotify_episode_uri"):
+            return NO_TRACK_LINK, "podcast episode"
+        return NO_TRACK_LINK, "no spotify_track_uri"
+
+    if not item.get("master_metadata_track_name") or not item.get("master_metadata_album_artist_name"):
+        return NEEDS_LOOKUP, ""
+
+    return IMPORTED, ""
+
+
+class Breakdown:
+    """ Accumulates per-category counts and example entries. """
+
+    def __init__(self, max_examples: int):
+        self.max_examples = max_examples
+        self.counts = Counter()
+        self.details = Counter()
+        self.examples = {}
+        self.files_scanned = []
+        self.files_ignored = []
+        self.account_data_files = []
+
+    def add_entry(self, item) -> None:
+        category, detail = classify_entry(item)
+        self.counts[category] += 1
+        if detail:
+            self.details[f"{category}: {detail}"] += 1
+        examples = self.examples.setdefault(category, [])
+        if category != IMPORTED and len(examples) < self.max_examples:
+            examples.append(_describe(item))
+
+    @property
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+
+def _describe(item) -> str:
+    if not isinstance(item, dict):
+        return repr(item)[:80]
+    name = item.get("master_metadata_track_name") or item.get("episode_name") or "<no name>"
+    artist = item.get("master_metadata_album_artist_name") or item.get("episode_show_name") or "<no artist>"
+    return f"{item.get('ts', '<no ts>')}  {artist} - {name} ({item.get('ms_played', '?')} ms)"
+
+
+def _analyze_stream(fileobj, breakdown: Breakdown) -> None:
+    try:
+        entries = json.load(fileobj)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        breakdown.counts[INVALID] += 1
+        breakdown.details[f"{INVALID}: file is not valid JSON"] += 1
+        return
+    if not isinstance(entries, list):
+        entries = [entries]
+    for item in entries:
+        breakdown.add_entry(item)
+
+
+def analyze_path(path: Path, breakdown: Breakdown) -> None:
+    """ Analyze a zip archive, a directory, or a single .json file. """
+    if path.is_dir():
+        for child in sorted(path.rglob("*.json")):
+            analyze_path(child, breakdown)
+        return
+
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as zf:
+            for name in zf.namelist():
+                if matches_import_filter(name):
+                    breakdown.files_scanned.append(name)
+                    with zf.open(name) as f:
+                        _analyze_stream(f, breakdown)
+                elif name.lower().endswith(".json"):
+                    breakdown.files_ignored.append(name)
+                    if is_account_data_history(name):
+                        breakdown.account_data_files.append(name)
+        return
+
+    # single file: analyze it even if the name would not match the zip filter,
+    # so users can inspect one file directly, but still surface the warning
+    if is_account_data_history(str(path)):
+        breakdown.account_data_files.append(str(path))
+        breakdown.files_ignored.append(str(path))
+        return
+    breakdown.files_scanned.append(str(path))
+    with open(path, encoding="utf-8") as f:
+        _analyze_stream(f, breakdown)
+
+
+def print_report(breakdown: Breakdown, show_skipped: int) -> None:
+    print(f"Files scanned: {len(breakdown.files_scanned)}")
+    for name in breakdown.files_scanned:
+        print(f"    {name}")
+    if breakdown.files_ignored:
+        print(f"Files ignored by the importer: {len(breakdown.files_ignored)}")
+        for name in breakdown.files_ignored:
+            print(f"    {name}")
+    if breakdown.account_data_files:
+        print()
+        print("WARNING: files like " + Path(breakdown.account_data_files[0]).name + " come from the")
+        print("simplified 'Account data' export, which ListenBrainz cannot import. Request the")
+        print("'Extended streaming history' from https://www.spotify.com/account/privacy/ instead.")
+
+    total = breakdown.total
+    print()
+    if total == 0:
+        print("No streaming history entries found.")
+        return
+
+    print(f"Total entries: {total}")
+    for category in (IMPORTED, NEEDS_LOOKUP, SHORT_PLAY, INCOGNITO, NO_TRACK_LINK, INVALID):
+        count = breakdown.counts.get(category, 0)
+        if count == 0:
+            continue
+        print(f"    {count:>8}  ({count / total:6.1%})  {CATEGORY_LABELS[category]}")
+
+    detail_lines = [f"    {count:>8}  {detail}" for detail, count in breakdown.details.most_common()]
+    if detail_lines:
+        print()
+        print("Skip reasons in detail:")
+        print("\n".join(detail_lines))
+
+    if show_skipped:
+        for category in (SHORT_PLAY, INCOGNITO, NO_TRACK_LINK, NEEDS_LOOKUP, INVALID):
+            examples = breakdown.examples.get(category)
+            if not examples:
+                continue
+            print()
+            print(f"Examples - {CATEGORY_LABELS[category]}:")
+            for example in examples[:show_skipped]:
+                print(f"    {example}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Preview which entries of a Spotify Extended Streaming History "
+                    "ListenBrainz would import, and why the rest would be skipped."
+    )
+    parser.add_argument("paths", nargs="+", type=Path,
+                        help="Spotify export zip, extracted folder, or individual "
+                             "Streaming_History_Audio_*.json files")
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="output the breakdown as JSON instead of text")
+    parser.add_argument("--show-skipped", type=int, default=0, metavar="N",
+                        help="also print up to N example entries per skip category")
+
+    args = parser.parse_args()
+    breakdown = Breakdown(max_examples=max(args.show_skipped, 5))
+
+    for path in args.paths:
+        if not path.exists():
+            print(f"error: {path} does not exist", file=sys.stderr)
+            return 1
+        analyze_path(path, breakdown)
+
+    if args.as_json:
+        print(json.dumps({
+            "total": breakdown.total,
+            "counts": dict(breakdown.counts),
+            "skip_details": dict(breakdown.details),
+            "files_scanned": breakdown.files_scanned,
+            "files_ignored": breakdown.files_ignored,
+            "account_data_files": breakdown.account_data_files,
+        }, indent=2))
+    else:
+        print_report(breakdown, args.show_skipped)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

When users upload their Spotify Extended Streaming History, we report how many listens were imported but not *why* the rest were skipped. The skips are legitimate (under-30s interrupted plays, incognito sessions, podcast episodes), but users have no way to see this for themselves.

Fixes [LB-1991](https://tickets.metabrainz.org/browse/LB-1991)

## Solution

Adds `listenbrainz/tools/spotify_import_breakdown.py` - a standalone, stdlib-only script users can run against their Spotify export (zip, extracted folder, or individual JSON files) to preview exactly what an import would do:

* Classifies every entry with the same rules as the real importer (`background/listens_importer/spotify.py`): would-import, short/interrupted play, incognito, no track link (podcasts/videos/audiobooks), needs-Spotify-lookup, invalid - with per-reason detail counts and optional `--show-skipped N` examples.
* Ignores the same files the importer ignores (video history), and detects the simplified "Account data" export (`StreamingHistory_music_*.json`) with a warning pointing users to the Extended Streaming History - a common source of confusion.
* `--json` flag for machine-readable output.
* Zero dependencies beyond the Python standard library, so the single file can be downloaded and run on its own - per the ticket's suggestion of a standalone tool rather than running this analysis on every import.

The module docstring notes it must be kept in sync with the importer's skip rules.

### Testing

* 19 unit tests covering every classification path, the file filter, and zip/folder/single-file analysis.
* A parity check: 378 combinations of `ms_played`/`skipped`/`reason_end`/`incognito_mode` fed to both the real `SpotifyListensImporter._skip_item` and this tool's classifier - 0 mismatches.
* Manual run on a 1000-entry sample export (screenshots below).

<img width="1917" height="1015" alt="Screenshot 2026-08-29 135622" src="https://github.com/user-attachments/assets/b211ae95-c027-4394-9862-8df3a480e2b7" />
<img width="1917" height="1020" alt="Screenshot 2026-08-29 135650" src="https://github.com/user-attachments/assets/e0157620-08dc-4ac5-834d-7bfe61a02844" />

- [x] I have run the code and manually tested the changes

## AI usage

- [x] I have used AI in this PR (add more details below)
- [x] I used AI tools for communication
- [x] I used AI tools for coding
- [x] I understand all the changes made in this PR

The code was written with an AI coding assistant (Claude Code) working under my direction. The AI analysed the existing zip importer's skip rules and mirrored them in the standalone tool, including a parity test against the real importer. I reviewed every change and ran the tests and the CLI myself to verify the output.

## Action

None on merge - the tool is standalone and changes no server behaviour. Happy to add a link to it from the import page or docs if you'd like (follow-up).
