### PR TITLE
feat: store user data exports in garage

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -335,8 +335,13 @@ REJECT_LISTENS_WITHOUT_USER_EMAIL = {{template "KEY_JSON" "reject_listens_withou
 # If set to True, do not allow new users without email to register and warn existing without email
 REJECT_NEW_USERS_WITHOUT_EMAIL = {{template "KEY_JSON" "reject_new_users_without_email"}}
 
-# base directory for user data exports
-USER_DATA_EXPORT_BASE_DIR = '''{{template "KEY" "user_data_export_base_dir"}}'''
+# Garage object storage, user data exports are stored here.
+GARAGE_ENDPOINT = "virtual-garage.service.consul:3900"
+GARAGE_ACCESS_KEY = '''{{template "KEY" "garage/access_key"}}'''
+GARAGE_SECRET_KEY = '''{{template "KEY" "garage/secret_key"}}'''
+GARAGE_SECURE = False
+GARAGE_REGION = "garage"
+GARAGE_USER_DATA_EXPORT_BUCKET = '''{{template "KEY" "garage/user_data_export_bucket"}}'''
 
 # Navidrome configuration
 # Set to a base64 encoded key for encryption/decryption of passwords.

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -24,6 +24,21 @@ services:
   rabbitmq:
     image: rabbitmq:3.8.16
 
+  garage:
+    build:
+      context: ./garage
+    environment:
+      GARAGE_ACCESS_KEY: GK1e5b4c3a2d0f9e8b7a6c5d40
+      GARAGE_SECRET_KEY: 0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0
+      GARAGE_BUCKETS: listenbrainz-user-data-exports
+    healthcheck:
+      # the S3 api port is open long before the layout is applied and the buckets exist,
+      # the entrypoint only writes this file once provisioning is complete
+      test: ["CMD", "test", "-f", "/tmp/garage-provisioned"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
   listenbrainz:
     build:
       context: ..
@@ -38,9 +53,14 @@ services:
       PYTHON_TESTS_RUNNING: 1
     user: "${LB_DOCKER_USER:-root}:${LB_DOCKER_GROUP:-root}"
     depends_on:
-      - redis
-      - lb_db
-      - rabbitmq
+      redis:
+        condition: service_started
+      lb_db:
+        condition: service_started
+      rabbitmq:
+        condition: service_started
+      garage:
+        condition: service_healthy
 
   timescale_writer:
     image: listenbrainz
@@ -57,11 +77,14 @@ services:
     image: listenbrainz
     command: python3 -m "listenbrainz.background.background_tasks"
     depends_on:
-      - redis
-      - lb_db
+      redis:
+        condition: service_started
+      lb_db:
+        condition: service_started
+      garage:
+        condition: service_healthy
     environment:
       PYTHON_TESTS_RUNNING: 1
-    restart: unless-stopped
     user: "${LB_DOCKER_USER:-root}:${LB_DOCKER_GROUP:-root}"
     volumes:
       - ..:/code/listenbrainz:z

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
   # The contents of /root, so that bash and ipython can store history
   web_home:
   couchdb:
+  garage:
 
 services:
 
@@ -44,6 +45,25 @@ services:
     ports:
       - "127.0.0.1:25672:15672"
 
+  garage:
+    build:
+      context: ./garage
+    environment:
+      GARAGE_ACCESS_KEY: GK1e5b4c3a2d0f9e8b7a6c5d40
+      GARAGE_SECRET_KEY: 0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0
+      GARAGE_BUCKETS: listenbrainz-user-data-exports
+    volumes:
+      - garage:/var/lib/garage:z
+    ports:
+      - "127.0.0.1:3900:3900"
+    healthcheck:
+      # the S3 api port is open long before the layout is applied and the buckets exist,
+      # the entrypoint only writes this file once provisioning is complete
+      test: ["CMD", "test", "-f", "/tmp/garage-provisioned"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
   web:
     build:
       context: ..
@@ -63,10 +83,16 @@ services:
       - "127.0.0.1:8100:80"
     user: "${LB_DOCKER_USER:-root}:${LB_DOCKER_GROUP:-root}"
     depends_on:
-      - redis
-      - lb_db
-      - rabbitmq
-      - couchdb
+      redis:
+        condition: service_started
+      lb_db:
+        condition: service_started
+      rabbitmq:
+        condition: service_started
+      couchdb:
+        condition: service_started
+      garage:
+        condition: service_healthy
 
   api_compat:
     image: web
@@ -101,9 +127,14 @@ services:
       - ..:/code/listenbrainz:z
     user: "${LB_DOCKER_USER:-root}:${LB_DOCKER_GROUP:-root}"
     depends_on:
-      - redis
-      - lb_db
-      - rabbitmq
+      redis:
+        condition: service_started
+      lb_db:
+        condition: service_started
+      rabbitmq:
+        condition: service_started
+      garage:
+        condition: service_healthy
 
   spotify_reader:
     image: web

--- a/docker/garage/Dockerfile
+++ b/docker/garage/Dockerfile
@@ -1,10 +1,10 @@
-ARG GARAGE_VERSION=v1.0.1
+ARG GARAGE_VERSION=v2.3.0
 
 FROM dxflrs/garage:${GARAGE_VERSION} AS upstream
 
 # The upstream image is built FROM scratch and has no shell, so the (statically
 # linked) binary is copied into an image that can run the provisioning script.
-FROM alpine:3.21
+FROM alpine:3.24
 
 COPY --from=upstream /garage /usr/local/bin/garage
 COPY garage.toml /etc/garage.toml

--- a/docker/garage/Dockerfile
+++ b/docker/garage/Dockerfile
@@ -1,0 +1,15 @@
+ARG GARAGE_VERSION=v1.0.1
+
+FROM dxflrs/garage:${GARAGE_VERSION} AS upstream
+
+# The upstream image is built FROM scratch and has no shell, so the (statically
+# linked) binary is copied into an image that can run the provisioning script.
+FROM alpine:3.21
+
+COPY --from=upstream /garage /usr/local/bin/garage
+COPY garage.toml /etc/garage.toml
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+EXPOSE 3900 3901 3903
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/garage/entrypoint.sh
+++ b/docker/garage/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Start a single node Garage cluster and provision the development access key and
+# buckets. Garage needs a layout to be assigned and applied before it accepts any
+# S3 request so this cannot be done from a plain `garage server` invocation.
+set -e
+
+# the healthcheck waits for this file, drop any copy left behind by a previous run of the
+# container so that a restart is only reported healthy once it has provisioned itself again
+rm -f /tmp/garage-provisioned
+
+garage server &
+server_pid=$!
+
+echo "Waiting for garage to start up..."
+until garage status > /dev/null 2>&1; do
+    if ! kill -0 "$server_pid" 2> /dev/null; then
+        echo "garage server exited during startup"
+        exit 1
+    fi
+    sleep 1
+done
+
+# the layout can only be assigned and applied once, the sentinel lives on the data volume
+# so that it survives a restart of the container
+if [ ! -f /var/lib/garage/meta/.provisioned ]; then
+    node_id=$(garage node id -q | cut -d@ -f1)
+    echo "Assigning layout to node $node_id"
+    garage layout assign -z dc1 -c 1G "$node_id"
+    garage layout apply --version 1
+
+    echo "Importing development access key"
+    garage key import --yes -n listenbrainz "$GARAGE_ACCESS_KEY" "$GARAGE_SECRET_KEY"
+    garage key allow --create-bucket "$GARAGE_ACCESS_KEY"
+
+    touch /var/lib/garage/meta/.provisioned
+fi
+
+# creating buckets is idempotent and runs on every start so that buckets added to
+# GARAGE_BUCKETS later are created on an already provisioned volume too
+for bucket in $GARAGE_BUCKETS; do
+    if garage bucket info "$bucket" > /dev/null 2>&1; then
+        echo "Bucket $bucket already exists"
+    else
+        echo "Creating bucket $bucket"
+        garage bucket create "$bucket"
+    fi
+    garage bucket allow --read --write --owner "$bucket" --key "$GARAGE_ACCESS_KEY"
+done
+
+# the S3 api port is open long before the layout is applied and the buckets exist, so the
+# healthcheck waits for this instead of the port
+touch /tmp/garage-provisioned
+
+echo "Garage is ready."
+wait "$server_pid"

--- a/docker/garage/garage.toml
+++ b/docker/garage/garage.toml
@@ -1,0 +1,19 @@
+# Single node Garage setup for local development and tests. Do not use in production.
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+
+replication_factor = 1
+
+rpc_bind_addr = "[::]:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "b8f1a1a4c8d94e4db0f8b1b0a0d8f5e2a7c3b9d1e4f60718293a4b5c6d7e8f90"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+root_domain = ".s3.garage.localhost"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "listenbrainz-dev-admin-token"

--- a/frontend/js/src/settings/export/ExportButtons.tsx
+++ b/frontend/js/src/settings/export/ExportButtons.tsx
@@ -250,7 +250,8 @@ export default function ExportButtons({ listens = true, feedback = false }) {
     exports.findIndex(
       (exp) =>
         exp.type === ExportType.allUserData &&
-        exp.status !== ExportStatus.complete
+        exp.status !== ExportStatus.complete &&
+        exp.status !== ExportStatus.failed
     ) !== -1;
 
   const createExport = React.useCallback(

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -7,11 +7,11 @@ import orjson
 from brainzutils.mail import send_mail
 from dateutil.relativedelta import relativedelta
 from flask import current_app, render_template
-from minio.deleteobjects import DeleteObject
 from sqlalchemy import text
 
 from listenbrainz.db import user as db_user
-from listenbrainz.garage import ensure_bucket, get_garage_client, get_user_data_export_bucket
+from listenbrainz.garage import delete_objects, ensure_bucket, get_garage_client, \
+    get_user_data_export_bucket, list_object_names
 from listenbrainz.webserver import timescale_connection
 
 BATCH_SIZE = 1000
@@ -326,7 +326,7 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
             client = get_garage_client()
             bucket = get_user_data_export_bucket()
             ensure_bucket(client, bucket)
-            client.fput_object(bucket, archive_name, archive_path, content_type="application/zip")
+            client.upload_file(archive_path, bucket, archive_name, ExtraArgs={"ContentType": "application/zip"})
 
         created = datetime.now()
         available_until = created + USER_DATA_EXPORT_AVAILABILITY
@@ -380,10 +380,10 @@ def cleanup_old_exports(db_conn):
 
     # Delete exports that are no longer required
     objects_to_delete = []
-    for obj in client.list_objects(bucket):
-        if obj.object_name not in files_to_keep:
-            current_app.logger.info("Removing export: %s", obj.object_name)
-            objects_to_delete.append(DeleteObject(obj.object_name))
+    for object_name in list_object_names(client, bucket):
+        if object_name not in files_to_keep:
+            current_app.logger.info("Removing export: %s", object_name)
+            objects_to_delete.append(object_name)
 
-    for error in client.remove_objects(bucket, objects_to_delete):
-        current_app.logger.error("Failed to remove export %s: %s", error.name, error.message)
+    for error in delete_objects(client, bucket, objects_to_delete):
+        current_app.logger.error("Failed to remove export %s: %s", error.get("Key"), error.get("Message"))

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -280,29 +280,28 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
         current_app.logger.error("No export with export_id: %s, skipping.", metadata["export_id"])
         return
 
-    client = get_garage_client()
-    bucket = get_user_data_export_bucket()
-    ensure_bucket(client, bucket)
-
     export_id = export.id
-
-    archive_name =  f"listenbrainz_{user.musicbrainz_id}_{int(datetime.now().timestamp())}.zip"
-
-    db_conn.execute(text("""
-         UPDATE user_data_export
-            SET
-                filename = :filename
-              , status = 'in_progress'
-              , progress = :progress
-          WHERE id = :export_id    
-    """), {
-        "export_id": export_id,
-        "filename": archive_name,
-        "progress": "Starting export",
-    })
-    db_conn.commit()
-
     try:
+        client = get_garage_client()
+        bucket = get_user_data_export_bucket()
+        ensure_bucket(client, bucket)
+
+        archive_name = f"listenbrainz_{user.musicbrainz_id}_{int(datetime.now().timestamp())}.zip"
+
+        db_conn.execute(text("""
+             UPDATE user_data_export
+                SET
+                    filename = :filename
+                  , status = 'in_progress'
+                  , progress = :progress
+              WHERE id = :export_id
+        """), {
+            "export_id": export_id,
+            "filename": archive_name,
+            "progress": "Starting export",
+        })
+        db_conn.commit()
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             archive_path = os.path.join(tmp_dir, archive_name)
             with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -280,6 +280,10 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
         current_app.logger.error("No export with export_id: %s, skipping.", metadata["export_id"])
         return
 
+    client = get_garage_client()
+    bucket = get_user_data_export_bucket()
+    ensure_bucket(client, bucket)
+
     export_id = export.id
 
     archive_name =  f"listenbrainz_{user.musicbrainz_id}_{int(datetime.now().timestamp())}.zip"
@@ -323,9 +327,6 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
                     archive.write(file, arcname=os.path.relpath(file, tmp_dir))
 
             update_export_progress(db_conn, export_id, "Finalizing user data export")
-            client = get_garage_client()
-            bucket = get_user_data_export_bucket()
-            ensure_bucket(client, bucket)
             client.upload_file(archive_path, bucket, archive_name, ExtraArgs={"ContentType": "application/zip"})
 
         created = datetime.now()

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -1,20 +1,21 @@
 import os.path
-import shutil
 import tempfile
 import zipfile
 from datetime import datetime, date, time, timedelta, timezone
-from pathlib import Path
 
 import orjson
 from brainzutils.mail import send_mail
 from dateutil.relativedelta import relativedelta
 from flask import current_app, render_template
+from minio.deleteobjects import DeleteObject
 from sqlalchemy import text
 
 from listenbrainz.db import user as db_user
+from listenbrainz.garage import ensure_bucket, get_garage_client, get_user_data_export_bucket
 from listenbrainz.webserver import timescale_connection
 
 BATCH_SIZE = 1000
+EXPORT_FAILED_PROGRESS = "Export failed, please try again."
 USER_DATA_EXPORT_AVAILABILITY = timedelta(days=30)  # how long should a user data export be saved for on our servers
 
 
@@ -25,6 +26,24 @@ def update_export_progress(db_conn, export_id, progress):
            SET progress = :progress
          WHERE id = :export_id
     """), {"export_id": export_id, "progress": progress})
+    db_conn.commit()
+
+
+def mark_export_failed(db_conn, export_id):
+    """ Mark the given export as failed.
+
+    An export that is left in progress blocks the user from requesting a new one forever
+    because of the user_data_export_deduplicate_waiting_idx unique index, so any failure
+    must be recorded in the export's status.
+    """
+    # the failure may have left the connection in an aborted transaction
+    db_conn.rollback()
+    db_conn.execute(text("""
+        UPDATE user_data_export
+           SET status = 'failed'
+             , progress = :progress
+         WHERE id = :export_id
+    """), {"export_id": export_id, "progress": EXPORT_FAILED_PROGRESS})
     db_conn.commit()
 
 
@@ -264,8 +283,6 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
     export_id = export.id
 
     archive_name =  f"listenbrainz_{user.musicbrainz_id}_{int(datetime.now().timestamp())}.zip"
-    dest_path = os.path.join(current_app.config["USER_DATA_EXPORT_BASE_DIR"], archive_name)
-    os.makedirs(current_app.config["USER_DATA_EXPORT_BASE_DIR"], exist_ok=True)
 
     db_conn.execute(text("""
          UPDATE user_data_export
@@ -281,43 +298,50 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
     })
     db_conn.commit()
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        archive_path = os.path.join(tmp_dir, archive_name)
-        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-            all_files = []
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            archive_path = os.path.join(tmp_dir, archive_name)
+            with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                all_files = []
 
-            user_file = export_info_for_user(export_id, db_conn, tmp_dir, user)
-            all_files.append(user_file)
+                user_file = export_info_for_user(export_id, db_conn, tmp_dir, user)
+                all_files.append(user_file)
 
-            listen_files = export_listens_for_user(export_id, db_conn, ts_conn, tmp_dir, user_id)
-            all_files.extend(listen_files)
+                listen_files = export_listens_for_user(export_id, db_conn, ts_conn, tmp_dir, user_id)
+                all_files.extend(listen_files)
 
-            feedback_file = export_feedback_for_user(export_id, db_conn, tmp_dir, user_id)
-            if feedback_file:
-                all_files.append(feedback_file)
+                feedback_file = export_feedback_for_user(export_id, db_conn, tmp_dir, user_id)
+                if feedback_file:
+                    all_files.append(feedback_file)
 
-            pinned_recording_file = export_pinned_recordings_for_user(export_id, db_conn, tmp_dir, user_id)
-            if pinned_recording_file:
-                all_files.append(pinned_recording_file)
+                pinned_recording_file = export_pinned_recordings_for_user(export_id, db_conn, tmp_dir, user_id)
+                if pinned_recording_file:
+                    all_files.append(pinned_recording_file)
 
-            update_export_progress(db_conn, export_id, "Writing export files")
-            for file in all_files:
-                archive.write(file, arcname=os.path.relpath(file, tmp_dir))
+                update_export_progress(db_conn, export_id, "Writing export files")
+                for file in all_files:
+                    archive.write(file, arcname=os.path.relpath(file, tmp_dir))
 
-        update_export_progress(db_conn, export_id, "Finalizing user data export")
-        shutil.move(archive_path, dest_path)
+            update_export_progress(db_conn, export_id, "Finalizing user data export")
+            client = get_garage_client()
+            bucket = get_user_data_export_bucket()
+            ensure_bucket(client, bucket)
+            client.fput_object(bucket, archive_name, archive_path, content_type="application/zip")
 
-    created = datetime.now()
-    available_until = created + USER_DATA_EXPORT_AVAILABILITY
-    result = db_conn.execute(text("""
-        UPDATE user_data_export
-           SET progress = :progress
-             , available_until = :available_until
-             , status = 'completed'
-         WHERE id = :export_id
-     RETURNING id
-    """), {"export_id": export_id, "available_until": available_until, "progress": "Export completed"})
-    db_conn.commit()
+        created = datetime.now()
+        available_until = created + USER_DATA_EXPORT_AVAILABILITY
+        result = db_conn.execute(text("""
+            UPDATE user_data_export
+               SET progress = :progress
+                 , available_until = :available_until
+                 , status = 'completed'
+             WHERE id = :export_id
+         RETURNING id
+        """), {"export_id": export_id, "available_until": available_until, "progress": "Export completed"})
+        db_conn.commit()
+    except Exception:
+        mark_export_failed(db_conn, export_id)
+        raise
 
     if result.first() is None:
         return
@@ -348,10 +372,18 @@ def cleanup_old_exports(db_conn):
     with db_conn.begin():
         db_conn.execute(text("DELETE FROM user_data_export WHERE available_until < NOW()"))
         result = db_conn.execute(text("SELECT filename FROM user_data_export"))
-        files_to_keep = {r.filename for r in result.all()}
+        files_to_keep = {r.filename for r in result.all() if r.filename is not None}
 
-        # Delete exports that are no longer required
-        for path in Path(current_app.config["USER_DATA_EXPORT_BASE_DIR"]).iterdir():
-            if path.is_file() and path.name not in files_to_keep:
-                current_app.logger.info("Removing file: %s", path)
-                path.unlink(missing_ok=True)
+    client = get_garage_client()
+    bucket = get_user_data_export_bucket()
+    ensure_bucket(client, bucket)
+
+    # Delete exports that are no longer required
+    objects_to_delete = []
+    for obj in client.list_objects(bucket):
+        if obj.object_name not in files_to_keep:
+            current_app.logger.info("Removing export: %s", obj.object_name)
+            objects_to_delete.append(DeleteObject(obj.object_name))
+
+    for error in client.remove_objects(bucket, objects_to_delete):
+        current_app.logger.error("Failed to remove export %s: %s", error.name, error.message)

--- a/listenbrainz/background/migrate_exports.py
+++ b/listenbrainz/background/migrate_exports.py
@@ -1,0 +1,142 @@
+""" Migrate user data export archives from the on-disk export directory to Garage.
+
+User data exports used to be written to a directory shared between the webserver and the
+background tasks container (the USER_DATA_EXPORT_BASE_DIR docker volume), they are stored in
+the Garage bucket named by GARAGE_USER_DATA_EXPORT_BUCKET now. This uploads the archives that
+are still on disk, using the filename recorded in user_data_export as the object name so that
+the existing rows keep working unchanged.
+
+Uploads are skipped for archives that already exist in the bucket, so the migration can be run
+again after a partial run. Files without a matching user_data_export row are left alone (or
+removed with --delete-source), they are the ones the cleanup cronjob would have deleted anyway.
+Completed exports whose archive exists neither in the bucket nor on disk cannot be migrated, so
+they are marked as failed and the user is asked to create a new export. Because that is a
+destructive and irreversible update, it is skipped unless the directory actually contained
+archives belonging to a completed export; pass --mark-missing-failed to do it anyway.
+"""
+from collections import defaultdict
+from pathlib import Path
+
+import click
+from flask import current_app
+from sqlalchemy import text
+
+from listenbrainz.garage import ensure_bucket, get_garage_client, get_user_data_export_bucket
+
+ARCHIVE_MISSING_PROGRESS = "Export archive is no longer available, please create a new export."
+
+
+def get_completed_exports(db_conn) -> dict[str, list[int]]:
+    """ Get the export ids of all completed exports, keyed by the archive's filename. """
+    result = db_conn.execute(text("""
+        SELECT id, filename
+          FROM user_data_export
+         WHERE status = 'completed'
+           AND filename IS NOT NULL
+    """))
+    exports = defaultdict(list)
+    for row in result:
+        exports[row.filename].append(row.id)
+    return exports
+
+
+def get_all_export_filenames(db_conn) -> set[str]:
+    """ Get the archive filenames of all exports, whatever their status.
+
+    Only completed exports are migrated but an archive belonging to an export in any other
+    status is not an orphan either, so it must not be deleted by --delete-source.
+    """
+    result = db_conn.execute(text("SELECT filename FROM user_data_export WHERE filename IS NOT NULL"))
+    return {row.filename for row in result}
+
+
+def mark_exports_failed(db_conn, export_ids: list[int]):
+    """ Mark the given exports as failed so that the user is asked to create a new one. """
+    db_conn.execute(text("""
+        UPDATE user_data_export
+           SET status = 'failed'
+             , progress = :progress
+         WHERE id = ANY(:export_ids)
+    """), {"export_ids": export_ids, "progress": ARCHIVE_MISSING_PROGRESS})
+    db_conn.commit()
+
+
+def migrate_exports(db_conn, export_dir: str, delete_source: bool = False, dry_run: bool = False,
+                    mark_missing_failed: bool = False):
+    """ Upload the user data export archives in export_dir to garage and update the database. """
+    source_dir = Path(export_dir)
+    if not source_dir.is_dir():
+        raise click.ClickException(f"Export directory does not exist: {export_dir}")
+
+    client = get_garage_client()
+    bucket = get_user_data_export_bucket()
+    if dry_run:
+        # the bucket is created by ops in production but may not exist yet, a dry run should
+        # still report what it would do instead of erroring out with NoSuchBucket
+        bucket_exists = client.bucket_exists(bucket)
+        if not bucket_exists:
+            current_app.logger.info("Bucket %s does not exist yet, it would be created", bucket)
+    else:
+        ensure_bucket(client, bucket)
+        bucket_exists = True
+
+    exports = get_completed_exports(db_conn)
+    known_filenames = get_all_export_filenames(db_conn)
+    # archives that do not need to be uploaded (again), this run's uploads are added as they happen
+    available = {obj.object_name for obj in client.list_objects(bucket)} if bucket_exists else set()
+    files = sorted(path for path in source_dir.iterdir() if path.is_file())
+
+    uploaded_count, skipped_count, orphan_count, pending_count = 0, 0, 0, 0
+
+    for path in files:
+        if path.name in exports:
+            if path.name in available:
+                current_app.logger.info("%s already exists in garage, not uploading it again", path.name)
+                skipped_count += 1
+            else:
+                current_app.logger.info("Uploading %s (%d bytes)", path.name, path.stat().st_size)
+                if not dry_run:
+                    client.fput_object(bucket, path.name, str(path), content_type="application/zip")
+                available.add(path.name)
+                uploaded_count += 1
+            deletable = True
+        elif path.name in known_filenames:
+            # the export is in progress or failed, only completed exports are migrated and the
+            # archive must survive in case the export completes while the migration runs
+            current_app.logger.info("%s does not belong to a completed export, leaving it alone", path.name)
+            pending_count += 1
+            deletable = False
+        else:
+            current_app.logger.info("No export exists for %s, not migrating it", path.name)
+            orphan_count += 1
+            deletable = True
+
+        if delete_source and deletable and not dry_run:
+            path.unlink(missing_ok=True)
+
+    missing = {filename: ids for filename, ids in exports.items() if filename not in available}
+    marked_failed = 0
+    if missing:
+        # every completed export looks missing if the wrong directory was passed or the export
+        # volume was not mounted, refuse to fail all of them on the strength of an empty scan
+        if uploaded_count + skipped_count == 0 and not mark_missing_failed:
+            current_app.logger.warning(
+                "%d completed export(s) have no archive but no archive of a completed export was found in %s"
+                " either. Not marking them as failed, check the directory and re-run with"
+                " --mark-missing-failed if this is expected.",
+                len(missing), export_dir
+            )
+        else:
+            current_app.logger.info(
+                "Marking %d export(s) as failed, their archive is missing: %s",
+                len(missing), ", ".join(sorted(missing))
+            )
+            marked_failed = len(missing)
+            if not dry_run:
+                mark_exports_failed(db_conn, [export_id for ids in missing.values() for export_id in ids])
+
+    current_app.logger.info(
+        "Migrated %d archive(s), %d already in garage, %d not completed yet, %d without an export,"
+        " %d export(s) marked failed.",
+        uploaded_count, skipped_count, pending_count, orphan_count, marked_failed
+    )

--- a/listenbrainz/background/migrate_exports.py
+++ b/listenbrainz/background/migrate_exports.py
@@ -21,7 +21,8 @@ import click
 from flask import current_app
 from sqlalchemy import text
 
-from listenbrainz.garage import ensure_bucket, get_garage_client, get_user_data_export_bucket
+from listenbrainz.garage import bucket_exists, ensure_bucket, get_garage_client, \
+    get_user_data_export_bucket, list_object_names
 
 ARCHIVE_MISSING_PROGRESS = "Export archive is no longer available, please create a new export."
 
@@ -73,17 +74,17 @@ def migrate_exports(db_conn, export_dir: str, delete_source: bool = False, dry_r
     if dry_run:
         # the bucket is created by ops in production but may not exist yet, a dry run should
         # still report what it would do instead of erroring out with NoSuchBucket
-        bucket_exists = client.bucket_exists(bucket)
-        if not bucket_exists:
+        bucket_available = bucket_exists(client, bucket)
+        if not bucket_available:
             current_app.logger.info("Bucket %s does not exist yet, it would be created", bucket)
     else:
         ensure_bucket(client, bucket)
-        bucket_exists = True
+        bucket_available = True
 
     exports = get_completed_exports(db_conn)
     known_filenames = get_all_export_filenames(db_conn)
     # archives that do not need to be uploaded (again), this run's uploads are added as they happen
-    available = {obj.object_name for obj in client.list_objects(bucket)} if bucket_exists else set()
+    available = set(list_object_names(client, bucket)) if bucket_available else set()
     files = sorted(path for path in source_dir.iterdir() if path.is_file())
 
     uploaded_count, skipped_count, orphan_count, pending_count = 0, 0, 0, 0
@@ -96,7 +97,8 @@ def migrate_exports(db_conn, export_dir: str, delete_source: bool = False, dry_r
             else:
                 current_app.logger.info("Uploading %s (%d bytes)", path.name, path.stat().st_size)
                 if not dry_run:
-                    client.fput_object(bucket, path.name, str(path), content_type="application/zip")
+                    client.upload_file(str(path), bucket, path.name,
+                                       ExtraArgs={"ContentType": "application/zip"})
                 available.add(path.name)
                 uploaded_count += 1
             deletable = True

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -240,8 +240,14 @@ REJECT_LISTENS_WITHOUT_USER_EMAIL = False
 # If set to True, do not allow new users without email to register
 REJECT_NEW_USERS_WITHOUT_EMAIL = False
 
-# base directory for user data exports
-USER_DATA_EXPORT_BASE_DIR = "/code/listenbrainz/exports/"
+# Garage object storage, user data exports are stored here.
+# The endpoint must not include a URL scheme.
+GARAGE_ENDPOINT = "garage:3900"
+GARAGE_ACCESS_KEY = "GK1e5b4c3a2d0f9e8b7a6c5d40"
+GARAGE_SECRET_KEY = "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0"
+GARAGE_SECURE = False
+GARAGE_REGION = "garage"
+GARAGE_USER_DATA_EXPORT_BUCKET = "listenbrainz-user-data-exports"
 
 # Service monitoring -- only needed for MetaBrainz production
 SERVICE_MONITOR_TELEGRAM_BOT_TOKEN = ""

--- a/listenbrainz/garage.py
+++ b/listenbrainz/garage.py
@@ -1,26 +1,34 @@
-"""MinIO client for Garage's S3-compatible API."""
+"""boto3 client for Garage's S3-compatible API."""
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import timedelta
 from typing import Any
 
-import urllib3
+import boto3
+from botocore.client import BaseClient
+from botocore.config import Config
+from botocore.exceptions import ClientError
 from flask import current_app
-from minio import Minio
-from minio.error import S3Error
 
-# minio's default pool only allows 10 connections, an export download holds one for the entire
+# botocore's default pool only allows 10 connections, an export download holds one for the entire
 # duration of the transfer so a handful of concurrent downloads would exhaust it.
 CONNECTION_POOL_SIZE = 50
 CONNECTION_TIMEOUT = timedelta(minutes=5).seconds
+# maximum number of keys a single DeleteObjects request accepts
+DELETE_BATCH_SIZE = 1000
 
 
 class GarageConfigurationError(ValueError):
     """Raised when the Garage client configuration is incomplete or invalid."""
 
 
-def create_garage_client(config: Mapping[str, Any]) -> Minio:
-    """Create a MinIO client configured for Garage."""
+def get_error_code(error: ClientError) -> str:
+    """Get the S3 error code of the given error, an empty string if it has none."""
+    return error.response.get("Error", {}).get("Code", "")
+
+
+def create_garage_client(config: Mapping[str, Any]) -> BaseClient:
+    """Create a boto3 S3 client configured for Garage."""
     required = ("GARAGE_ENDPOINT", "GARAGE_ACCESS_KEY", "GARAGE_SECRET_KEY")
     missing = [key for key in required if not config.get(key)]
     if missing:
@@ -38,26 +46,31 @@ def create_garage_client(config: Mapping[str, Any]) -> Minio:
     if not isinstance(secure, bool):
         raise GarageConfigurationError("GARAGE_SECURE must be a boolean")
 
-    # same as the client minio creates by default, except for the larger pool. urllib3 verifies
-    # certificates against the system trust store by default so the ca bundle is left to it.
-    http_client = urllib3.PoolManager(
-        timeout=urllib3.util.Timeout(connect=CONNECTION_TIMEOUT, read=CONNECTION_TIMEOUT),
-        maxsize=CONNECTION_POOL_SIZE,
-        cert_reqs="CERT_REQUIRED",
-        retries=urllib3.Retry(total=5, backoff_factor=0.2, status_forcelist=[500, 502, 503, 504]),
+    client_config = Config(
+        region_name=str(config.get("GARAGE_REGION", "garage")),
+        signature_version="s3v4",
+        # garage serves one host, virtual hosted style buckets would resolve to a name that
+        # does not exist
+        s3={"addressing_style": "path"},
+        max_pool_connections=CONNECTION_POOL_SIZE,
+        connect_timeout=CONNECTION_TIMEOUT,
+        read_timeout=CONNECTION_TIMEOUT,
+        retries={"max_attempts": 5, "mode": "standard"},
+        # garage is not S3, only compute the checksums the operations that require them need
+        request_checksum_calculation="when_required",
+        response_checksum_validation="when_required",
     )
 
-    return Minio(
-        endpoint,
-        access_key=str(config["GARAGE_ACCESS_KEY"]),
-        secret_key=str(config["GARAGE_SECRET_KEY"]),
-        secure=secure,
-        region=str(config.get("GARAGE_REGION", "garage")),
-        http_client=http_client,
+    return boto3.client(
+        "s3",
+        endpoint_url=f"{'https' if secure else 'http'}://{endpoint}",
+        aws_access_key_id=str(config["GARAGE_ACCESS_KEY"]),
+        aws_secret_access_key=str(config["GARAGE_SECRET_KEY"]),
+        config=client_config,
     )
 
 
-def get_garage_client() -> Minio:
+def get_garage_client() -> BaseClient:
     """Get the Garage client for the current app, creating it on first use."""
     client = current_app.extensions.get("garage")
     if client is None:
@@ -73,16 +86,62 @@ def get_user_data_export_bucket() -> str:
     return bucket
 
 
-def ensure_bucket(client: Minio, bucket: str):
+def get_user_data_import_bucket() -> str:
+    """Get the name of the bucket the files uploaded for user data imports are stored in."""
+    bucket = current_app.config.get("GARAGE_USER_DATA_IMPORT_BUCKET")
+    if not bucket:
+        raise GarageConfigurationError("Missing Garage configuration: GARAGE_USER_DATA_IMPORT_BUCKET")
+    return bucket
+
+
+def bucket_exists(client: BaseClient, bucket: str) -> bool:
+    """Check whether the given bucket exists and is accessible with our credentials."""
+    try:
+        client.head_bucket(Bucket=bucket)
+        return True
+    except ClientError as e:
+        # a HEAD response has no body to carry the error code in, botocore reports the status
+        if get_error_code(e) in ("404", "NoSuchBucket"):
+            return False
+        raise
+
+
+def ensure_bucket(client: BaseClient, bucket: str):
     """Create the given bucket if it does not exist yet.
 
     Buckets are created by ops in production, this only matters for development
     setups where the bucket has not been provisioned yet.
     """
     try:
-        if not client.bucket_exists(bucket):
-            client.make_bucket(bucket)
-    except S3Error as e:
+        if not bucket_exists(client, bucket):
+            client.create_bucket(Bucket=bucket)
+    except ClientError as e:
         # another worker may have created the bucket in the meantime
-        if e.code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+        if get_error_code(e) not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
             raise
+
+
+def list_object_names(client: BaseClient, bucket: str) -> list[str]:
+    """List the names of all the objects in the given bucket."""
+    names = []
+    for page in client.get_paginator("list_objects_v2").paginate(Bucket=bucket):
+        names.extend(obj["Key"] for obj in page.get("Contents", []))
+    return names
+
+
+def delete_objects(client: BaseClient, bucket: str, object_names: Iterable[str]) -> list[dict]:
+    """Delete the given objects from the bucket, returning the errors the deletions failed with.
+
+    A DeleteObjects request only accepts a limited number of keys, so the deletion is split
+    into batches. Errors do not raise, S3 reports them per object in the response.
+    """
+    names = list(object_names)
+    errors = []
+    for index in range(0, len(names), DELETE_BATCH_SIZE):
+        batch = names[index:index + DELETE_BATCH_SIZE]
+        response = client.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": [{"Key": name} for name in batch], "Quiet": True},
+        )
+        errors.extend(response.get("Errors", []))
+    return errors

--- a/listenbrainz/garage.py
+++ b/listenbrainz/garage.py
@@ -1,0 +1,88 @@
+"""MinIO client for Garage's S3-compatible API."""
+
+from collections.abc import Mapping
+from datetime import timedelta
+from typing import Any
+
+import urllib3
+from flask import current_app
+from minio import Minio
+from minio.error import S3Error
+
+# minio's default pool only allows 10 connections, an export download holds one for the entire
+# duration of the transfer so a handful of concurrent downloads would exhaust it.
+CONNECTION_POOL_SIZE = 50
+CONNECTION_TIMEOUT = timedelta(minutes=5).seconds
+
+
+class GarageConfigurationError(ValueError):
+    """Raised when the Garage client configuration is incomplete or invalid."""
+
+
+def create_garage_client(config: Mapping[str, Any]) -> Minio:
+    """Create a MinIO client configured for Garage."""
+    required = ("GARAGE_ENDPOINT", "GARAGE_ACCESS_KEY", "GARAGE_SECRET_KEY")
+    missing = [key for key in required if not config.get(key)]
+    if missing:
+        raise GarageConfigurationError(
+            f"Missing Garage configuration: {', '.join(missing)}"
+        )
+
+    endpoint = str(config["GARAGE_ENDPOINT"])
+    if "://" in endpoint:
+        raise GarageConfigurationError(
+            "GARAGE_ENDPOINT must be host:port without a URL scheme"
+        )
+
+    secure = config.get("GARAGE_SECURE", False)
+    if not isinstance(secure, bool):
+        raise GarageConfigurationError("GARAGE_SECURE must be a boolean")
+
+    # same as the client minio creates by default, except for the larger pool. urllib3 verifies
+    # certificates against the system trust store by default so the ca bundle is left to it.
+    http_client = urllib3.PoolManager(
+        timeout=urllib3.util.Timeout(connect=CONNECTION_TIMEOUT, read=CONNECTION_TIMEOUT),
+        maxsize=CONNECTION_POOL_SIZE,
+        cert_reqs="CERT_REQUIRED",
+        retries=urllib3.Retry(total=5, backoff_factor=0.2, status_forcelist=[500, 502, 503, 504]),
+    )
+
+    return Minio(
+        endpoint,
+        access_key=str(config["GARAGE_ACCESS_KEY"]),
+        secret_key=str(config["GARAGE_SECRET_KEY"]),
+        secure=secure,
+        region=str(config.get("GARAGE_REGION", "garage")),
+        http_client=http_client,
+    )
+
+
+def get_garage_client() -> Minio:
+    """Get the Garage client for the current app, creating it on first use."""
+    client = current_app.extensions.get("garage")
+    if client is None:
+        client = current_app.extensions["garage"] = create_garage_client(current_app.config)
+    return client
+
+
+def get_user_data_export_bucket() -> str:
+    """Get the name of the bucket user data exports are stored in."""
+    bucket = current_app.config.get("GARAGE_USER_DATA_EXPORT_BUCKET")
+    if not bucket:
+        raise GarageConfigurationError("Missing Garage configuration: GARAGE_USER_DATA_EXPORT_BUCKET")
+    return bucket
+
+
+def ensure_bucket(client: Minio, bucket: str):
+    """Create the given bucket if it does not exist yet.
+
+    Buckets are created by ops in production, this only matters for development
+    setups where the bucket has not been provisioned yet.
+    """
+    try:
+        if not client.bucket_exists(bucket):
+            client.make_bucket(bucket)
+    except S3Error as e:
+        # another worker may have created the bucket in the meantime
+        if e.code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+            raise

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -478,6 +478,6 @@ def migrate_user_data_exports(export_dir, delete_source, dry_run, mark_missing_f
     app = create_app()
     with app.app_context():
         app.logger.info("Migrating user data exports from %s to garage", export_dir)
-        migrate_exports(webserver.db_conn, export_dir, delete_source=delete_source, dry_run=dry_run,
+        migrate_exports(webserver.db_conn, export_dir=export_dir, delete_source=delete_source, dry_run=dry_run,
                         mark_missing_failed=mark_missing_failed)
         app.logger.info("Completed migrating user data exports")

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -8,6 +8,7 @@ import sqlalchemy
 from listenbrainz import db
 from listenbrainz import webserver
 from listenbrainz.background import export
+from listenbrainz.background.migrate_exports import migrate_exports
 from listenbrainz.db import listens as listens_db, timescale as ts, do_not_recommend
 
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data, \
@@ -463,3 +464,20 @@ def delete_old_user_data_exports():
         app.logger.info("Deleting old and expired user data exports")
         export.cleanup_old_exports(webserver.db_conn)
         app.logger.info("Completed deleting old and expired user data exports")
+
+
+@cli.command(name="migrate_user_data_exports")
+@click.option("--export-dir", required=True, help="Directory the user data export archives are currently stored in.")
+@click.option("--delete-source", is_flag=True, help="Delete the archives from the directory once they are migrated.")
+@click.option("--dry-run", is_flag=True, help="Log what would be migrated without uploading or updating anything.")
+@click.option("--mark-missing-failed", is_flag=True,
+              help="Mark completed exports whose archive cannot be found as failed even if the directory"
+                   " contained no archive of a completed export at all.")
+def migrate_user_data_exports(export_dir, delete_source, dry_run, mark_missing_failed):
+    """ Migrate user data exports from the given directory to garage """
+    app = create_app()
+    with app.app_context():
+        app.logger.info("Migrating user data exports from %s to garage", export_dir)
+        migrate_exports(webserver.db_conn, export_dir, delete_source=delete_source, dry_run=dry_run,
+                        mark_missing_failed=mark_missing_failed)
+        app.logger.info("Completed migrating user data exports")

--- a/listenbrainz/tests/integration/test_export.py
+++ b/listenbrainz/tests/integration/test_export.py
@@ -1,21 +1,27 @@
 import json
 import os
+import tempfile
 import time
 import zipfile
+from datetime import datetime, timedelta
 from io import BytesIO
+from unittest import mock
 
 from brainzutils import cache
+from minio.deleteobjects import DeleteObject
 from sqlalchemy import text
 
 import listenbrainz.db.feedback as db_feedback
 import listenbrainz.db.pinned_recording as db_pinned_rec
 import listenbrainz.db.user as db_user
-from listenbrainz.background.export import cleanup_old_exports
+from listenbrainz.background.export import EXPORT_FAILED_PROGRESS, cleanup_old_exports, export_user
+from listenbrainz.background.migrate_exports import ARCHIVE_MISSING_PROGRESS, migrate_exports
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.db.model.pinned_recording import WritablePinnedRecording
+from listenbrainz.garage import ensure_bucket, get_garage_client, get_user_data_export_bucket
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
-from listenbrainz.webserver import db_conn
+from listenbrainz.webserver import db_conn, ts_conn
 
 
 class ExportTestCase(ListenAPIIntegrationTestCase):
@@ -75,9 +81,18 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
     def tearDown(self):
         with self.app.app_context():
             self.redis.flushall()
-        for archive in os.listdir(self.app.config["USER_DATA_EXPORT_BASE_DIR"]):
-            os.remove(os.path.join(self.app.config["USER_DATA_EXPORT_BASE_DIR"], archive))
+            client, bucket = self.get_export_storage()
+            objects = [DeleteObject(obj.object_name) for obj in client.list_objects(bucket)]
+            for error in client.remove_objects(bucket, objects):
+                self.fail(f"Failed to remove export {error.name}: {error.message}")
         super(ExportTestCase, self).tearDown()
+
+    def get_export_storage(self):
+        """ Get the garage client and the bucket user data exports are stored in. """
+        client = get_garage_client()
+        bucket = get_user_data_export_bucket()
+        ensure_bucket(client, bucket)
+        return client, bucket
 
     def create_mapping_record(self, recording_msid):
         self.ts_conn.execute(text("""
@@ -289,4 +304,215 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
 
         with self.app.app_context():
             cleanup_old_exports(db_conn)
-        self.assertEqual(len(os.listdir(self.app.config["USER_DATA_EXPORT_BASE_DIR"])), 0)
+            client, bucket = self.get_export_storage()
+            self.assertEqual([obj.object_name for obj in client.list_objects(bucket)], [])
+
+    def create_export_row(self, filename, status="completed", available_until=None, user=None):
+        """ Insert a user data export row directly, as if it had been created by an earlier export. """
+        if available_until is None:
+            available_until = datetime.now() + timedelta(days=30)
+        result = self.db_conn.execute(text("""
+            INSERT INTO user_data_export (user_id, type, status, progress, filename, available_until)
+                 VALUES (:user_id, 'export_all_user_data', :status, 'Export completed', :filename, :available_until)
+              RETURNING id
+        """), {
+            "user_id": (user or self.user)["id"],
+            "status": status,
+            "filename": filename,
+            "available_until": available_until,
+        })
+        self.db_conn.commit()
+        return result.first().id
+
+    def get_export_row(self, export_id):
+        result = self.db_conn.execute(
+            text("SELECT status, progress FROM user_data_export WHERE id = :export_id"),
+            {"export_id": export_id}
+        )
+        return result.first()
+
+    def test_migrate_exports(self):
+        migrated_name = "listenbrainz_lucifer-export_1.zip"
+        orphan_name = "listenbrainz_lucifer-export_2.zip"
+        missing_name = "listenbrainz_lucifer-export_3.zip"
+
+        migrated_id = self.create_export_row(migrated_name)
+        missing_id = self.create_export_row(missing_name)
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            for name in (migrated_name, orphan_name):
+                with open(os.path.join(export_dir, name), "wb") as f:
+                    f.write(b"archive contents of " + name.encode())
+
+            with self.app.app_context():
+                client, bucket = self.get_export_storage()
+
+                migrate_exports(db_conn, export_dir, dry_run=True)
+                self.assertEqual([obj.object_name for obj in client.list_objects(bucket)], [])
+                self.assertEqual("completed", self.get_export_row(missing_id).status)
+
+                migrate_exports(db_conn, export_dir)
+
+                # the archive with an export row is uploaded, the orphan one is not
+                self.assertEqual([migrated_name], [obj.object_name for obj in client.list_objects(bucket)])
+                archive = client.get_object(bucket, migrated_name)
+                self.assertEqual(b"archive contents of " + migrated_name.encode(), archive.read())
+                archive.close()
+                archive.release_conn()
+
+                # source files are kept unless asked otherwise
+                self.assertEqual({migrated_name, orphan_name}, set(os.listdir(export_dir)))
+
+                # the export whose archive is nowhere to be found cannot be migrated
+                missing_export = self.get_export_row(missing_id)
+                self.assertEqual("failed", missing_export.status)
+                self.assertEqual(ARCHIVE_MISSING_PROGRESS, missing_export.progress)
+                self.assertEqual("completed", self.get_export_row(migrated_id).status)
+
+                # re-running does not upload again and removes the source files when asked to
+                migrate_exports(db_conn, export_dir, delete_source=True)
+                self.assertEqual([migrated_name], [obj.object_name for obj in client.list_objects(bucket)])
+                self.assertEqual([], os.listdir(export_dir))
+
+    def put_archive(self, filename, contents=b"archive contents"):
+        """ Put an archive in the export bucket, as if an earlier export had uploaded it. """
+        with self.app.app_context():
+            client, bucket = self.get_export_storage()
+            client.put_object(bucket, filename, BytesIO(contents), len(contents))
+
+    def list_archives(self):
+        with self.app.app_context():
+            client, bucket = self.get_export_storage()
+            return [obj.object_name for obj in client.list_objects(bucket)]
+
+    def test_export_endpoints_only_serve_the_owner(self):
+        """ An export must not be readable or deletable by any user other than its owner. """
+        filename = "listenbrainz_lucifer-export_7.zip"
+        export_id = self.create_export_row(filename)
+        self.put_archive(filename)
+
+        other_user = db_user.get_or_create(self.db_conn, 1800, "lucifer-export-other")
+        db_user.agree_to_gdpr(self.db_conn, other_user["musicbrainz_id"])
+        self.temporary_login(other_user["login_id"])
+
+        response = self.client.get(self.custom_url_for("export.get_export_task", export_id=export_id))
+        self.assert404(response)
+
+        response = self.client.get(self.custom_url_for("export.list_export_tasks"))
+        self.assert200(response)
+        self.assertEqual([], response.json)
+
+        response = self.client.post(self.custom_url_for("export.download_export_archive", export_id=export_id))
+        self.assert404(response)
+
+        response = self.client.post(self.custom_url_for("export.delete_export_archive", export_id=export_id))
+        self.assert404(response)
+
+        # the owner's export and its archive are untouched
+        self.assertEqual("completed", self.get_export_row(export_id).status)
+        self.assertEqual([filename], self.list_archives())
+
+    def test_create_export_task_rejects_a_second_request(self):
+        """ The unique index only allows one waiting or in progress export per user. """
+        self.create_export_row(None, status="waiting")
+        self.temporary_login(self.user["login_id"])
+
+        response = self.client.post(self.custom_url_for("export.create_export_task"))
+        self.assert400(response)
+        self.assertEqual("Data export already requested.", response.json["error"])
+
+    def test_download_export_archive_when_the_archive_is_missing(self):
+        """ The export row may outlive its archive, the migration marks such exports failed. """
+        export_id = self.create_export_row("listenbrainz_lucifer-export_8.zip")
+        with self.app.app_context():
+            self.get_export_storage()  # the bucket exists, only the archive is missing
+
+        self.temporary_login(self.user["login_id"])
+        response = self.client.post(self.custom_url_for("export.download_export_archive", export_id=export_id))
+        self.assert404(response)
+
+    def test_cleanup_old_exports_removes_expired_exports(self):
+        expired_name = "listenbrainz_lucifer-export_9.zip"
+        live_name = "listenbrainz_lucifer-export_10.zip"
+        expired_id = self.create_export_row(expired_name, available_until=datetime.now() - timedelta(days=1))
+        live_id = self.create_export_row(live_name)
+        self.put_archive(expired_name)
+        self.put_archive(live_name)
+
+        with self.app.app_context():
+            cleanup_old_exports(db_conn)
+
+        self.assertIsNone(self.get_export_row(expired_id))
+        self.assertIsNotNone(self.get_export_row(live_id))
+        self.assertEqual([live_name], self.list_archives())
+
+    def test_export_is_marked_failed_when_the_archive_cannot_be_uploaded(self):
+        """ An export left in progress would block the user from ever requesting another one. """
+        export_id = self.create_export_row(None, status="waiting")
+
+        with self.app.app_context():
+            with mock.patch("listenbrainz.background.export.get_garage_client",
+                            side_effect=RuntimeError("garage is unavailable")):
+                with self.assertRaises(RuntimeError):
+                    export_user(db_conn, ts_conn, self.user["id"], {"export_id": export_id})
+
+        export = self.get_export_row(export_id)
+        self.assertEqual("failed", export.status)
+        self.assertEqual(EXPORT_FAILED_PROGRESS, export.progress)
+        self.assertEqual([], self.list_archives())
+
+        # the user can request a new export, the failed one no longer conflicts with it
+        self.create_export_row(None, status="waiting")
+
+    def test_download_export_archive_with_non_ascii_filename(self):
+        """ Archive names contain the musicbrainz id which may not be ascii encodable. """
+        filename = "listenbrainz_lüdwig_1.zip"
+        export_id = self.create_export_row(filename)
+        self.put_archive(filename)
+
+        self.temporary_login(self.user["login_id"])
+        response = self.client.post(self.custom_url_for("export.download_export_archive", export_id=export_id))
+        self.assert200(response)
+        self.assertEqual(b"archive contents", response.data)
+        self.assertEqual(
+            "attachment; filename=listenbrainz_ludwig_1.zip;"
+            " filename*=UTF-8''listenbrainz_l%C3%BCdwig_1.zip",
+            response.headers["Content-Disposition"]
+        )
+
+    def test_migrate_exports_keeps_archives_of_exports_in_progress(self):
+        """ An archive of an export that is not completed yet is neither migrated nor deleted. """
+        in_progress_name = "listenbrainz_lucifer-export_4.zip"
+        migrated_name = "listenbrainz_lucifer-export_5.zip"
+        self.create_export_row(in_progress_name, status="in_progress")
+        self.create_export_row(migrated_name)
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            for name in (in_progress_name, migrated_name):
+                with open(os.path.join(export_dir, name), "wb") as f:
+                    f.write(b"archive contents of " + name.encode())
+
+            with self.app.app_context():
+                client, bucket = self.get_export_storage()
+                migrate_exports(db_conn, export_dir, delete_source=True)
+
+                self.assertEqual([migrated_name], [obj.object_name for obj in client.list_objects(bucket)])
+                self.assertEqual([in_progress_name], os.listdir(export_dir))
+
+    def test_migrate_exports_does_not_fail_exports_when_no_archive_was_found(self):
+        """ Pointing the migration at the wrong directory must not fail every completed export. """
+        missing_name = "listenbrainz_lucifer-export_6.zip"
+        missing_id = self.create_export_row(missing_name)
+
+        with tempfile.TemporaryDirectory() as export_dir:
+            with self.app.app_context():
+                self.get_export_storage()
+
+                migrate_exports(db_conn, export_dir)
+                self.assertEqual("completed", self.get_export_row(missing_id).status)
+
+                # unless the operator confirms that this is expected
+                migrate_exports(db_conn, export_dir, mark_missing_failed=True)
+                missing_export = self.get_export_row(missing_id)
+                self.assertEqual("failed", missing_export.status)
+                self.assertEqual(ARCHIVE_MISSING_PROGRESS, missing_export.progress)

--- a/listenbrainz/tests/integration/test_export.py
+++ b/listenbrainz/tests/integration/test_export.py
@@ -8,7 +8,6 @@ from io import BytesIO
 from unittest import mock
 
 from brainzutils import cache
-from minio.deleteobjects import DeleteObject
 from sqlalchemy import text
 
 import listenbrainz.db.feedback as db_feedback
@@ -18,7 +17,8 @@ from listenbrainz.background.export import EXPORT_FAILED_PROGRESS, cleanup_old_e
 from listenbrainz.background.migrate_exports import ARCHIVE_MISSING_PROGRESS, migrate_exports
 from listenbrainz.db.model.feedback import Feedback
 from listenbrainz.db.model.pinned_recording import WritablePinnedRecording
-from listenbrainz.garage import ensure_bucket, get_garage_client, get_user_data_export_bucket
+from listenbrainz.garage import delete_objects, ensure_bucket, get_garage_client, \
+    get_user_data_export_bucket, list_object_names
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
 from listenbrainz.webserver import db_conn, ts_conn
@@ -82,9 +82,8 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
         with self.app.app_context():
             self.redis.flushall()
             client, bucket = self.get_export_storage()
-            objects = [DeleteObject(obj.object_name) for obj in client.list_objects(bucket)]
-            for error in client.remove_objects(bucket, objects):
-                self.fail(f"Failed to remove export {error.name}: {error.message}")
+            for error in delete_objects(client, bucket, list_object_names(client, bucket)):
+                self.fail(f"Failed to remove export {error.get('Key')}: {error.get('Message')}")
         super(ExportTestCase, self).tearDown()
 
     def get_export_storage(self):
@@ -305,7 +304,7 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
         with self.app.app_context():
             cleanup_old_exports(db_conn)
             client, bucket = self.get_export_storage()
-            self.assertEqual([obj.object_name for obj in client.list_objects(bucket)], [])
+            self.assertEqual(list_object_names(client, bucket), [])
 
     def create_export_row(self, filename, status="completed", available_until=None, user=None):
         """ Insert a user data export row directly, as if it had been created by an earlier export. """
@@ -348,17 +347,16 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
                 client, bucket = self.get_export_storage()
 
                 migrate_exports(db_conn, export_dir, dry_run=True)
-                self.assertEqual([obj.object_name for obj in client.list_objects(bucket)], [])
+                self.assertEqual(list_object_names(client, bucket), [])
                 self.assertEqual("completed", self.get_export_row(missing_id).status)
 
                 migrate_exports(db_conn, export_dir)
 
                 # the archive with an export row is uploaded, the orphan one is not
-                self.assertEqual([migrated_name], [obj.object_name for obj in client.list_objects(bucket)])
-                archive = client.get_object(bucket, migrated_name)
-                self.assertEqual(b"archive contents of " + migrated_name.encode(), archive.read())
-                archive.close()
-                archive.release_conn()
+                self.assertEqual([migrated_name], list_object_names(client, bucket))
+                archive = client.get_object(Bucket=bucket, Key=migrated_name)
+                with archive["Body"] as body:
+                    self.assertEqual(b"archive contents of " + migrated_name.encode(), body.read())
 
                 # source files are kept unless asked otherwise
                 self.assertEqual({migrated_name, orphan_name}, set(os.listdir(export_dir)))
@@ -371,19 +369,19 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
 
                 # re-running does not upload again and removes the source files when asked to
                 migrate_exports(db_conn, export_dir, delete_source=True)
-                self.assertEqual([migrated_name], [obj.object_name for obj in client.list_objects(bucket)])
+                self.assertEqual([migrated_name], list_object_names(client, bucket))
                 self.assertEqual([], os.listdir(export_dir))
 
     def put_archive(self, filename, contents=b"archive contents"):
         """ Put an archive in the export bucket, as if an earlier export had uploaded it. """
         with self.app.app_context():
             client, bucket = self.get_export_storage()
-            client.put_object(bucket, filename, BytesIO(contents), len(contents))
+            client.put_object(Bucket=bucket, Key=filename, Body=contents)
 
     def list_archives(self):
         with self.app.app_context():
             client, bucket = self.get_export_storage()
-            return [obj.object_name for obj in client.list_objects(bucket)]
+            return list_object_names(client, bucket)
 
     def test_export_endpoints_only_serve_the_owner(self):
         """ An export must not be readable or deletable by any user other than its owner. """
@@ -496,7 +494,7 @@ class ExportTestCase(ListenAPIIntegrationTestCase):
                 client, bucket = self.get_export_storage()
                 migrate_exports(db_conn, export_dir, delete_source=True)
 
-                self.assertEqual([migrated_name], [obj.object_name for obj in client.list_objects(bucket)])
+                self.assertEqual([migrated_name], list_object_names(client, bucket))
                 self.assertEqual([in_progress_name], os.listdir(export_dir))
 
     def test_migrate_exports_does_not_fail_exports_when_no_archive_was_found(self):

--- a/listenbrainz/webserver/views/export.py
+++ b/listenbrainz/webserver/views/export.py
@@ -1,17 +1,40 @@
 import json
-import os
+import unicodedata
+from urllib.parse import quote
 
-from flask import Blueprint, current_app, jsonify, send_file
+from flask import Blueprint, Response, current_app, jsonify
 from flask_login import current_user
+from minio.error import S3Error
 from psycopg2 import DatabaseError
 from sqlalchemy import text
+from werkzeug.datastructures import Headers
 
+from listenbrainz.garage import get_garage_client, get_user_data_export_bucket
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.errors import APIInternalServerError, APINotFound, APIBadRequest
 from listenbrainz.webserver.login import api_login_required
 
 export_bp = Blueprint("export", __name__)
+
+STREAM_CHUNK_SIZE = 64 * 1024  # size of the chunks the export archive is streamed to the user in
+
+
+def content_disposition_names(filename: str) -> dict[str, str]:
+    """ Build the Content-Disposition filename parameters for the given filename.
+
+    WSGI headers must be latin-1 encodable but musicbrainz ids (and hence the archive names)
+    may contain arbitrary unicode, so non-ascii names are also sent RFC 5987 encoded. This is
+    what werkzeug's send_file does, we cannot use it because the archive is streamed from garage.
+    """
+    try:
+        filename.encode("ascii")
+    except UnicodeEncodeError:
+        simple = unicodedata.normalize("NFKD", filename).encode("ascii", "ignore").decode("ascii")
+        quoted = quote(filename, safe="!#$&+-.^_`|~")
+        return {"filename": simple, "filename*": f"UTF-8''{quoted}"}
+    else:
+        return {"filename": filename}
 
 
 @export_bp.post("/")
@@ -121,8 +144,29 @@ def download_export_archive(export_id):
     if row is None:
         raise APINotFound("Export not found")
 
-    file_path = os.path.join(current_app.config["USER_DATA_EXPORT_BASE_DIR"], str(row.filename))
-    return send_file(file_path, mimetype="application/zip", as_attachment=True)
+    filename = str(row.filename)
+    try:
+        archive = get_garage_client().get_object(get_user_data_export_bucket(), filename)
+    except S3Error as e:
+        if e.code in ("NoSuchKey", "NoSuchBucket"):
+            raise APINotFound("Export not found")
+        current_app.logger.error("Error while downloading user data export: %s", filename, exc_info=True)
+        raise APIInternalServerError("Error while downloading export, please try again later.")
+
+    def stream_archive():
+        try:
+            yield from archive.stream(STREAM_CHUNK_SIZE)
+        finally:
+            archive.close()
+            archive.release_conn()
+
+    headers = Headers()
+    headers.set("Content-Disposition", "attachment", **content_disposition_names(filename))
+    content_length = archive.headers.get("Content-Length")
+    if content_length is not None:
+        headers.set("Content-Length", content_length)
+
+    return Response(stream_archive(), mimetype="application/zip", headers=headers)
 
 
 
@@ -142,7 +186,7 @@ def delete_export_archive(export_id):
             {"user_id": current_user.id, "export_id": export_id}
         )
         db_conn.commit()
-        # file is deleted from disk by cronjob
+        # archive is deleted from garage by cronjob
         return jsonify({"success": True})
     else:
         raise APINotFound("Export not found")

--- a/listenbrainz/webserver/views/export.py
+++ b/listenbrainz/webserver/views/export.py
@@ -1,13 +1,10 @@
 import json
-import unicodedata
-from urllib.parse import quote
 
 from botocore.exceptions import ClientError
-from flask import Blueprint, Response, current_app, jsonify
+from flask import Blueprint, current_app, jsonify, send_file
 from flask_login import current_user
 from psycopg2 import DatabaseError
 from sqlalchemy import text
-from werkzeug.datastructures import Headers
 
 from listenbrainz.garage import get_error_code, get_garage_client, get_user_data_export_bucket
 from listenbrainz.webserver import db_conn
@@ -16,25 +13,6 @@ from listenbrainz.webserver.errors import APIInternalServerError, APINotFound, A
 from listenbrainz.webserver.login import api_login_required
 
 export_bp = Blueprint("export", __name__)
-
-STREAM_CHUNK_SIZE = 64 * 1024  # size of the chunks the export archive is streamed to the user in
-
-
-def content_disposition_names(filename: str) -> dict[str, str]:
-    """ Build the Content-Disposition filename parameters for the given filename.
-
-    WSGI headers must be latin-1 encodable but musicbrainz ids (and hence the archive names)
-    may contain arbitrary unicode, so non-ascii names are also sent RFC 5987 encoded. This is
-    what werkzeug's send_file does, we cannot use it because the archive is streamed from garage.
-    """
-    try:
-        filename.encode("ascii")
-    except UnicodeEncodeError:
-        simple = unicodedata.normalize("NFKD", filename).encode("ascii", "ignore").decode("ascii")
-        quoted = quote(filename, safe="!#$&+-.^_`|~")
-        return {"filename": simple, "filename*": f"UTF-8''{quoted}"}
-    else:
-        return {"filename": filename}
 
 
 @export_bp.post("/")
@@ -153,21 +131,18 @@ def download_export_archive(export_id):
         current_app.logger.error("Error while downloading user data export: %s", filename, exc_info=True)
         raise APIInternalServerError("Error while downloading export, please try again later.")
 
-    body = archive["Body"]
-
-    def stream_archive():
-        try:
-            yield from body.iter_chunks(STREAM_CHUNK_SIZE)
-        finally:
-            body.close()
-
-    headers = Headers()
-    headers.set("Content-Disposition", "attachment", **content_disposition_names(filename))
+    response = send_file(
+        archive["Body"],
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=filename,
+        conditional=False,
+    )
     content_length = archive.get("ContentLength")
     if content_length is not None:
-        headers.set("Content-Length", str(content_length))
+        response.content_length = content_length
 
-    return Response(stream_archive(), mimetype="application/zip", headers=headers)
+    return response
 
 
 

--- a/listenbrainz/webserver/views/export.py
+++ b/listenbrainz/webserver/views/export.py
@@ -2,14 +2,14 @@ import json
 import unicodedata
 from urllib.parse import quote
 
+from botocore.exceptions import ClientError
 from flask import Blueprint, Response, current_app, jsonify
 from flask_login import current_user
-from minio.error import S3Error
 from psycopg2 import DatabaseError
 from sqlalchemy import text
 from werkzeug.datastructures import Headers
 
-from listenbrainz.garage import get_garage_client, get_user_data_export_bucket
+from listenbrainz.garage import get_error_code, get_garage_client, get_user_data_export_bucket
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import web_listenstore_needed
 from listenbrainz.webserver.errors import APIInternalServerError, APINotFound, APIBadRequest
@@ -146,25 +146,26 @@ def download_export_archive(export_id):
 
     filename = str(row.filename)
     try:
-        archive = get_garage_client().get_object(get_user_data_export_bucket(), filename)
-    except S3Error as e:
-        if e.code in ("NoSuchKey", "NoSuchBucket"):
+        archive = get_garage_client().get_object(Bucket=get_user_data_export_bucket(), Key=filename)
+    except ClientError as e:
+        if get_error_code(e) in ("NoSuchKey", "NoSuchBucket", "404"):
             raise APINotFound("Export not found")
         current_app.logger.error("Error while downloading user data export: %s", filename, exc_info=True)
         raise APIInternalServerError("Error while downloading export, please try again later.")
 
+    body = archive["Body"]
+
     def stream_archive():
         try:
-            yield from archive.stream(STREAM_CHUNK_SIZE)
+            yield from body.iter_chunks(STREAM_CHUNK_SIZE)
         finally:
-            archive.close()
-            archive.release_conn()
+            body.close()
 
     headers = Headers()
     headers.set("Content-Disposition", "attachment", **content_disposition_names(filename))
-    content_length = archive.headers.get("Content-Length")
+    content_length = archive.get("ContentLength")
     if content_length is not None:
-        headers.set("Content-Length", content_length)
+        headers.set("Content-Length", str(content_length))
 
     return Response(stream_archive(), mimetype="application/zip", headers=headers)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ pandas==2.3.3
 pyarrow==23.0.1
 more-itertools==10.8.0
 kombu==5.6.2
+minio==7.2.20
 itsdangerous==2.2.0
 urllib3==2.7.0
 orjson==3.11.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pandas==2.3.3
 pyarrow==23.0.1
 more-itertools==10.8.0
 kombu==5.6.2
-minio==7.2.20
+boto3==1.43.83
 itsdangerous==2.2.0
 urllib3==2.7.0
 orjson==3.11.6

--- a/test.sh
+++ b/test.sh
@@ -84,11 +84,17 @@ function docker_compose_run_spark {
 }
 
 function build_unit_containers {
-    invoke_docker_compose build listenbrainz
+    invoke_docker_compose build listenbrainz garage
 }
 
 function bring_up_unit_db {
-    invoke_docker_compose up -d lb_db redis rabbitmq couchdb timescale_writer background_tasks websockets
+    invoke_docker_compose up -d lb_db redis rabbitmq couchdb timescale_writer websockets
+}
+
+function bring_up_background_tasks {
+    # The background tasks processor exits when the tables it polls do not exist, so it can only be
+    # started once unit_setup has created the schema.
+    invoke_docker_compose up -d background_tasks
 }
 
 function unit_setup {
@@ -242,6 +248,7 @@ if [ "$1" == "-u" ]; then
         echo "Bringing up DB"
         bring_up_unit_db
         unit_setup
+        bring_up_background_tasks
     fi
     exit 0
 fi
@@ -253,6 +260,7 @@ if [ $DB_RUNNING -eq 1 ] ; then
     build_unit_containers
     bring_up_unit_db
     unit_setup
+    bring_up_background_tasks
     echo "Running tests"
     docker_compose_run listenbrainz pytest "$@"
     RET=$?


### PR DESCRIPTION
User data exports were written to a directory shared between the webserver and the background tasks container through the USER_DATA_EXPORT_BASE_DIR volume, which tied the two to the same host. They are uploaded to the garage bucket named by GARAGE_USER_DATA_EXPORT_BUCKET now and streamed back to the user from there, so the containers no longer need shared storage.

* [X] I have run the code and manually tested the changes on test.listenbrainz.org.
* [X] I have used AI in this PR for tests, reviewing the code changes and applying certain fixes based on the automated review.