### PR TITLE
fix: add timeouts to remaining external HTTP requests

### DIFF
--- a/listenbrainz/db/couchdb.py
+++ b/listenbrainz/db/couchdb.py
@@ -68,7 +68,7 @@ def create_database(database: str):
          database: the database's name
     """
     databases_url = _get_database_url(database)
-    response = requests.put(databases_url)
+    response = requests.put(databases_url, timeout=30)
     response.raise_for_status()
 
 
@@ -83,7 +83,7 @@ def list_databases(stat_prefix: str) -> list[str]:
     starts with the given stat prefix.
     """
     databases_url = f"{get_base_url()}/_all_dbs"
-    response = requests.get(databases_url)
+    response = requests.get(databases_url, timeout=30)
     response.raise_for_status()
     all_databases = response.json()
 
@@ -120,7 +120,7 @@ def delete_database(prefix: str):
         if check_database_lock(database):
             retained.append(database)
         else:
-            response = requests.delete(_get_database_url(database))
+            response = requests.delete(_get_database_url(database), timeout=30)
             response.raise_for_status()
             deleted.append(database)
 
@@ -142,7 +142,7 @@ def fetch_data(prefix: str, user_id: int):
 
     for database in databases:
         document_url = f"{_get_database_url(database)}/{user_id}"
-        response = requests.get(document_url)
+        response = requests.get(document_url, timeout=30)
         if response.status_code == 404:
             continue
         response.raise_for_status()
@@ -158,7 +158,7 @@ def fetch_exact_data(database: str, document_id: str):
          document_id: the document_id to retrieve data for
     """
     document_url = f"{_get_database_url(database)}/{document_id}"
-    response = requests.get(document_url)
+    response = requests.get(document_url, timeout=30)
     if response.status_code == 404:
         return None
     return response.json()
@@ -171,7 +171,7 @@ def insert_data(database: str, data: list[dict]):
 
     with start_span(op="http", name="insert docs in couchdb using api"):
         couchdb_url = f"{_get_database_url(database)}/_bulk_docs"
-        response = requests.post(couchdb_url, data=docs, headers={"Content-Type": "application/json"})
+        response = requests.post(couchdb_url, data=docs, headers={"Content-Type": "application/json"}, timeout=30)
         response.raise_for_status()
 
     with start_span(op="deserializing", name="checking response for conflicts"):
@@ -189,7 +189,8 @@ def insert_data(database: str, data: list[dict]):
         response = requests.post(
             f"{_get_database_url(database)}/_bulk_get",
             data=conflict_docs,
-            headers={"Content-Type": "application/json"}
+            headers={"Content-Type": "application/json"},
+            timeout=30,
         )
         response.raise_for_status()
 
@@ -209,7 +210,7 @@ def insert_data(database: str, data: list[dict]):
         docs_to_update = orjson.dumps({"docs": docs_to_update})
 
     with start_span(op="http", name="retry updating conflicts in database"):
-        response = requests.post(couchdb_url, data=docs_to_update, headers={"Content-Type": "application/json"})
+        response = requests.post(couchdb_url, data=docs_to_update, headers={"Content-Type": "application/json"}, timeout=30)
         response.raise_for_status()
 
 
@@ -234,11 +235,11 @@ def delete_data(database: str, doc_id: int | str):
          doc_id: the id of the document to delete
     """
     document_url = f"{_get_database_url(database)}/{doc_id}"
-    response = requests.head(document_url)
+    response = requests.head(document_url, timeout=30)
     response.raise_for_status()
 
     rev = json.loads(response.headers.get("ETag"))
-    response = requests.delete(document_url, params={"rev": rev})
+    response = requests.delete(document_url, params={"rev": rev}, timeout=30)
     response.raise_for_status()
 
 
@@ -247,7 +248,7 @@ def check_database_lock(database: str):
      DATABASE_LOCK_FILE. A database is usually locked only during dumps.
     """
     url = f"{_get_database_url(database)}/{DATABASE_LOCK_FILE}"
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
     return response.status_code == 200
 
 
@@ -260,7 +261,7 @@ def lock_database(database: str):
     """
     document_url = f"{_get_database_url(database)}/{DATABASE_LOCK_FILE}"
     # TODO: figure out why PUT works but POST fails with a weird referer header error
-    response = requests.put(document_url, json={})
+    response = requests.put(document_url, json={}, timeout=30)
     response.raise_for_status()
 
 
@@ -312,7 +313,7 @@ def dump_database(prefix: str, fp: BinaryIO):
     try:
         with _get_requests_session() as http:
             database_url = _get_database_url(database)
-            response = http.get(database_url)
+            response = http.get(database_url, timeout=120)
             total_docs = response.json()["doc_count"]
 
             all_docs_url = f"{database_url}/_all_docs"
@@ -327,7 +328,7 @@ def dump_database(prefix: str, fp: BinaryIO):
                 if startkey_docid is not None:
                     params["startkey_docid"] = startkey_docid
                     params["skip"] = 1
-                response = http.get(all_docs_url, params=params)
+                response = http.get(all_docs_url, params=params, timeout=120)
 
                 rows = orjson.loads(response.content)["rows"]
                 for row in rows:

--- a/listenbrainz/misc/submit_release.py
+++ b/listenbrainz/misc/submit_release.py
@@ -34,7 +34,8 @@ def submit_listen(url, listen_type, payload, token):
         },
         headers={
             "Authorization": "Token {0}".format(token)
-        }
+        },
+        timeout=10,
     )
     response.raise_for_status()
 
@@ -56,9 +57,10 @@ def submit_release_impl(token, release, url):
     """
 
     resp = requests.get(
-        "https://musicbrainz.org/ws/2/release/%s?inc=recordings+artists&fmt=json" % release)
+        "https://musicbrainz.org/ws/2/release/%s?inc=recordings+artists&fmt=json" % release,
+        timeout=10)
     if resp.status_code != 200:
-        print("Failed to fetch album: %d" % resp.code)
+        print("Failed to fetch album: %d" % resp.status_code)
         sys.exit(-1)
 
     jdata = resp.json()

--- a/listenbrainz/webserver/views/api_tools.py
+++ b/listenbrainz/webserver/views/api_tools.py
@@ -550,7 +550,8 @@ def validate_auth_header(*, optional: bool = False, fetch_email: bool = False, s
                     "client_secret": current_app.config["OAUTH_CLIENT_SECRET"],
                     "token": auth_token,
                     "token_type_hint": "access_token",
-                }
+                },
+                timeout=10,
             )
             token = response.json()
         except requests.exceptions.RequestException:

--- a/listenbrainz_spark/dump/__init__.py
+++ b/listenbrainz_spark/dump/__init__.py
@@ -115,6 +115,6 @@ class ListenbrainzDumpLoader(ABC):
     def check_dump_type(self, dump_id: int):
         """ Query ListenBrainz dump info API to check the type of the dump with the given dump ID """
         url = f"{self.get_api_base_url()}/1/status/get-dump-info"
-        response = requests.get(url, params={"id": dump_id})
+        response = requests.get(url, params={"id": dump_id}, timeout=10)
         response.raise_for_status()
         return DumpType(response.json()["dump_type"])

--- a/listenbrainz_spark/fresh_releases/fresh_releases.py
+++ b/listenbrainz_spark/fresh_releases/fresh_releases.py
@@ -18,7 +18,7 @@ FRESH_RELEASES_ENDPOINT = "https://api.listenbrainz.org/1/explore/fresh-releases
 
 
 def load_all_releases():
-    response = requests.get(FRESH_RELEASES_ENDPOINT)
+    response = requests.get(FRESH_RELEASES_ENDPOINT, timeout=10)
     data = response.json()
 
     releases = []

--- a/mbid_mapping/cron_job.py
+++ b/mbid_mapping/cron_job.py
@@ -25,7 +25,8 @@ def post_telegram_message(msg):
                           data={
                               'chat_id': config.SERVICE_MONITOR_TELEGRAM_CHAT_ID,
                               'text': msg
-                          })
+                          },
+                          timeout=10)
         if r.status_code == 200:
             return
 

--- a/mbid_mapping/mapping/release_colors.py
+++ b/mbid_mapping/mapping/release_colors.py
@@ -76,7 +76,7 @@ def process_row(row):
         }
         release_mbid, caa_id = row["release_mbid"], row["caa_id"]
         url = f"https://archive.org/download/mbid-{release_mbid}/mbid-{release_mbid}-{caa_id}_thumb250.jpg"
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, timeout=30)
         if r.status_code == 200:
             filename = "/tmp/release-colors-%s.img" % get_ident()
             with open(filename, 'wb') as f:


### PR DESCRIPTION
# Problem

A previous fix added timeouts to external API requests, but several other places still make HTTP requests without a timeout.

If a remote server hangs or becomes unresponsive, these requests can block indefinitely, potentially leaving the caller waiting forever.

# Solution

Added timeouts to the remaining HTTP calls in:

* `listenbrainz/db/couchdb.py`
* `listenbrainz/misc/submit_release.py`
* `listenbrainz/webserver/views/api_tools.py`
* `listenbrainz_spark/dump/__init__.py`
* `listenbrainz_spark/fresh_releases/fresh_releases.py`
* `mbid_mapping/cron_job.py`
* `mbid_mapping/mapping/release_colors.py`

Also fixed `resp.code` in `submit_release.py` to `resp.status_code`. The previous attribute did not exist on the response object and raised an `AttributeError` when a release could not be fetched from MusicBrainz.

These changes ensure the remaining external HTTP requests cannot block indefinitely and correctly handle the response status code when fetching releases.

# Testing

I have run the relevant tests and manually verified the changes.

# AI usage

* [ ] I did not use any AI

* [x] I have used AI in this PR (add more details below)

* [x] I used AI tools for communication

* [x] I used AI tools for coding

* [x] I understand all the changes made in this PR

Used AI for code assistance and review
