### PR TITLE
Attempt to force an ordering on database migrations

### DIFF
--- a/.github/workflows/check-database-migration-ordering.yaml
+++ b/.github/workflows/check-database-migration-ordering.yaml
@@ -1,0 +1,32 @@
+# ensure that the dates in database migration filenames are (roughly) at merge time. this is done to better allow automatically running migrations on self-hosted instances.
+# whomever merges needs to re-run this check right before merging.
+name: Check database migration filename date
+permissions: {}
+on:
+  pull_request:
+    branches: ['master']
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths: ['admin/sql/updates']
+jobs:
+  check-migration-date:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Find changed migrations
+        run: |
+          oldest_valid_timestamp=$(date --utc --date='1 days ago' +%s)
+          expired_migrations=0
+          for file in $(git diff --name-only master..HEAD admin/sql/updates); do
+            date=$(echo "$file" | rev | cut -d/ -f1 | rev | cut -d- -f1-3)
+            timestamp=$(date --utc --date="$date" +%s)
+            echo "::debug::Found migration: $file"
+            if [ "$timestamp" -lt "$oldest_valid_timestamp" ]; then
+              diff_days=$(awk -v oldest="$oldest_valid_timestamp" -v pull="$timestamp" 'BEGIN { print (oldest-pull)/(60*60*24) }' </dev/null)
+              echo "::error file=$file::Date in migration is too old by $diff_days days"
+              expired_migrations=$((expired_migrations + 1))
+            fi
+          done
+          exit $expired_migrations


### PR DESCRIPTION
# Problem
Database migrations generally need to be applied in order. If a PR with migrations dating back 6 months were merged today, they'd be applied **before** a 2-month old PR with migrations that was merged last month. Not enforcing an order on migrations makes applying them automatically risky[^1].

[^1]: in extremely specific situations. Nonetheless it'd suck to break existing setups due to something entirely avoidable.

This is hardly problematic for highly managed and carefully monitored instances like Listenbrainz.org. Instead this PR exists in hopes that self-hosted options could be more hands-free, having migrations automatically apply when updating to a newer version. I specifically want this "guarantee" for a NixOS module I'm writing.

[See discussion on Matrix.](https://matrix.to/#/!eCpNNRGiaOtkqENwWi:chatbrainz.org/$5lDSMUWdZXLq2slhih1pSJD7V51GSP6uX6vZXszoTCc?via=chatbrainz.org&via=matrix.org&via=kanp.ai)

# Solution
Add a CI action that runs on pull requests. The action checks that the date in filenames of added[^2] migrations is within some interval of _now_ (default is a day; see action section)

[^2]: technically this is any _changed_ migration, so old migrations being changed would trigger this check, but realistically migrations are append-only ⇒ this isn't an issue.

Doing this allows getting all the migrations in the order they _should_ be applied, not just when they were being worked on, as well as applying migrations based on when an instance was last updated.

- [x] I have run the code and manually tested the changes

# Action
Should the interval be longer? e.g. have check pass when migration dates are 2 days out-of-date as opposed to just one?

Test this somehow? I did try locally using [act](https://gitbub.com/nektos/act) by hardcoding different commits for `master` and `HEAD` in the git diff (l22c46). If this were merged, it'd probably be a good idea to make a faux PR adding a migration to see if everything is right.

Also unsure about the triggered PR types. Does this seem sensible?

I always find actions really annoying to test... :b

# Alternative solution
automatic database migrations could alternatively order by birth, though that is quite a bit more complicated and may require otherwise unnecessary tooling (e.g. git).

# AI usage
no.