### PR TITLE
Add documentation about building the documentation

### DIFF
--- a/docs/developers/docs.rst
+++ b/docs/developers/docs.rst
@@ -1,0 +1,27 @@
+This Documentation
+==================
+
+The ListenBrainz documentation lives in the :code:`docs` directory and is built
+with Sphinx. To run it locally, install the documentation dependencies and build
+the HTML output from that directory:
+
+.. code-block:: console
+
+    cd listenbrainz-server/docs
+    pip install -r requirements.txt
+    make clean html
+
+.. note::
+
+    The documentation build requires Python 3.11 or newer.
+
+The built documentation is written to :code:`docs/_build/html`. To browse it
+locally, you can open the HTML files directly with your browser.
+
+Alternatively you can serve that directory with Python's built-in HTTP server:
+
+.. code-block:: console
+
+    python -m http.server --directory _build/html 8000
+
+Then open http://localhost:8000 in a browser.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Contents
    developers/architecture
    developers/spark-architecture
    developers/mapping
+   developers/docs
    developers/commands
    developers/troubleshooting
 


### PR DESCRIPTION
# Problem
There are a couple of lines in the readme but there should be some in the developer docs for those who look for it

# Solution
Add some docas about building docs...
I added a note about python version because the slightly older one I had installed caused me some issues with dependencies.

* [x] I have run the code and manually tested the changes

# AI usage

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)

<img width="1120" height="852" alt="image" src="https://github.com/user-attachments/assets/da5acee4-5efd-4234-b1c1-7bfb04fcbba2" />
