### PR TITLE
test(frontend): cover listenStorage

### DIFF
--- a/frontend/js/tests/utils/listenStorage.test.ts
+++ b/frontend/js/tests/utils/listenStorage.test.ts
@@ -1,0 +1,107 @@
+/*
+ * listenStorage is the offline retry queue: useListenSubmission calls
+ * saveFailedListen when a submission fails, then getFailedListens and
+ * removeFailedListen when it retries. Two things therefore matter beyond the
+ * plumbing — that two listens are never stored under the same key, and that
+ * they come back in the order they were played.
+ */
+
+const store = {
+  setItem: jest.fn().mockResolvedValue(undefined),
+  removeItem: jest.fn().mockResolvedValue(undefined),
+  clear: jest.fn().mockResolvedValue(undefined),
+  iterate: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock("localforage", () => ({
+  __esModule: true,
+  default: { createInstance: jest.fn(() => store) },
+}));
+
+// eslint-disable-next-line import/first
+import {
+  clearFailedListens,
+  getFailedListens,
+  removeFailedListen,
+  saveFailedListen,
+} from "../../src/utils/listenStorage";
+
+const listenAt = (listened_at: number, track_name = "t"): Listen =>
+  ({ listened_at, track_metadata: { artist_name: "a", track_name } } as Listen);
+
+describe("listenStorage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("saveFailedListen", () => {
+    it("keys the entry by when the track was played", async () => {
+      await saveFailedListen(listenAt(1605927742));
+
+      const [key, value] = store.setItem.mock.calls[0];
+      expect(key).toMatch(/^1605927742-/);
+      expect(value).toEqual(listenAt(1605927742));
+    });
+
+    it("gives two listens played in the same second distinct keys", async () => {
+      // Without the random suffix the second save would overwrite the first
+      // and a listen would be silently dropped from the retry queue.
+      await saveFailedListen(listenAt(1605927742, "first"));
+      await saveFailedListen(listenAt(1605927742, "second"));
+
+      const [firstKey] = store.setItem.mock.calls[0];
+      const [secondKey] = store.setItem.mock.calls[1];
+      expect(firstKey).not.toEqual(secondKey);
+    });
+  });
+
+  describe("getFailedListens", () => {
+    it("returns each entry with the key it is stored under", async () => {
+      store.iterate.mockImplementation(async (fn: any) => {
+        fn(listenAt(200), "key-b");
+        fn(listenAt(100), "key-a");
+      });
+
+      const result = await getFailedListens();
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.id)).toEqual(["key-a", "key-b"]);
+    });
+
+    it("orders them by when they were played, not by key order", async () => {
+      // The queue is replayed in this order, so it has to be chronological
+      // regardless of how the store happens to enumerate.
+      store.iterate.mockImplementation(async (fn: any) => {
+        fn(listenAt(300), "c");
+        fn(listenAt(100), "a");
+        fn(listenAt(200), "b");
+      });
+
+      const result = await getFailedListens();
+
+      expect(result.map((r) => r.listen.listened_at)).toEqual([100, 200, 300]);
+    });
+
+    it("returns an empty list when nothing is queued", async () => {
+      store.iterate.mockImplementation(async () => {});
+
+      await expect(getFailedListens()).resolves.toEqual([]);
+    });
+  });
+
+  describe("removeFailedListen and clearFailedListens", () => {
+    it("removes a single entry by its key", async () => {
+      await removeFailedListen("key-a");
+
+      expect(store.removeItem).toHaveBeenCalledWith("key-a");
+      expect(store.clear).not.toHaveBeenCalled();
+    });
+
+    it("clears the whole queue", async () => {
+      await clearFailedListens();
+
+      expect(store.clear).toHaveBeenCalled();
+      expect(store.removeItem).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# Problem

`frontend/js/src/utils/listenStorage.ts` has no tests.

It is the offline retry queue — `useListenSubmission` calls `saveFailedListen`
when a submission fails, then `getFailedListens` and `removeFailedListen` when
it retries. Two of its behaviours are load-bearing and were unasserted.

# Solution

Seven tests. The two that matter:

**Two listens played in the same second must get distinct keys.** The key is
`` `${listened_at}-${random}` ``, and without the random half the second save
overwrites the first — a listen silently disappears from the retry queue.

**Entries must come back ordered by `listened_at`**, not by however the store
happens to enumerate them, because that is the order they are replayed in.

Plus the plumbing: the key is derived from `listened_at`, each entry is returned
with the key it is stored under, an empty queue returns an empty list, and
`removeFailedListen` / `clearFailedListens` each touch only their own store
method.

| | before | after |
|---|---|---|
| Statements | 0% | **100%** (19/19) |
| Functions | 0% | **100%** (6/6) |
| Lines | 0% | **100%** (15/15) |

Checked against mutations rather than only run:

| mutation | tests that catch it |
|---|---|
| drop the random suffix from the key | keys the entry by when the track was played; gives two listens played in the same second distinct keys |
| reverse the sort | returns each entry with the key it is stored under; orders them by when they were played |

* [x] I have run the code and manually tested the changes

Ran locally: `npx jest frontend/js/tests/utils/listenStorage.test.ts` — 7
passed. ESLint and Prettier clean.

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [x] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

Claude Code was used to read `listenStorage.ts` and its caller, write the tests,
run them and the mutation checks, and draft this description. Every figure above
came from running the suite locally.
