### PR TITLE
Store user data imports in garage

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -240,10 +240,6 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 # Size is in bytes
 MAX_CONTENT_LENGTH = 200 * 1024 * 1024 + 10  # 200MB plus some buffer
 
-# Specify the upload folder where user uploaded files for import will be stored
-# The path must be absolute path
-UPLOAD_FOLDER = '''{{template "KEY" "upload_folder"}}'''
-
 
 API_URL = '''{{template "KEY" "api_url"}}'''
 LASTFM_PROXY_URL = '''{{template "KEY" "lastfm_proxy_url"}}'''
@@ -342,6 +338,7 @@ GARAGE_SECRET_KEY = '''{{template "KEY" "garage/secret_key"}}'''
 GARAGE_SECURE = False
 GARAGE_REGION = "garage"
 GARAGE_USER_DATA_EXPORT_BUCKET = '''{{template "KEY" "garage/user_data_export_bucket"}}'''
+GARAGE_USER_DATA_IMPORT_BUCKET = '''{{template "KEY" "garage/user_data_import_bucket"}}'''
 
 # Navidrome configuration
 # Set to a base64 encoded key for encryption/decryption of passwords.

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -30,7 +30,7 @@ services:
     environment:
       GARAGE_ACCESS_KEY: GK1e5b4c3a2d0f9e8b7a6c5d40
       GARAGE_SECRET_KEY: 0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0
-      GARAGE_BUCKETS: listenbrainz-user-data-exports
+      GARAGE_BUCKETS: listenbrainz-user-data-exports listenbrainz-user-data-imports
     healthcheck:
       # the S3 api port is open long before the layout is applied and the buckets exist,
       # the entrypoint only writes this file once provisioning is complete

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     environment:
       GARAGE_ACCESS_KEY: GK1e5b4c3a2d0f9e8b7a6c5d40
       GARAGE_SECRET_KEY: 0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0
-      GARAGE_BUCKETS: listenbrainz-user-data-exports
+      GARAGE_BUCKETS: listenbrainz-user-data-exports listenbrainz-user-data-imports
     volumes:
       - garage:/var/lib/garage:z
     ports:

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -280,10 +280,6 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
         current_app.logger.error("No export with export_id: %s, skipping.", metadata["export_id"])
         return
 
-    client = get_garage_client()
-    bucket = get_user_data_export_bucket()
-    ensure_bucket(client, bucket)
-
     export_id = export.id
     try:
         client = get_garage_client()

--- a/listenbrainz/background/export.py
+++ b/listenbrainz/background/export.py
@@ -280,6 +280,10 @@ def export_user(db_conn, ts_conn, user_id: int, metadata):
         current_app.logger.error("No export with export_id: %s, skipping.", metadata["export_id"])
         return
 
+    client = get_garage_client()
+    bucket = get_user_data_export_bucket()
+    ensure_bucket(client, bucket)
+
     export_id = export.id
     try:
         client = get_garage_client()

--- a/listenbrainz/background/listens_importer/base.py
+++ b/listenbrainz/background/listens_importer/base.py
@@ -11,7 +11,8 @@ from flask import current_app
 from sqlalchemy.sql.expression import text
 from werkzeug.exceptions import InternalServerError, ServiceUnavailable
 
-from listenbrainz.background.listens_importer.storage import delete_import_file, download_import_file
+from listenbrainz.background.listens_importer.storage import delete_import_file, download_import_file, \
+    FINISHED_STATUSES
 from listenbrainz.db import user as db_user
 from listenbrainz.domain.external_service import ExternalServiceError
 from listenbrainz.webserver.errors import ImportFailedError, ListenValidationError
@@ -64,7 +65,7 @@ class BaseListensImporter(ABC):
 
         import_id = import_task["id"]
         metadata = import_task["metadata"]
-        if metadata["status"] in {"cancelled", "failed"}:
+        if metadata["status"] in FINISHED_STATUSES:
             # the import is not going to run, its file is of no use to anyone any more
             delete_import_file(import_task["file_path"])
             return

--- a/listenbrainz/background/listens_importer/base.py
+++ b/listenbrainz/background/listens_importer/base.py
@@ -1,9 +1,9 @@
 import json
+import tempfile
 import zipfile
 from abc import ABC, abstractmethod
 from datetime import datetime
 from io import TextIOWrapper
-from pathlib import Path
 from typing import Any, Iterator
 from zipfile import ZipFile
 
@@ -11,6 +11,7 @@ from flask import current_app
 from sqlalchemy.sql.expression import text
 from werkzeug.exceptions import InternalServerError, ServiceUnavailable
 
+from listenbrainz.background.listens_importer.storage import delete_import_file, download_import_file
 from listenbrainz.db import user as db_user
 from listenbrainz.domain.external_service import ExternalServiceError
 from listenbrainz.webserver.errors import ImportFailedError, ListenValidationError
@@ -64,27 +65,35 @@ class BaseListensImporter(ABC):
         import_id = import_task["id"]
         metadata = import_task["metadata"]
         if metadata["status"] in {"cancelled", "failed"}:
+            # the import is not going to run, its file is of no use to anyone any more
+            delete_import_file(import_task["file_path"])
             return
 
         self.update_import_progress_and_status(import_id, "in_progress", "Importing user listens")
 
+        object_name = import_task["file_path"]
         try:
-            validation_stats = self._initialize_validation_stats()
-            self.persist_validation_stats(import_id, validation_stats)
-            for batch in self.process_import_file(import_task):
-                validated_listens, validation_stats = self.parse_and_validate_listen_items(
-                    batch,
-                    validation_stats,
-                )
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                # the importers seek around in the uploaded file, so it is downloaded to a
+                # temporary file instead of being streamed out of garage
+                local_task = dict(import_task, file_path=download_import_file(object_name, tmp_dir))
 
-                self.submit_listens(validated_listens, user_id, user["musicbrainz_id"], import_id)
+                validation_stats = self._initialize_validation_stats()
                 self.persist_validation_stats(import_id, validation_stats)
+                for batch in self.process_import_file(local_task):
+                    validated_listens, validation_stats = self.parse_and_validate_listen_items(
+                        batch,
+                        validation_stats,
+                    )
+
+                    self.submit_listens(validated_listens, user_id, user["musicbrainz_id"], import_id)
+                    self.persist_validation_stats(import_id, validation_stats)
 
             self.update_import_progress_and_status(import_id, "completed", "Import completed!")
         except Exception as e:
             self.update_import_progress_and_status(import_id, "failed", str(e))
         finally:
-            Path(import_task["file_path"]).unlink(missing_ok=True)
+            delete_import_file(object_name)
 
     @abstractmethod
     def process_import_file(self, import_task: dict[str, Any]) -> Iterator[list[dict[str, Any]]]:

--- a/listenbrainz/background/listens_importer/storage.py
+++ b/listenbrainz/background/listens_importer/storage.py
@@ -1,0 +1,102 @@
+""" Storage of the files users upload to import their listens.
+
+The webserver uploads the file to the import bucket in garage and the background tasks
+container downloads it from there when it runs the import, so that the two do not need a
+shared directory.
+"""
+import os
+from datetime import datetime, timedelta, timezone
+
+from botocore.exceptions import BotoCoreError, ClientError
+from flask import current_app
+from sqlalchemy import text
+
+from listenbrainz.garage import delete_objects, ensure_bucket, get_garage_client, \
+    get_user_data_import_bucket, list_objects
+
+# statuses of the imports that have not run yet and whose file is therefore still needed
+PENDING_STATUSES = ("waiting", "in_progress")
+# the file is uploaded before the import row it belongs to is committed, a file that has only
+# just been uploaded cannot be told apart from one whose row is still on its way
+IMPORT_FILE_MIN_AGE = timedelta(days=1)
+
+
+def object_name_for(file_path: str) -> str:
+    """ Get the object name of the file recorded for an import.
+
+    Imports created before the uploaded files moved to garage recorded the full path of the
+    file on disk. migrate_user_data_imports rewrites those to the object name, but an import
+    queued before the migration ran may still be picked up with the old value, and the file is
+    stored under its basename either way.
+    """
+    return os.path.basename(file_path)
+
+
+def upload_import_file(object_name: str, uploaded_file):
+    """ Upload the file the user submitted for an import to garage. """
+    client = get_garage_client()
+    bucket = get_user_data_import_bucket()
+    ensure_bucket(client, bucket)
+
+    extra_args = {"ContentType": uploaded_file.mimetype} if uploaded_file.mimetype else None
+    # upload_fileobj reads the stream in chunks and uses a multipart upload for large files,
+    # so the file is never buffered in memory in its entirety
+    client.upload_fileobj(uploaded_file.stream, bucket, object_name, ExtraArgs=extra_args)
+
+
+def download_import_file(object_name: str, directory: str) -> str:
+    """ Download the file uploaded for an import into the given directory, returning its path.
+
+    The importers seek around in the file, so it cannot be streamed out of garage.
+    """
+    object_name = object_name_for(object_name)
+    local_path = os.path.join(directory, object_name)
+    get_garage_client().download_file(get_user_data_import_bucket(), object_name, local_path)
+    return local_path
+
+
+def delete_import_file(object_name: str):
+    """ Remove the file uploaded for an import from garage.
+
+    The file is of no use once the import has run or been cancelled. Failing to delete it must
+    not fail the caller, the import it belongs to is already gone.
+    """
+    if not object_name:
+        return
+    try:
+        get_garage_client().delete_object(
+            Bucket=get_user_data_import_bucket(), Key=object_name_for(object_name)
+        )
+    except (ClientError, BotoCoreError):
+        current_app.logger.error("Error while deleting import file: %s", object_name, exc_info=True)
+
+
+def cleanup_import_files(db_conn):
+    """ Delete the files of imports that are never going to run from garage.
+
+    The importer deletes the file of an import as soon as it is done with it, but a file is
+    left behind whenever it does not get that far: the import was cancelled or had already
+    failed when the task ran, or the row the upload belongs to was never committed.
+    """
+    result = db_conn.execute(text("""
+        SELECT file_path
+          FROM user_data_import
+         WHERE metadata->>'status' = ANY(:statuses)
+           AND file_path IS NOT NULL
+    """), {"statuses": list(PENDING_STATUSES)})
+    files_to_keep = {object_name_for(row.file_path) for row in result}
+
+    client = get_garage_client()
+    bucket = get_user_data_import_bucket()
+    ensure_bucket(client, bucket)
+
+    cutoff = datetime.now(timezone.utc) - IMPORT_FILE_MIN_AGE
+    objects_to_delete = []
+    for obj in list_objects(client, bucket):
+        if obj["Key"] in files_to_keep or obj["LastModified"] > cutoff:
+            continue
+        current_app.logger.info("Removing import file: %s", obj["Key"])
+        objects_to_delete.append(obj["Key"])
+
+    for error in delete_objects(client, bucket, objects_to_delete):
+        current_app.logger.error("Failed to remove import file %s: %s", error.get("Key"), error.get("Message"))

--- a/listenbrainz/background/listens_importer/storage.py
+++ b/listenbrainz/background/listens_importer/storage.py
@@ -14,8 +14,9 @@ from sqlalchemy import text
 from listenbrainz.garage import delete_objects, ensure_bucket, get_garage_client, \
     get_user_data_import_bucket, list_objects
 
-# statuses of the imports that have not run yet and whose file is therefore still needed
-PENDING_STATUSES = ("waiting", "in_progress")
+# statuses of the imports that will not run again and whose file is therefore of no further use,
+# an import in any other status may still need its file
+FINISHED_STATUSES = ("completed", "cancelled", "failed")
 # the file is uploaded before the import row it belongs to is committed, a file that has only
 # just been uploaded cannot be told apart from one whose row is still on its way
 IMPORT_FILE_MIN_AGE = timedelta(days=1)
@@ -81,9 +82,9 @@ def cleanup_import_files(db_conn):
     result = db_conn.execute(text("""
         SELECT file_path
           FROM user_data_import
-         WHERE metadata->>'status' = ANY(:statuses)
+         WHERE metadata->>'status' != ALL(:statuses)
            AND file_path IS NOT NULL
-    """), {"statuses": list(PENDING_STATUSES)})
+    """), {"statuses": list(FINISHED_STATUSES)})
     files_to_keep = {object_name_for(row.file_path) for row in result}
 
     client = get_garage_client()

--- a/listenbrainz/background/migrate_imports.py
+++ b/listenbrainz/background/migrate_imports.py
@@ -6,9 +6,9 @@ in the Garage bucket named by GARAGE_USER_DATA_IMPORT_BUCKET now, with the name 
 generated for the file as the object name.
 
 Only imports that have not run yet still need their file, the importer deletes the file of an
-import as soon as it is done with it. So the files of imports that are waiting or in progress are
-uploaded, everything else in the directory is a leftover that is left alone (or removed with
---delete-source). Imports that are still pending but whose file exists neither in the bucket nor
+import as soon as it is done with it. So the files of imports that have not completed, failed or
+been cancelled are uploaded, everything else in the directory is a leftover that is left alone (or
+removed with --delete-source). Imports that are still pending but whose file exists neither in the bucket nor
 on disk cannot be run, so they are marked as failed and the user is asked to upload the file
 again. Because that is a destructive and irreversible update, it is skipped unless the directory
 actually contained a file of a pending import; pass --mark-missing-failed to do it anyway.
@@ -26,7 +26,7 @@ import click
 from flask import current_app
 from sqlalchemy import text
 
-from listenbrainz.background.listens_importer.storage import PENDING_STATUSES
+from listenbrainz.background.listens_importer.storage import FINISHED_STATUSES
 from listenbrainz.garage import bucket_exists, ensure_bucket, get_garage_client, \
     get_user_data_import_bucket, list_object_names
 
@@ -38,9 +38,9 @@ def get_pending_imports(db_conn) -> dict[str, list[int]]:
     result = db_conn.execute(text("""
         SELECT id, file_path
           FROM user_data_import
-         WHERE metadata->>'status' = ANY(:statuses)
+         WHERE metadata->>'status' != ALL(:statuses)
            AND file_path IS NOT NULL
-    """), {"statuses": list(PENDING_STATUSES)})
+    """), {"statuses": list(FINISHED_STATUSES)})
     imports = defaultdict(list)
     for row in result:
         imports[os.path.basename(row.file_path)].append(row.id)
@@ -137,7 +137,7 @@ def migrate_imports(db_conn, upload_dir: str, delete_source: bool = False, dry_r
                     " Run the migration again to upload it.", path.name
                 )
             else:
-                path.unlink(missing_ok=True)
+                deletable.append(path)
         for path in deletable:
             path.unlink(missing_ok=True)
 

--- a/listenbrainz/background/migrate_imports.py
+++ b/listenbrainz/background/migrate_imports.py
@@ -1,0 +1,174 @@
+""" Migrate the files uploaded for user data imports from the upload directory to Garage.
+
+The files users upload to import their listens used to be written to the directory named by
+UPLOAD_FOLDER, shared between the webserver and the background tasks container. They are stored
+in the Garage bucket named by GARAGE_USER_DATA_IMPORT_BUCKET now, with the name the webserver
+generated for the file as the object name.
+
+Only imports that have not run yet still need their file, the importer deletes the file of an
+import as soon as it is done with it. So the files of imports that are waiting or in progress are
+uploaded, everything else in the directory is a leftover that is left alone (or removed with
+--delete-source). Imports that are still pending but whose file exists neither in the bucket nor
+on disk cannot be run, so they are marked as failed and the user is asked to upload the file
+again. Because that is a destructive and irreversible update, it is skipped unless the directory
+actually contained a file of a pending import; pass --mark-missing-failed to do it anyway.
+
+The file_path column holds the full path of the file on disk for imports created before this
+migration, it is rewritten to the object name at the end of the run (a run that found no file of
+a pending import at all rewrites nothing, its scan cannot be trusted). The importer takes the
+basename of file_path either way, so an import queued before this migration ran still works.
+"""
+import os
+from collections import defaultdict
+from pathlib import Path
+
+import click
+from flask import current_app
+from sqlalchemy import text
+
+from listenbrainz.background.listens_importer.storage import PENDING_STATUSES
+from listenbrainz.garage import bucket_exists, ensure_bucket, get_garage_client, \
+    get_user_data_import_bucket, list_object_names
+
+FILE_MISSING_PROGRESS = "The uploaded file is no longer available, please start the import again."
+
+
+def get_pending_imports(db_conn) -> dict[str, list[int]]:
+    """ Get the import ids of all imports that have not run yet, keyed by the file's object name. """
+    result = db_conn.execute(text("""
+        SELECT id, file_path
+          FROM user_data_import
+         WHERE metadata->>'status' = ANY(:statuses)
+           AND file_path IS NOT NULL
+    """), {"statuses": list(PENDING_STATUSES)})
+    imports = defaultdict(list)
+    for row in result:
+        imports[os.path.basename(row.file_path)].append(row.id)
+    return imports
+
+
+def get_all_import_filenames(db_conn) -> set[str]:
+    """ Get the object names of the files of all imports, whatever their status. """
+    result = db_conn.execute(text("SELECT file_path FROM user_data_import WHERE file_path IS NOT NULL"))
+    return {os.path.basename(row.file_path) for row in result}
+
+
+def mark_imports_failed(db_conn, import_ids: list[int]):
+    """ Mark the given imports as failed so that the user is asked to start a new one. """
+    db_conn.execute(text("""
+        UPDATE user_data_import
+           SET metadata = metadata || jsonb_build_object('status', 'failed', 'progress', :progress)
+         WHERE id = ANY(:import_ids)
+    """), {"import_ids": import_ids, "progress": FILE_MISSING_PROGRESS})
+    db_conn.commit()
+
+
+def rewrite_file_paths(db_conn) -> int:
+    """ Replace the on-disk path of the uploaded file with the object name it is stored under. """
+    result = db_conn.execute(text("""
+        UPDATE user_data_import
+           SET file_path = regexp_replace(file_path, '^.*/', '')
+         WHERE file_path LIKE '%/%'
+    """))
+    db_conn.commit()
+    return result.rowcount
+
+
+def migrate_imports(db_conn, upload_dir: str, delete_source: bool = False, dry_run: bool = False,
+                    mark_missing_failed: bool = False):
+    """ Upload the files in upload_dir to garage and update the database. """
+    source_dir = Path(upload_dir)
+    if not source_dir.is_dir():
+        raise click.ClickException(f"Upload directory does not exist: {upload_dir}")
+
+    client = get_garage_client()
+    bucket = get_user_data_import_bucket()
+    if dry_run:
+        # the bucket is created by ops in production but may not exist yet, a dry run should
+        # still report what it would do instead of erroring out with NoSuchBucket
+        bucket_available = bucket_exists(client, bucket)
+        if not bucket_available:
+            current_app.logger.info("Bucket %s does not exist yet, it would be created", bucket)
+    else:
+        ensure_bucket(client, bucket)
+        bucket_available = True
+
+    pending = get_pending_imports(db_conn)
+    known_filenames = get_all_import_filenames(db_conn)
+    # files that do not need to be uploaded (again), this run's uploads are added as they happen
+    available = set(list_object_names(client, bucket)) if bucket_available else set()
+    files = sorted(path for path in source_dir.iterdir() if path.is_file())
+
+    uploaded_count, skipped_count, finished_count, orphan_count = 0, 0, 0, 0
+    # files that are safe to delete with --delete-source, and the ones that only look that way
+    # because no import exists for them yet
+    deletable, orphans = [], []
+
+    for path in files:
+        if path.name in pending:
+            if path.name in available:
+                current_app.logger.info("%s already exists in garage, not uploading it again", path.name)
+                skipped_count += 1
+            else:
+                current_app.logger.info("Uploading %s (%d bytes)", path.name, path.stat().st_size)
+                if not dry_run:
+                    client.upload_file(str(path), bucket, path.name)
+                available.add(path.name)
+                uploaded_count += 1
+            deletable.append(path)
+        elif path.name in known_filenames:
+            # the importer deletes the file when it is done, this one was left behind by a crash
+            current_app.logger.info("%s belongs to an import that has already run, not migrating it", path.name)
+            finished_count += 1
+            deletable.append(path)
+        else:
+            current_app.logger.info("No import exists for %s, not migrating it", path.name)
+            orphan_count += 1
+            orphans.append(path)
+
+    if delete_source and not dry_run:
+        # the imports were read before the upload started, one created since then turns a file
+        # that looked like an orphan into the file of a pending import that was never uploaded
+        known_now = get_all_import_filenames(db_conn)
+        for path in orphans:
+            if path.name in known_now:
+                current_app.logger.warning(
+                    "An import was created for %s while the migration ran, keeping the file."
+                    " Run the migration again to upload it.", path.name
+                )
+            else:
+                path.unlink(missing_ok=True)
+        for path in deletable:
+            path.unlink(missing_ok=True)
+
+    missing = {filename: ids for filename, ids in pending.items() if filename not in available}
+    # every pending import looks missing if the wrong directory was passed or the upload volume
+    # was not mounted, such a run must not update the table at all
+    empty_scan = bool(missing) and uploaded_count + skipped_count == 0 and not mark_missing_failed
+    marked_failed = 0
+    if missing:
+        if empty_scan:
+            current_app.logger.warning(
+                "%d pending import(s) have no file but no file of a pending import was found in %s"
+                " either. Not marking them as failed, check the directory and re-run with"
+                " --mark-missing-failed if this is expected.",
+                len(missing), upload_dir
+            )
+        else:
+            current_app.logger.info(
+                "Marking %d import(s) as failed, their file is missing: %s",
+                len(missing), ", ".join(sorted(missing))
+            )
+            marked_failed = len(missing)
+            if not dry_run:
+                mark_imports_failed(db_conn, [import_id for ids in missing.values() for import_id in ids])
+
+    rewritten = 0
+    if not dry_run and not empty_scan:
+        rewritten = rewrite_file_paths(db_conn)
+
+    current_app.logger.info(
+        "Migrated %d file(s), %d already in garage, %d of imports that already ran, %d without an import,"
+        " %d import(s) marked failed, %d file path(s) rewritten.",
+        uploaded_count, skipped_count, finished_count, orphan_count, marked_failed, rewritten
+    )

--- a/listenbrainz/config.py.sample
+++ b/listenbrainz/config.py.sample
@@ -158,10 +158,6 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 # Size is in bytes
 MAX_CONTENT_LENGTH = 200 * 1024 * 1024 + 10  # 200MB plus some buffer
 
-# Specify the upload folder where user uploaded files for import will be stored
-# The path must be absolute path
-UPLOAD_FOLDER = "/code/listenbrainz/uploads"
-
 # Set to "https://api.listenbrainz.org" if you want to work on frontend for user statistics
 # without going through the process of generating the stats in local environment. Otherwise,
 # set it to "http://localhost:8100"
@@ -248,6 +244,7 @@ GARAGE_SECRET_KEY = "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d
 GARAGE_SECURE = False
 GARAGE_REGION = "garage"
 GARAGE_USER_DATA_EXPORT_BUCKET = "listenbrainz-user-data-exports"
+GARAGE_USER_DATA_IMPORT_BUCKET = "listenbrainz-user-data-imports"
 
 # Service monitoring -- only needed for MetaBrainz production
 SERVICE_MONITOR_TELEGRAM_BOT_TOKEN = ""

--- a/listenbrainz/db/background.py
+++ b/listenbrainz/db/background.py
@@ -11,11 +11,11 @@ def _with_validation_counts(metadata):
     return metadata
 
 
-def create_import_task(db_conn, user_id, service, from_date, to_date, save_path, filename, user_timezone=None):
+def create_import_task(db_conn, user_id, service, from_date, to_date, file_path, filename, user_timezone=None):
     """ Create a new import task for the specified user.
 
-        Note, this method does not commit so that the API can commit only if the file upload
-        completes successfully.
+        Note, this method does not commit so that the API can delete the uploaded file again
+        if the task cannot be created.
     """
     query = """\
         INSERT INTO user_data_import (user_id, service, from_date, to_date, file_path, metadata)
@@ -26,7 +26,7 @@ def create_import_task(db_conn, user_id, service, from_date, to_date, save_path,
         "service": service,
         "from_date": from_date,
         "to_date": to_date,
-        "file_path": save_path,
+        "file_path": file_path,
         "metadata": json.dumps({
             "status": "waiting",
             "progress": "Your data import will start soon.",

--- a/listenbrainz/garage.py
+++ b/listenbrainz/garage.py
@@ -78,20 +78,21 @@ def get_garage_client() -> BaseClient:
     return client
 
 
+def _get_bucket(config_key: str) -> str:
+    bucket = current_app.config.get(config_key)
+    if not bucket:
+        raise GarageConfigurationError(f"Missing Garage configuration: {config_key}")
+    return bucket
+
+
 def get_user_data_export_bucket() -> str:
     """Get the name of the bucket user data exports are stored in."""
-    bucket = current_app.config.get("GARAGE_USER_DATA_EXPORT_BUCKET")
-    if not bucket:
-        raise GarageConfigurationError("Missing Garage configuration: GARAGE_USER_DATA_EXPORT_BUCKET")
-    return bucket
+    return _get_bucket("GARAGE_USER_DATA_EXPORT_BUCKET")
 
 
 def get_user_data_import_bucket() -> str:
     """Get the name of the bucket the files uploaded for user data imports are stored in."""
-    bucket = current_app.config.get("GARAGE_USER_DATA_IMPORT_BUCKET")
-    if not bucket:
-        raise GarageConfigurationError("Missing Garage configuration: GARAGE_USER_DATA_IMPORT_BUCKET")
-    return bucket
+    return _get_bucket("GARAGE_USER_DATA_IMPORT_BUCKET")
 
 
 def bucket_exists(client: BaseClient, bucket: str) -> bool:
@@ -121,12 +122,17 @@ def ensure_bucket(client: BaseClient, bucket: str):
             raise
 
 
+def list_objects(client: BaseClient, bucket: str) -> list[dict]:
+    """List all the objects in the given bucket, with the metadata the listing reports."""
+    objects = []
+    for page in client.get_paginator("list_objects_v2").paginate(Bucket=bucket):
+        objects.extend(page.get("Contents", []))
+    return objects
+
+
 def list_object_names(client: BaseClient, bucket: str) -> list[str]:
     """List the names of all the objects in the given bucket."""
-    names = []
-    for page in client.get_paginator("list_objects_v2").paginate(Bucket=bucket):
-        names.extend(obj["Key"] for obj in page.get("Contents", []))
-    return names
+    return [obj["Key"] for obj in list_objects(client, bucket)]
 
 
 def delete_objects(client: BaseClient, bucket: str, object_names: Iterable[str]) -> list[dict]:

--- a/listenbrainz/manage.py
+++ b/listenbrainz/manage.py
@@ -8,7 +8,9 @@ import sqlalchemy
 from listenbrainz import db
 from listenbrainz import webserver
 from listenbrainz.background import export
+from listenbrainz.background.listens_importer.storage import cleanup_import_files
 from listenbrainz.background.migrate_exports import migrate_exports
+from listenbrainz.background.migrate_imports import migrate_imports
 from listenbrainz.db import listens as listens_db, timescale as ts, do_not_recommend
 
 from listenbrainz.listenstore.timescale_utils import recalculate_all_user_data as ts_recalculate_all_user_data, \
@@ -466,6 +468,16 @@ def delete_old_user_data_exports():
         app.logger.info("Completed deleting old and expired user data exports")
 
 
+@cli.command()
+def delete_old_user_data_imports():
+    """ Delete the uploaded files of user data imports that are never going to run """
+    app = create_app()
+    with app.app_context():
+        app.logger.info("Deleting leftover user data import files")
+        cleanup_import_files(webserver.db_conn)
+        app.logger.info("Completed deleting leftover user data import files")
+
+
 @cli.command(name="migrate_user_data_exports")
 @click.option("--export-dir", required=True, help="Directory the user data export archives are currently stored in.")
 @click.option("--delete-source", is_flag=True, help="Delete the archives from the directory once they are migrated.")
@@ -481,3 +493,20 @@ def migrate_user_data_exports(export_dir, delete_source, dry_run, mark_missing_f
         migrate_exports(webserver.db_conn, export_dir=export_dir, delete_source=delete_source, dry_run=dry_run,
                         mark_missing_failed=mark_missing_failed)
         app.logger.info("Completed migrating user data exports")
+
+
+@cli.command(name="migrate_user_data_imports")
+@click.option("--upload-dir", required=True, help="Directory the uploaded import files are currently stored in.")
+@click.option("--delete-source", is_flag=True, help="Delete the files from the directory once they are migrated.")
+@click.option("--dry-run", is_flag=True, help="Log what would be migrated without uploading or updating anything.")
+@click.option("--mark-missing-failed", is_flag=True,
+              help="Mark pending imports whose file cannot be found as failed even if the directory"
+                   " contained no file of a pending import at all.")
+def migrate_user_data_imports(upload_dir, delete_source, dry_run, mark_missing_failed):
+    """ Migrate the files uploaded for user data imports from the given directory to garage """
+    app = create_app()
+    with app.app_context():
+        app.logger.info("Migrating user data imports from %s to garage", upload_dir)
+        migrate_imports(webserver.db_conn, upload_dir, delete_source=delete_source, dry_run=dry_run,
+                        mark_missing_failed=mark_missing_failed)
+        app.logger.info("Completed migrating user data imports")

--- a/listenbrainz/rtd_config.py
+++ b/listenbrainz/rtd_config.py
@@ -65,10 +65,6 @@ PLAYING_NOW_MAX_DURATION = 10 * 60
 # Size is in bytes
 MAX_CONTENT_LENGTH = 25 * 1024 * 1024  # 25MB
 
-# Specify the upload folder where all the lastfm-backup will be stored
-# The path must be absolute path
-UPLOAD_FOLDER = "/mnt/user-data-imports"
-
 API_URL = 'https://api.listenbrainz.org'
 LASTFM_PROXY_URL = 'http://0.0.0.0:7080/'
 SPOTIFY_CLIENT_ID = ''

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -1303,19 +1303,26 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertEqual([], os.listdir(upload_dir))
 
     def test_cleanup_import_files_removes_files_of_imports_that_will_not_run(self):
-        """ An import that is cancelled or has failed leaves its uploaded file behind. """
+        """ An import that has run, been cancelled or failed leaves its uploaded file behind. """
         pending_name = "66666666-6666-6666-6666-666666666666-pending.zip"
         failed_name = "77777777-7777-7777-7777-777777777777-failed.zip"
+        completed_name = "88888888-8888-8888-8888-888888888888-completed.zip"
+        cancelled_name = "99999999-9999-9999-9999-999999999999-cancelled.zip"
         self.create_import_row(pending_name)
         self.create_import_row(failed_name, status="failed", service="listenbrainz")
-        self.put_import_file(pending_name)
-        self.put_import_file(failed_name)
+        self.create_import_row(completed_name, status="completed", service="listenbrainz")
+        self.create_import_row(cancelled_name, status="cancelled", service="listenbrainz")
+        for name in (pending_name, failed_name, completed_name, cancelled_name):
+            self.put_import_file(name)
 
         with self.app.app_context():
             # a file that was only just uploaded may belong to an import that is still being
             # created, it is left alone until it is old enough
             cleanup_import_files(db_conn)
-            self.assertEqual({pending_name, failed_name}, set(self.list_import_files()))
+            self.assertEqual(
+                {pending_name, failed_name, completed_name, cancelled_name},
+                set(self.list_import_files())
+            )
 
             with mock.patch("listenbrainz.background.listens_importer.storage.IMPORT_FILE_MIN_AGE",
                             timedelta(minutes=-1)):

--- a/listenbrainz/tests/integration/test_listens_importer.py
+++ b/listenbrainz/tests/integration/test_listens_importer.py
@@ -2,19 +2,24 @@ import io
 import json
 import os.path
 import shutil
+import tempfile
 import time
 import zipfile
 from datetime import datetime, timezone, timedelta
-from pathlib import Path
 from unittest import mock
 
 from sqlalchemy import text
 
 import listenbrainz.db.user as db_user
+from listenbrainz.background.listens_importer.storage import cleanup_import_files
+from listenbrainz.background.migrate_imports import FILE_MISSING_PROGRESS, migrate_imports
 from listenbrainz.db import background
+from listenbrainz.garage import delete_objects, ensure_bucket, get_garage_client, \
+    get_user_data_import_bucket, list_object_names
 from listenbrainz.metadata_cache.spotify.handler import SpotifyCrawlerHandler
 
 from listenbrainz.tests.integration import ListenAPIIntegrationTestCase
+from listenbrainz.webserver import db_conn
 
 
 class ImportTestCase(ListenAPIIntegrationTestCase):
@@ -25,8 +30,29 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         db_user.agree_to_gdpr(self.db_conn, self.user["musicbrainz_id"])
 
     def tearDown(self):
-        shutil.rmtree(self.app.config["UPLOAD_FOLDER"], ignore_errors=True)
+        with self.app.app_context():
+            client, bucket = self.get_import_storage()
+            for error in delete_objects(client, bucket, list_object_names(client, bucket)):
+                self.fail(f"Failed to remove import file {error.get('Key')}: {error.get('Message')}")
         super().tearDown()
+
+    def get_import_storage(self):
+        """ Get the garage client and the bucket the uploaded import files are stored in. """
+        client = get_garage_client()
+        bucket = get_user_data_import_bucket()
+        ensure_bucket(client, bucket)
+        return client, bucket
+
+    def put_import_file(self, object_name, contents=b"import file contents"):
+        """ Put a file in the import bucket, as if the webserver had uploaded it. """
+        with self.app.app_context():
+            client, bucket = self.get_import_storage()
+            client.put_object(Bucket=bucket, Key=object_name, Body=contents)
+
+    def list_import_files(self):
+        with self.app.app_context():
+            client, bucket = self.get_import_storage()
+            return list_object_names(client, bucket)
 
     def create_zip(self, name, items: list[tuple[str, str]]) -> io.BytesIO:
         buffer = io.BytesIO()
@@ -194,7 +220,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             headers={"Authorization": f"Token {self.user['auth_token']}"},
         )
         self.assert200(response)
-        self.assertFalse(Path(orig_data["file_path"]).exists())
+        self.assertEqual([], self.list_import_files())
 
         response = self.client.get(
             self.custom_url_for("import_listens_api_v1.list_import_tasks"),
@@ -320,10 +346,11 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             content_type="multipart/form-data"
         )
         self.assert200(response)
-        self.assertTrue(
-            os.path.abspath(response.json["file_path"])
-            .startswith(self.app.config["UPLOAD_FOLDER"])
-        )
+        # the object name must not be able to escape the bucket's top level
+        object_name = response.json["file_path"]
+        self.assertNotIn("/", object_name)
+        self.assertTrue(object_name.endswith("etc_passwd.zip"), object_name)
+        self.assertEqual([object_name], self.list_import_files())
 
     def test_same_name_file_does_not_override(self):
         from_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -357,10 +384,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         )
         self.assert200(response)
 
-        self.assertEqual(
-            len(list(Path(self.app.config["UPLOAD_FOLDER"]).iterdir())),
-            2
-        )
+        self.assertEqual(2, len(self.list_import_files()))
 
     def test_import_task_auth(self):
         from_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -1058,7 +1082,7 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
             service="foobar",
             from_date=datetime(2021, 1, 1, tzinfo=timezone.utc),
             to_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
-            save_path="xyz.zip",
+            file_path="xyz.zip",
             filename="xyz.zip",
         )
         self.db_conn.commit()
@@ -1197,3 +1221,124 @@ class ImportTestCase(ListenAPIIntegrationTestCase):
         self.assertIn("success_count", metadata)
         self.assertEqual(metadata["attempted_count"], 5)
         self.assertEqual(metadata["success_count"], 3)
+
+
+    def create_import_row(self, file_path, status="waiting", service="spotify"):
+        """ Insert a user data import row directly, as if the file had been uploaded to disk. """
+        result = self.db_conn.execute(text("""
+            INSERT INTO user_data_import (user_id, service, from_date, to_date, file_path, metadata)
+                 VALUES (:user_id, :service, :from_date, :to_date, :file_path, :metadata)
+              RETURNING id
+        """), {
+            "user_id": self.user["id"],
+            "service": service,
+            "from_date": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "to_date": datetime.now(tz=timezone.utc),
+            "file_path": file_path,
+            "metadata": json.dumps({"status": status, "progress": "", "filename": os.path.basename(file_path)}),
+        })
+        self.db_conn.commit()
+        return result.first().id
+
+    def get_import_row(self, import_id):
+        result = self.db_conn.execute(
+            text("SELECT file_path, metadata FROM user_data_import WHERE id = :import_id"),
+            {"import_id": import_id}
+        )
+        return result.first()
+
+    def test_migrate_imports(self):
+        upload_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, upload_dir, True)
+
+        pending_name = "11111111-1111-1111-1111-111111111111-pending.zip"
+        finished_name = "22222222-2222-2222-2222-222222222222-finished.zip"
+        orphan_name = "33333333-3333-3333-3333-333333333333-orphan.zip"
+        missing_name = "44444444-4444-4444-4444-444444444444-missing.zip"
+
+        # the paths of imports created before the migration are absolute paths on disk
+        pending_id = self.create_import_row(os.path.join(upload_dir, pending_name))
+        finished_id = self.create_import_row(
+            os.path.join(upload_dir, finished_name), status="completed", service="listenbrainz"
+        )
+        missing_id = self.create_import_row(os.path.join(upload_dir, missing_name), status="waiting", service="librefm")
+
+        for name in (pending_name, finished_name, orphan_name):
+            with open(os.path.join(upload_dir, name), "wb") as f:
+                f.write(b"contents of " + name.encode())
+
+        with self.app.app_context():
+            client, bucket = self.get_import_storage()
+
+            migrate_imports(db_conn, upload_dir, dry_run=True)
+            self.assertEqual([], self.list_import_files())
+            self.assertEqual("waiting", self.get_import_row(missing_id).metadata["status"])
+            self.assertTrue(self.get_import_row(pending_id).file_path.startswith(upload_dir))
+
+            migrate_imports(db_conn, upload_dir)
+
+            # only the file of the import that has not run yet is uploaded
+            self.assertEqual([pending_name], self.list_import_files())
+            uploaded = client.get_object(Bucket=bucket, Key=pending_name)
+            with uploaded["Body"] as body:
+                self.assertEqual(b"contents of " + pending_name.encode(), body.read())
+
+        # the on disk paths are rewritten to the object names
+        self.assertEqual(pending_name, self.get_import_row(pending_id).file_path)
+        self.assertEqual(finished_name, self.get_import_row(finished_id).file_path)
+
+        # the import whose file is nowhere to be found cannot be run
+        missing = self.get_import_row(missing_id)
+        self.assertEqual("failed", missing.metadata["status"])
+        self.assertEqual(FILE_MISSING_PROGRESS, missing.metadata["progress"])
+        self.assertEqual("waiting", self.get_import_row(pending_id).metadata["status"])
+
+        # source files are kept unless asked otherwise
+        self.assertEqual({pending_name, finished_name, orphan_name}, set(os.listdir(upload_dir)))
+
+        with self.app.app_context():
+            # re-running does not upload again and removes the source files when asked to
+            migrate_imports(db_conn, upload_dir, delete_source=True)
+            self.assertEqual([pending_name], self.list_import_files())
+        self.assertEqual([], os.listdir(upload_dir))
+
+    def test_cleanup_import_files_removes_files_of_imports_that_will_not_run(self):
+        """ An import that is cancelled or has failed leaves its uploaded file behind. """
+        pending_name = "66666666-6666-6666-6666-666666666666-pending.zip"
+        failed_name = "77777777-7777-7777-7777-777777777777-failed.zip"
+        self.create_import_row(pending_name)
+        self.create_import_row(failed_name, status="failed", service="listenbrainz")
+        self.put_import_file(pending_name)
+        self.put_import_file(failed_name)
+
+        with self.app.app_context():
+            # a file that was only just uploaded may belong to an import that is still being
+            # created, it is left alone until it is old enough
+            cleanup_import_files(db_conn)
+            self.assertEqual({pending_name, failed_name}, set(self.list_import_files()))
+
+            with mock.patch("listenbrainz.background.listens_importer.storage.IMPORT_FILE_MIN_AGE",
+                            timedelta(minutes=-1)):
+                cleanup_import_files(db_conn)
+            self.assertEqual([pending_name], self.list_import_files())
+
+    def test_migrate_imports_does_not_fail_imports_when_no_file_was_found(self):
+        """ Pointing the migration at the wrong directory must not fail every pending import. """
+        upload_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, upload_dir, True)
+
+        missing_name = "55555555-5555-5555-5555-555555555555-missing.zip"
+        missing_id = self.create_import_row(os.path.join(upload_dir, missing_name))
+
+        with self.app.app_context():
+            self.get_import_storage()
+
+            migrate_imports(db_conn, upload_dir)
+            self.assertEqual("waiting", self.get_import_row(missing_id).metadata["status"])
+
+            # unless the operator confirms that this is expected
+            migrate_imports(db_conn, upload_dir, mark_missing_failed=True)
+
+        missing = self.get_import_row(missing_id)
+        self.assertEqual("failed", missing.metadata["status"])
+        self.assertEqual(FILE_MISSING_PROGRESS, missing.metadata["progress"])

--- a/listenbrainz/webserver/views/import_listens.py
+++ b/listenbrainz/webserver/views/import_listens.py
@@ -5,10 +5,10 @@ from flask import Blueprint, current_app, jsonify, request
 from psycopg2 import DatabaseError
 from sqlalchemy import text
 from datetime import datetime, timezone
-from pathlib import Path
 
 from werkzeug.utils import secure_filename
 
+from listenbrainz.background.listens_importer.storage import delete_import_file, upload_import_file
 from listenbrainz.db.background import _with_validation_counts
 from listenbrainz.webserver import db_conn
 from listenbrainz.webserver.decorators import web_listenstore_needed, crossdomain
@@ -92,7 +92,6 @@ def create_import_task():
 
     # add a unique ID to the filename to avoid collisions
     saved_filename = str(uuid.uuid4()) + "-" + secure_filename(filename)
-    save_path = os.path.join(current_app.config["UPLOAD_FOLDER"], saved_filename)
 
     try:
         query = """
@@ -107,28 +106,43 @@ def create_import_task():
         check_existing = result.first()
         if check_existing is not None:
             raise APIBadRequest("An import task is already in progress!")
-
-        result = background.create_import_task(
-            db_conn,
-            user_id=user["id"],
-            service=service,
-            from_date=from_date,
-            to_date=to_date,
-            save_path=save_path,
-            user_timezone=user_timezone,
-            filename=filename
-        )
-        if result is not None:
-            os.makedirs(current_app.config["UPLOAD_FOLDER"], exist_ok=True)
-            uploaded_file.save(save_path)
-
-            db_conn.commit()
-
-            return jsonify(result)
-
-        # task already exists in queue, rollback new entry
+        # the file can be a few hundred megabytes, uploading it must not hold a transaction
+        # (and the pooled connection it is checked out on) open for the entire transfer
         db_conn.rollback()
-        raise APIBadRequest(message="Data import already requested.")
+
+        try:
+            upload_import_file(saved_filename, uploaded_file)
+        except Exception:
+            current_app.logger.error("Error while uploading import file: %s", saved_filename, exc_info=True)
+            raise APIInternalServerError("Error while uploading the file, please try again later.")
+
+        try:
+            result = background.create_import_task(
+                db_conn,
+                user_id=user["id"],
+                service=service,
+                from_date=from_date,
+                to_date=to_date,
+                file_path=saved_filename,
+                user_timezone=user_timezone,
+                filename=filename
+            )
+            if result is None:
+                # task already exists in queue, rollback new entry
+                db_conn.rollback()
+            else:
+                db_conn.commit()
+        except Exception:
+            # the uploaded file belongs to no import, do not leave it behind in the bucket
+            db_conn.rollback()
+            delete_import_file(saved_filename)
+            raise
+
+        if result is None:
+            delete_import_file(saved_filename)
+            raise APIBadRequest(message="Data import already requested.")
+
+        return jsonify(result)
 
     except DatabaseError:
         current_app.logger.error("Error while creating import user data task: %s", user["musicbrainz_id"], exc_info=True)
@@ -198,7 +212,7 @@ def delete_import_task(import_id):
             text("DELETE FROM background_tasks WHERE user_id = :user_id AND (metadata->>'import_id')::int = :import_id"),
             {"user_id": user["id"], "import_id": import_id}
         )
-        Path(row.file_path).unlink(missing_ok=True)
+        delete_import_file(row.file_path)
         db_conn.commit()
         return jsonify({"success": True})
     else:


### PR DESCRIPTION
Store uploaded user data import files in a dedicated Garage bucket instead of a shared local directory. Download files to temporary storage while an import runs and remove them after completion, cancellation, or failure. Add commands to migrate existing uploads and clean up stale objects.

* [X] I used AI tools for coding
* [X] I understand all the changes made in this PR
