### PR TITLE
fix: update pinned recording MBID when user submits manual mapping (LB-1985)

### DIFF
--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -269,6 +269,32 @@ def get_pin_count_for_user(db_conn, user_id: int) -> int:
     return count
 
 
+def update_recording_mbid_for_msid(db_conn, user_id: int, recording_msid: str, recording_mbid: str) -> int:
+    """ Updates recording_mbid on all pins for the user that match the given recording_msid.
+
+        Args:
+            db_conn: Database connection
+            user_id: the row ID of the user
+            recording_msid: the recording MSID to match
+            recording_mbid: the new recording MBID to set
+
+        Returns:
+            Number of rows updated
+    """
+    result = db_conn.execute(sqlalchemy.text("""
+        UPDATE pinned_recording
+           SET recording_mbid = :recording_mbid
+         WHERE user_id = :user_id
+           AND recording_msid = :recording_msid
+    """), {
+        "user_id": user_id,
+        "recording_msid": recording_msid,
+        "recording_mbid": recording_mbid,
+    })
+    db_conn.commit()
+    return result.rowcount
+
+
 def update_comment(db_conn, row_id: int, blurb_content: str) -> bool:
     """ Updates the comment of the user of the current pinned recording
 

--- a/listenbrainz/db/pinned_recording.py
+++ b/listenbrainz/db/pinned_recording.py
@@ -269,7 +269,7 @@ def get_pin_count_for_user(db_conn, user_id: int) -> int:
     return count
 
 
-def update_recording_mbid_for_msid(db_conn, user_id: int, recording_msid: str, recording_mbid: str) -> int:
+def update_pinned_recording_mbid_for_msid(db_conn, user_id: int, recording_msid: str, recording_mbid: str) -> int:
     """ Updates recording_mbid on all pins for the user that match the given recording_msid.
 
         Args:

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -4,6 +4,7 @@ from datasethoster import RequestSource
 from flask import Blueprint, request, jsonify, current_app
 
 from listenbrainz.db.mbid_manual_mapping import create_mbid_manual_mapping, get_mbid_manual_mapping
+from listenbrainz.db.pinned_recording import update_recording_mbid_for_msid
 from listenbrainz.db.metadata import get_metadata_for_recording, get_metadata_for_artist, get_metadata_for_release_group
 from listenbrainz.db.model.mbid_manual_mapping import MbidManualMapping
 from listenbrainz.labs_api.labs.api.artist_credit_recording_lookup import ArtistCreditRecordingLookupQuery, \
@@ -12,7 +13,7 @@ from listenbrainz.labs_api.labs.api.artist_credit_recording_release_lookup impor
     ArtistCreditRecordingReleaseLookupQuery, ArtistCreditRecordingReleaseLookupInput
 from listenbrainz.labs_api.labs.api.mbid_mapping import MBIDMappingQuery, MBIDMappingInput
 from listenbrainz.mbid_mapping_writer.mbid_mapper import MBIDMapper
-from listenbrainz.webserver import ts_conn
+from listenbrainz.webserver import db_conn, ts_conn
 from listenbrainz.webserver.listens_cache import invalidate_user_listen_caches
 from listenbrainz.webserver.decorators import cache_public, crossdomain
 from listenbrainz.webserver.errors import APIBadRequest, APIInternalServerError
@@ -524,6 +525,7 @@ def submit_manual_mapping():
     )
 
     create_mbid_manual_mapping(ts_conn, mapping)
+    update_recording_mbid_for_msid(db_conn, user["id"], recording_msid, recording_mbid)
 
     invalidate_user_listen_caches(user["id"])
 

--- a/listenbrainz/webserver/views/metadata_api.py
+++ b/listenbrainz/webserver/views/metadata_api.py
@@ -4,7 +4,7 @@ from datasethoster import RequestSource
 from flask import Blueprint, request, jsonify, current_app
 
 from listenbrainz.db.mbid_manual_mapping import create_mbid_manual_mapping, get_mbid_manual_mapping
-from listenbrainz.db.pinned_recording import update_recording_mbid_for_msid
+from listenbrainz.db.pinned_recording import update_pinned_recording_mbid_for_msid
 from listenbrainz.db.metadata import get_metadata_for_recording, get_metadata_for_artist, get_metadata_for_release_group
 from listenbrainz.db.model.mbid_manual_mapping import MbidManualMapping
 from listenbrainz.labs_api.labs.api.artist_credit_recording_lookup import ArtistCreditRecordingLookupQuery, \
@@ -525,7 +525,7 @@ def submit_manual_mapping():
     )
 
     create_mbid_manual_mapping(ts_conn, mapping)
-    update_recording_mbid_for_msid(db_conn, user["id"], recording_msid, recording_mbid)
+    update_pinned_recording_mbid_for_msid(db_conn, user["id"], recording_msid, recording_mbid)
 
     invalidate_user_listen_caches(user["id"])
 


### PR DESCRIPTION
# Problem

LB-1985

When MusicBrainz merges two recordings, any pinned recording that referenced the old recording MBID becomes stale. The pin still displays but shows an unlinked state because the MBID it stores no longer exists in MusicBrainz.

When a user tries to fix this by clicking "Link with MusicBrainz" and selecting the correct recording, the `submit_manual_mapping` endpoint updates the `mbid_manual_mapping` table, but the `pinned_recording` table has its own `recording_mbid` column that is not updated. On page refresh, the pin still shows the old invalid MBID.

# Solution

- Add `update_recording_mbid_for_msid()` to `listenbrainz/db/pinned_recording.py` that updates `recording_mbid` on all pins for a user matching a given `recording_msid`
- Call it from `submit_manual_mapping()` in `metadata_api.py` after creating the manual mapping, so relinking a recording also fixes any matching pins

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

# Action

None needed.