### PR TITLE
Read custom_name, not custome_name, on the custom art feed

### DIFF
--- a/listenbrainz/tests/integration/test_atom_feeds.py
+++ b/listenbrainz/tests/integration/test_atom_feeds.py
@@ -112,6 +112,28 @@ class AtomFeedsTestCase(ListenAPIIntegrationTestCase):
         response = self.client.get(stats_url, query_string={"count": "-1"})
         self.assert400(response)
 
+    def test_get_cover_art_custom_stats_custom_name(self):
+        """
+        custom_name selects the artwork. It used to be read under a
+        misspelled key, so every request silently fell back to the default
+        and an unknown name was never rejected.
+        """
+        url = self.custom_url_for(
+            "atom.get_cover_art_custom_stats", user_name=self.user["musicbrainz_id"]
+        )
+
+        response = self.client.get(url, query_string={"custom_name": "not-a-style"})
+        self.assert400(response)
+
+        response = self.client.get(
+            url, query_string={"custom_name": "lps-on-the-floor"}
+        )
+        self.assertNotEqual(400, response.status_code)
+        if response.status_code == 200:
+            body = response.get_data(as_text=True)
+            self.assertIn("lps-on-the-floor", body)
+            self.assertNotIn("designer-top-5", body)
+
     def test_get_listens_feed_elements(self):
         """
         Check server sends valid listens feed.

--- a/listenbrainz/webserver/views/atom.py
+++ b/listenbrainz/webserver/views/atom.py
@@ -960,7 +960,7 @@ def get_cover_art_custom_stats(user_name):
         return BadRequest(f"Invalid range value: {range}")
 
     try:
-        custom_name = request.args.get("custome_name", "designer-top-5")
+        custom_name = request.args.get("custom_name", "designer-top-5")
         image_size = int(request.args.get("image_size", 750))
     except ValueError:
         return BadRequest("Image size must be an integer.")


### PR DESCRIPTION
## The bug

The custom cover art Atom feed reads its style from `custome_name`:

```python
# listenbrainz/webserver/views/atom.py:963
custom_name = request.args.get("custome_name", "designer-top-5")
```

Nothing sends that key. The docstring on the same view documents `custom_name`, and the Art Creator builds the URL with `custom_name`:

```tsx
// frontend/js/src/explore/art-creator/ArtCreator.tsx:580
)}/stats/art/custom?custom_name=${style.name}&range=${timeRange}`,
```

So `request.args.get` falls back to the default on every request. Reading the two spellings side by side against a real request:

```
frontend sends custom_name='lps-on-the-floor'
   view reads 'custome_name' -> 'designer-top-5'   <-- always the default
   correct spelling          -> 'lps-on-the-floor'
```

## What it costs

`custom_name` is used three times after that line, so all three go wrong for anyone who does not want Designer Top 5:

- `data_url` becomes `/art/designer-top-5/...`, so the feed links to the wrong artwork;
- `_get_cover_art_feed_title` titles the feed "Designer Top 5";
- the check against `["designer-top-5", "designer-top-10", "lps-on-the-floor"]` can never reject anything, because the value it tests is always the default.

Present since the feed was added in 2991df73f (Aug 2024).

## The change

One word in the view, plus a test in `test_atom_feeds.py` covering both halves: an unknown name is rejected, and a valid one reaches the feed.

## What I could not do

I could not run the integration suite locally — it needs the Docker stack, which I do not have on this machine — so CI will be its first real run. The Flask behaviour above was executed rather than assumed, and the change itself is one identifier, but I would rather say that than imply I had run the suite.
