### PR TITLE
feat: Display join date in listen count overview (LB-2024)

### DIFF
--- a/frontend/js/src/common/listens/ListenCountCard.tsx
+++ b/frontend/js/src/common/listens/ListenCountCard.tsx
@@ -12,6 +12,18 @@ function ListenCountCard(props: ListenCountCardProps) {
   const { listenCount, user } = props;
   const isCurrentUser = currentUser?.name === user?.name;
 
+  const joinDateString = React.useMemo(() => {
+    if (!user?.created) {
+      return null;
+    }
+    const date = new Date(user.created * 1000);
+    return date.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }, [user?.created]);
+
   let content;
 
   if (listenCount) {
@@ -22,6 +34,12 @@ function ListenCountCard(props: ListenCountCardProps) {
         {listenCount.toLocaleString()}
         <br />
         <small className="text-muted">songs so far</small>
+        {joinDateString && (
+          <>
+            <br />
+            <small className="text-muted">since {joinDateString}</small>
+          </>
+        )}
       </div>
     );
   } else {
@@ -35,6 +53,14 @@ function ListenCountCard(props: ListenCountCardProps) {
           {isCurrentUser ? "You haven't" : `${user.name} hasn't`} listened to
           any songs yet.
         </div>
+        {joinDateString && (
+          <div
+            style={{ fontSize: "12px", marginTop: "8px" }}
+            className="text-muted"
+          >
+            Member since {joinDateString}
+          </div>
+        )}
       </>
     );
   }

--- a/frontend/js/src/utils/types.d.ts
+++ b/frontend/js/src/utils/types.d.ts
@@ -82,6 +82,7 @@ declare type ListenBrainzUser = {
   id?: number;
   name: string;
   auth_token?: string;
+  created?: number;
 };
 
 declare type ImportService = "lastfm" | "librefm";

--- a/frontend/js/tests/common/listens/ListenCountCard.test.tsx
+++ b/frontend/js/tests/common/listens/ListenCountCard.test.tsx
@@ -14,6 +14,12 @@ const user = {
   name: "track_listener",
 };
 
+const userWithCreated = {
+  id: 1,
+  name: "track_listener",
+  created: 1579046400, // Jan 15, 2020 00:00:00 UTC
+};
+
 const loggedInUser = {
   id: 2,
   name: "iliekcomputers",
@@ -103,5 +109,34 @@ describe("ListenCountCard", () => {
     expect(
       screen.queryByText(/iliekcomputers has listened to/i)
     ).not.toBeInTheDocument();
+  });
+
+  it("displays join date when user has created timestamp and listens", () => {
+    render(
+      <ListenCountCard user={userWithCreated} listenCount={100} />
+    );
+
+    expect(screen.getByText(/songs so far/i)).toBeInTheDocument();
+    expect(screen.getByText(/since/i)).toBeInTheDocument();
+    expect(screen.getByText(/2020/)).toBeInTheDocument();
+  });
+
+  it("displays 'Member since' when user has created timestamp but no listens", () => {
+    render(
+      <ListenCountCard user={userWithCreated} />
+    );
+
+    expect(screen.getByText(/Member since/i)).toBeInTheDocument();
+    expect(screen.getByText(/2020/)).toBeInTheDocument();
+  });
+
+  it("does not display join date when created is not provided", () => {
+    render(
+      <ListenCountCard user={user} listenCount={100} />
+    );
+
+    expect(screen.getByText(/songs so far/i)).toBeInTheDocument();
+    expect(screen.queryByText(/since/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Member since/i)).not.toBeInTheDocument();
   });
 });

--- a/listenbrainz/webserver/views/api_compat.py
+++ b/listenbrainz/webserver/views/api_compat.py
@@ -247,7 +247,7 @@ def record_listens(data):
     for key, value in data.items():
         if key in ["sk", "token", "api_key", "method", "api_sig", "format"]:
             continue
-        matches = re.match('(.*)\[(\d+)\]', key)
+        matches = re.match(r'(.*)\[(\d+)\]', key)
         if matches:
             key = matches.group(1)
             number = matches.group(2)

--- a/listenbrainz/webserver/views/user.py
+++ b/listenbrainz/webserver/views/user.py
@@ -84,6 +84,7 @@ def profile(user_name):
         "user": {
             "id": user.id,
             "name": user.musicbrainz_id,
+            "created": int(user.created.timestamp()),
         },
         "listens": data["listens"],
         "latestListenTs": data["latest_listen_ts"],


### PR DESCRIPTION
# Problem

The `ListenCountCard` on the user dashboard currently displays only the raw listen count (e.g., "10,000 songs so far"). While useful, this number lacks context — a user with 10,000 listens over 5 years has very different listening habits than one who accumulated the same count in 6 months.

:beginner: **JIRA ticket:** [LB-2024](https://tickets.metabrainz.org/issues/LB-2024) — *Display join date in listen count overview*

# Solution

Added the user's join date to the `ListenCountCard` to provide meaningful context alongside the listen count.

### Backend
- **`listenbrainz/webserver/views/user.py`**: Pass `user.created` as a Unix timestamp in the `profile()` endpoint's user data dict. The `created` field already exists in the database and is already loaded by the `User` model — this change simply pipes it through to the frontend response. No database or migration changes needed.

### Frontend
- **`frontend/js/src/utils/types.d.ts`**: Added optional `created?: number` field to `ListenBrainzUser` type.
- **`frontend/js/src/common/listens/ListenCountCard.tsx`**: Enhanced the component to display the join date:
  - When listens exist: shows "since {formatted date}" below "songs so far"
  - When no listens exist: shows "Member since {formatted date}"
  - Gracefully handles missing `created` field (fully backward compatible)
  - Uses `toLocaleDateString()` with `{ year: "numeric", month: "short", day: "numeric" }` for locale-aware, readable formatting
- **`frontend/js/tests/common/listens/ListenCountCard.test.tsx`**: Added 3 new test cases:
  - Join date renders when `created` is provided with listens
  - "Member since" renders when `created` is provided without listens
  - No date rendered when `created` is not provided (backward compatibility)

* [x] I have run the code and manually tested the changes

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR

# Action

No special action needed on merge or deployment. This is a purely additive, backward-compatible UI change with no database schema modifications.
