### PR TITLE
test(frontend): cover the email verification components

### DIFF
--- a/frontend/js/tests/utils/emailVerification.test.tsx
+++ b/frontend/js/tests/utils/emailVerification.test.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  EMAIL_REQUIRED_BLOG_URL,
+  EmailRequiredBlogLink,
+  EmailVerificationRequiredAlert,
+  EmailVerificationRequiredToastMessage,
+  METABRAINZ_PROFILE_URL,
+  MetaBrainzProfileLink,
+} from "../../src/utils/emailVerification";
+
+describe("emailVerification", () => {
+  describe("MetaBrainzProfileLink", () => {
+    it("points at the MetaBrainz profile page", () => {
+      render(<MetaBrainzProfileLink />);
+      const link = screen.getByRole("link", {
+        name: "MetaBrainz profile page",
+      });
+
+      expect(link).toHaveAttribute("href", METABRAINZ_PROFILE_URL);
+    });
+
+    it("opens in a new tab without leaking the referrer", () => {
+      // target="_blank" without rel="noreferrer" hands the destination a
+      // window.opener reference, so both attributes belong together.
+      render(<MetaBrainzProfileLink />);
+      const link = screen.getByRole("link");
+
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noreferrer");
+    });
+  });
+
+  describe("EmailRequiredBlogLink", () => {
+    it("points at the blog post explaining the requirement", () => {
+      render(<EmailRequiredBlogLink />);
+      const link = screen.getByRole("link", { name: "blog post" });
+
+      expect(link).toHaveAttribute("href", EMAIL_REQUIRED_BLOG_URL);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noreferrer");
+    });
+  });
+
+  describe("EmailVerificationRequiredToastMessage", () => {
+    it("names the action the user was attempting", () => {
+      render(
+        <EmailVerificationRequiredToastMessage action="pinning a track" />
+      );
+
+      expect(
+        screen.getByText(/verify your email before pinning a track/)
+      ).toBeInTheDocument();
+    });
+
+    it("offers the profile link as the way to resolve it", () => {
+      render(<EmailVerificationRequiredToastMessage action="submitting" />);
+
+      expect(
+        screen.getByRole("link", { name: "MetaBrainz profile page" })
+      ).toHaveAttribute("href", METABRAINZ_PROFILE_URL);
+    });
+  });
+
+  describe("EmailVerificationRequiredAlert", () => {
+    it("names the action the user was attempting", () => {
+      render(<EmailVerificationRequiredAlert action="recommending a track" />);
+
+      expect(
+        screen.getByText(/verify an email address before recommending a track/)
+      ).toBeInTheDocument();
+    });
+
+    it("renders as a danger alert", () => {
+      render(<EmailVerificationRequiredAlert action="submitting" />);
+
+      expect(
+        screen.getByText(/You need to verify an email address before/)
+      ).toHaveClass("alert", "alert-danger");
+    });
+
+    it("offers both the profile link and the explanation", () => {
+      // The alert is the fuller form of the toast: it tells the user how to
+      // fix it and why the email is needed at all.
+      render(<EmailVerificationRequiredAlert action="submitting" />);
+
+      expect(
+        screen.getByRole("link", { name: "MetaBrainz profile page" })
+      ).toHaveAttribute("href", METABRAINZ_PROFILE_URL);
+      expect(screen.getByRole("link", { name: "blog post" })).toHaveAttribute(
+        "href",
+        EMAIL_REQUIRED_BLOG_URL
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Problem

`frontend/js/src/utils/emailVerification.tsx` has no tests.

It is imported in three places and its components are what a user sees when an
action is blocked pending email verification. The details worth pinning are the
link destinations, the security attributes on those outbound links, and the fact
that the caller's `action` actually reaches the message.

# Solution

Eight tests:

- `MetaBrainzProfileLink` points at `METABRAINZ_PROFILE_URL`
- it opens in a new tab **and** sets `rel="noreferrer"` — `target="_blank"`
  without it hands the destination a `window.opener` reference, so the pair
  belongs together and is asserted together
- `EmailRequiredBlogLink` points at `EMAIL_REQUIRED_BLOG_URL` with the same two
  attributes
- the toast names the action it was given, and offers the profile link
- the alert names the action, renders with `alert-danger`, and offers both the
  profile link and the blog explanation

| | before | after |
|---|---|---|
| Statements | 0% | **100%** (11/11) |
| Functions | 0% | **100%** (4/4) |
| Lines | 0% | **100%** (11/11) |

Checked against mutations rather than only run — each fails **only** the test
that asserts that thing:

| mutation | test that catches it |
|---|---|
| drop `rel="noreferrer"` | opens in a new tab without leaking the referrer |
| replace the interpolated action with fixed text | names the action the user was attempting |
| change the alert severity | renders as a danger alert |

* [x] I have run the code and manually tested the changes

Ran locally: `npx jest frontend/js/tests/utils/emailVerification.test.tsx` — 8
passed. ESLint and Prettier clean.

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Claude Code was used to read `emailVerification.tsx`, write the tests, run them
and the mutation checks, and draft this description. Every figure above came
from running the suite locally.
