### PR TITLE
fix: Skip non-track entries in Spotify import and replace bare except (LB-2021)

### DIFF
--- a/listenbrainz/background/listens_importer/spotify.py
+++ b/listenbrainz/background/listens_importer/spotify.py
@@ -68,15 +68,22 @@ class SpotifyListensImporter(ZipBaseListensImporter):
                         self.skipped_short_plays_count += 1
                     continue
 
+                # Skip non-music entries (podcasts, videos, etc.) where
+                # spotify_track_uri is absent or not a track URI.
+                spotify_track_uri = item.get("spotify_track_uri")
+                if not spotify_track_uri or not spotify_track_uri.startswith("spotify:track:"):
+                    continue
+
                 items.append({
                     "artist_name": item.get("master_metadata_album_artist_name"),
                     "track_name": item.get("master_metadata_track_name"),
                     "timestamp": int(item["timestamp"].timestamp()),
-                    "spotify_track_id": item["spotify_track_uri"].split(":")[2],
+                    "spotify_track_id": spotify_track_uri.split(":")[2],
                     "ms_played": item.get("ms_played"),
                     "release_name": item.get("master_metadata_album_name", ""),
                 })
-            except:
+            except Exception:
+                current_app.logger.warning("Failed to parse Spotify listen entry, skipping: %s", item, exc_info=True)
                 continue
 
         if not items:


### PR DESCRIPTION
# Problem

LB-2021: Spotify import 500s when video/podcast data is included.

When users import their Spotify Extended Streaming History, the ZIP files can contain entries for podcasts and video content where `spotify_track_uri` is `None` (or a non-track URI like `spotify:episode:...`). In `parse_listen_batch`, line 75 directly accesses `item["spotify_track_uri"].split(":")[2]`, which crashes with an `AttributeError` when the value is `None`.

Currently, a **bare `except:`** on line 79 silently catches this (and every other exception, including `SystemExit` and `KeyboardInterrupt`), hiding the real problem without any logging. This makes debugging import failures nearly impossible and is a [well-known Python anti-pattern](https://docs.python.org/3/howto/doanddont.html#except).

# Solution

**1. Explicit filtering of non-track entries** — Before attempting to parse the URI, we now check if `spotify_track_uri` is present and starts with `"spotify:track:"`. Podcast (`spotify:episode:`) and video entries are cleanly skipped rather than crashing into the except block.

**2. Replace bare `except:` with `except Exception`** — The catch-all is narrowed so it no longer swallows `SystemExit`/`KeyboardInterrupt`. A `logger.warning` with `exc_info=True` is added so unexpected parse failures are actually logged instead of silently dropped.

**3. Use the already-fetched variable** — `spotify_track_uri` is stored in a local variable and reused for `split()`, avoiding the redundant dictionary lookup.

### Files changed

- `listenbrainz/background/listens_importer/spotify.py`

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR
