### PR TITLE
Use fully qualified image specifications for containerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_BASE_IMAGE_VERSION=3.13-20250313
 ARG NODE_VERSION=20-alpine
-FROM metabrainz/python:$PYTHON_BASE_IMAGE_VERSION AS listenbrainz-base
+FROM docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION AS listenbrainz-base
 
 ARG PYTHON_BASE_IMAGE_VERSION
 
@@ -9,7 +9,7 @@ LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-serve
       org.label-schema.schema-version="1.0.0-rc1" \
       org.label-schema.vendor="MetaBrainz Foundation" \
       org.label-schema.name="ListenBrainz" \
-      org.metabrainz.based-on-image="metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
+      org.metabrainz.based-on-image="docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
 
 ENV DOCKERIZE_VERSION=v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -67,7 +67,7 @@ COPY . /code/listenbrainz
 #####################################################################################################
 # NOTE: The javascript files are continously watched and compiled using this image in developement. #
 #####################################################################################################
-FROM node:$NODE_VERSION AS listenbrainz-frontend-dev
+FROM docker.io/library/node:$NODE_VERSION AS listenbrainz-frontend-dev
 
 ARG NODE_VERSION
 
@@ -75,7 +75,7 @@ LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-serve
       org.label-schema.schema-version="1.0.0-rc1" \
       org.label-schema.vendor="MetaBrainz Foundation" \
       org.label-schema.name="ListenBrainz Static Builder" \
-      org.metabrainz.based-on-image="node:$NODE_VERSION"
+      org.metabrainz.based-on-image="docker.io/node:$NODE_VERSION"
 
 RUN mkdir /code
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION AS listenbrainz-base
 ARG PYTHON_BASE_IMAGE_VERSION
 
 LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-server.git" \
-      org.label-schema.vcs-ref="" \
-      org.label-schema.schema-version="1.0.0-rc1" \
-      org.label-schema.vendor="MetaBrainz Foundation" \
-      org.label-schema.name="ListenBrainz" \
-      org.metabrainz.based-on-image="docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
+    org.label-schema.vcs-ref="" \
+    org.label-schema.schema-version="1.0.0-rc1" \
+    org.label-schema.vendor="MetaBrainz Foundation" \
+    org.label-schema.name="ListenBrainz" \
+    org.metabrainz.based-on-image="docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
 
 ENV DOCKERIZE_VERSION=v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -23,22 +23,22 @@ ENV SENTRY_SERVICE_ERROR_ENVIRONMENT=listenbrainz
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-                       build-essential \
-                       git \
-                       libffi-dev \
-                       libpq-dev \
-                       libssl-dev \
-                       xz-utils \
-                       redis-tools \
-                       rsync \
-                       uuid \
-                       zstd \
+        build-essential \
+        git \
+        libffi-dev \
+        libpq-dev \
+        libssl-dev \
+        xz-utils \
+        redis-tools \
+        rsync \
+        uuid \
+        zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ENV PG_MAJOR=14
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" $PG_MAJOR >/etc/apt/sources.list.d/pgdg.list
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-$PG_MAJOR \
     && rm -rf /var/lib/apt/lists/*
@@ -72,10 +72,10 @@ FROM docker.io/library/node:$NODE_VERSION AS listenbrainz-frontend-dev
 ARG NODE_VERSION
 
 LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-server.git" \
-      org.label-schema.schema-version="1.0.0-rc1" \
-      org.label-schema.vendor="MetaBrainz Foundation" \
-      org.label-schema.name="ListenBrainz Static Builder" \
-      org.metabrainz.based-on-image="docker.io/node:$NODE_VERSION"
+    org.label-schema.schema-version="1.0.0-rc1" \
+    org.label-schema.vendor="MetaBrainz Foundation" \
+    org.label-schema.name="ListenBrainz Static Builder" \
+    org.metabrainz.based-on-image="docker.io/node:$NODE_VERSION"
 
 RUN mkdir /code
 WORKDIR /code
@@ -242,4 +242,4 @@ RUN rm -f /code/listenbrainz/listenbrainz/config.py /code/listenbrainz/listenbra
 
 ARG GIT_COMMIT_SHA
 LABEL org.label-schema.vcs-ref=$GIT_COMMIT_SHA
-ENV GIT_SHA ${GIT_COMMIT_SHA}
+ENV GIT_SHA=${GIT_COMMIT_SHA}

--- a/Dockerfile.nginx.prod
+++ b/Dockerfile.nginx.prod
@@ -1,7 +1,7 @@
 FROM docker.io/library/nginx:1.13.5
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends 
+    && apt-get install -y --no-install-recommends
 
 WORKDIR /etc
 COPY ./docker/prod/nginx/nginx.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile.nginx.prod
+++ b/Dockerfile.nginx.prod
@@ -1,4 +1,4 @@
-FROM nginx:1.13.5
+FROM docker.io/library/nginx:1.13.5
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends 

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -2,7 +2,7 @@ FROM docker.io/metabrainz/listenbrainz-spark-base:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-                       zstd \
+        zstd \
     && rm -rf /var/lib/apt/lists/*
 
 COPY docker/spark-cluster-config/test/core-site.xml $HADOOP_HOME/etc/hadoop/core-site.xml

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -1,4 +1,4 @@
-FROM metabrainz/listenbrainz-spark-base:latest
+FROM docker.io/metabrainz/listenbrainz-spark-base:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.spark.base
+++ b/docker/Dockerfile.spark.base
@@ -3,60 +3,60 @@ FROM docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION
 
 ARG PYTHON_BASE_IMAGE_VERSION
 LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-server.git" \
-      org.label-schema.schema-version="1.0.0-rc1" \
-      org.label-schema.vendor="MetaBrainz Foundation" \
-      org.label-schema.name="ListenBrainz Spark" \
-      org.metabrainz.based-on-image="docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
+    org.label-schema.schema-version="1.0.0-rc1" \
+    org.label-schema.vendor="MetaBrainz Foundation" \
+    org.label-schema.name="ListenBrainz Spark" \
+    org.metabrainz.based-on-image="docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    wget \
-    net-tools \
-    dnsutils \
-    bsdmainutils \
-    xz-utils \
-    zip \
-    libcurl4-openssl-dev \
+        wget \
+        net-tools \
+        dnsutils \
+        bsdmainutils \
+        xz-utils \
+        zip \
+        libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV DOCKERIZE_VERSION v0.6.1
+ENV DOCKERIZE_VERSION=v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR /usr/local
 
-ENV JAVA_VERSION 11.0.26
-ENV JAVA_MAJOR_VERSION 11
-ENV JAVA_BUILD_VERSION 4
+ENV JAVA_VERSION=11.0.26
+ENV JAVA_MAJOR_VERSION=11
+ENV JAVA_BUILD_VERSION=4
 RUN wget https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${JAVA_VERSION}%2B${JAVA_BUILD_VERSION}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_x64_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD_VERSION}.tar.gz \
     && tar xzf OpenJDK${JAVA_MAJOR_VERSION}U-jdk_x64_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD_VERSION}.tar.gz \
     && mv jdk-${JAVA_VERSION}+${JAVA_BUILD_VERSION} /usr/local/jdk \
     && rm OpenJDK${JAVA_MAJOR_VERSION}U-jdk_x64_linux_hotspot_${JAVA_VERSION}_${JAVA_BUILD_VERSION}.tar.gz
-ENV JAVA_HOME /usr/local/jdk
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/usr/local/jdk
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 COPY apache-download.sh /apache-download.sh
 
-ENV HADOOP_VERSION 3.4.1
+ENV HADOOP_VERSION=3.4.1
 RUN /apache-download.sh hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz \
     && tar xzf hadoop-${HADOOP_VERSION}.tar.gz \
     && mv hadoop-${HADOOP_VERSION} /usr/local/hadoop \
     && rm hadoop-${HADOOP_VERSION}.tar.gz
-ENV HADOOP_HOME /usr/local/hadoop
-ENV PATH $HADOOP_HOME/bin:$PATH
+ENV HADOOP_HOME=/usr/local/hadoop
+ENV PATH=$HADOOP_HOME/bin:$PATH
 
 RUN mkdir /hdfs
 
-ENV SPARK_VERSION 3.5.5
+ENV SPARK_VERSION=3.5.5
 RUN /apache-download.sh spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz \
     && tar xzf spark-${SPARK_VERSION}-bin-without-hadoop.tgz \
     && mv spark-${SPARK_VERSION}-bin-without-hadoop /usr/local/spark \
     && rm spark-${SPARK_VERSION}-bin-without-hadoop.tgz
-ENV SPARK_HOME /usr/local/spark
-ENV PATH $SPARK_HOME/bin:$PATH
-ENV PYTHONPATH $SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$SPARK_HOME/python:$PYTHONPATH
+ENV SPARK_HOME=/usr/local/spark
+ENV PATH=$SPARK_HOME/bin:$PATH
+ENV PYTHONPATH=$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$SPARK_HOME/python:$PYTHONPATH
 
-ENV POSTGRESQL_DRIVER_VERSION 42.7.5
+ENV POSTGRESQL_DRIVER_VERSION=42.7.5
 RUN wget -O postgresql-${POSTGRESQL_DRIVER_VERSION}.jar https://jdbc.postgresql.org/download/postgresql-${POSTGRESQL_DRIVER_VERSION}.jar \
     && mv postgresql-${POSTGRESQL_DRIVER_VERSION}.jar ${SPARK_HOME}/jars

--- a/docker/Dockerfile.spark.base
+++ b/docker/Dockerfile.spark.base
@@ -1,12 +1,12 @@
 ARG PYTHON_BASE_IMAGE_VERSION=3.12-20241130
-FROM metabrainz/python:$PYTHON_BASE_IMAGE_VERSION
+FROM docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION
 
 ARG PYTHON_BASE_IMAGE_VERSION
 LABEL org.label-schema.vcs-url="https://github.com/metabrainz/listenbrainz-server.git" \
       org.label-schema.schema-version="1.0.0-rc1" \
       org.label-schema.vendor="MetaBrainz Foundation" \
       org.label-schema.name="ListenBrainz Spark" \
-      org.metabrainz.based-on-image="metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
+      org.metabrainz.based-on-image="docker.io/metabrainz/python:$PYTHON_BASE_IMAGE_VERSION"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/garage/Dockerfile
+++ b/docker/garage/Dockerfile
@@ -1,10 +1,10 @@
 ARG GARAGE_VERSION=v2.3.0
 
-FROM dxflrs/garage:${GARAGE_VERSION} AS upstream
+FROM docker.io/dxflrs/garage:${GARAGE_VERSION} AS upstream
 
 # The upstream image is built FROM scratch and has no shell, so the (statically
 # linked) binary is copied into an image that can run the provisioning script.
-FROM alpine:3.24
+FROM docker.io/library/alpine:3.24
 
 COPY --from=upstream /garage /usr/local/bin/garage
 COPY garage.toml /etc/garage.toml

--- a/mbid_mapping/Dockerfile
+++ b/mbid_mapping/Dockerfile
@@ -1,4 +1,4 @@
-FROM metabrainz/python:3.13-20250313 as mbid-mapping-base
+FROM docker.io/metabrainz/python:3.13-20250313 as mbid-mapping-base
 
 RUN apt-get update && apt-get install -y ca-certificates python3-pip netpbm git && \
         pip install --upgrade pip

--- a/mbid_mapping/Dockerfile
+++ b/mbid_mapping/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/metabrainz/python:3.13-20250313 as mbid-mapping-base
+FROM docker.io/metabrainz/python:3.13-20250313 AS mbid-mapping-base
 
-RUN apt-get update && apt-get install -y ca-certificates python3-pip netpbm git && \
-        pip install --upgrade pip
+RUN apt-get update && apt-get install -y ca-certificates python3-pip netpbm git \
+    && pip install --upgrade pip
 
 RUN groupadd --gid 901 listenbrainz
 RUN useradd --create-home --shell /bin/bash --uid 901 --gid 901 listenbrainz
@@ -15,7 +15,7 @@ COPY . /code/mapper
 
 
 # Section for PROD specific setup
-FROM mbid-mapping-base as mbid-mapping-prod
+FROM mbid-mapping-base AS mbid-mapping-prod
 
 # service start up scripts
 COPY ./docker/consul-template.conf /etc/consul-template-mbid-mapping.conf


### PR DESCRIPTION
# Problem
The Containerfiles assume what registry is used. This means container building tooling has to guess at which to use, so e.g. buildah fails.

This shouldn't really change anything, except make more tools work. Would personally like them fully qualified as I'm working on something to make deploying LBS locally simpler.

# Solution
Seemed to me like the assumed registry is `docker.io`, so I changed all `FROM` instructions **and `org.metabrainz.based-on-image` labels** to use the fully qualified path.

# Action
- [ ] Seems to build fine for me, but could someone do a basic sanity check?
- [ ] This also changes the `org.metabrainz.based-on-image` label. I'm unsure where this fits into the infrastructure (monitoring?), so would like to know whether it's should be included or not.
- [ ] Any other containerfiles in the repo? I tried to find them using `rg --files-with-matches '^FROM'`.

# AI usage
no.