### PR TITLE
Disable to disabled

### DIFF
--- a/frontend/js/src/settings/music-services/details/MusicServices.tsx
+++ b/frontend/js/src/settings/music-services/details/MusicServices.tsx
@@ -586,7 +586,7 @@ export default function MusicServices() {
                   service="spotify"
                   current={permissions.spotify}
                   value="disable"
-                  title="Disable"
+                  title="Disabled"
                   details="You won't be able to listen to music on ListenBrainz or import listens using Spotify."
                   handlePermissionChange={handlePermissionChange}
                 />
@@ -652,7 +652,7 @@ export default function MusicServices() {
                   service="critiquebrainz"
                   current={permissions.critiquebrainz}
                   value="disable"
-                  title="Disable"
+                  title="Disabled"
                   details="You will not be able to publish reviews from ListenBrainz."
                   handlePermissionChange={handlePermissionChange}
                 />
@@ -709,7 +709,7 @@ export default function MusicServices() {
                   service="soundcloud"
                   current={permissions.soundcloud}
                   value="disable"
-                  title="Disable"
+                  title="Disabled"
                   details="You will not be able to listen to music on ListenBrainz using SoundCloud."
                   handlePermissionChange={handlePermissionChange}
                 />
@@ -748,7 +748,7 @@ export default function MusicServices() {
                   service="appleMusic"
                   current={permissions.appleMusic}
                   value="disable"
-                  title="Disable"
+                  title="Disabled"
                   details="You won't be able to listen to music on ListenBrainz using Apple Music."
                   handlePermissionChange={handleAppleMusicPermissionChange}
                 />
@@ -836,7 +836,7 @@ export default function MusicServices() {
                   service="funkwhale"
                   current={permissions.funkwhale}
                   value="disable"
-                  title="Disable"
+                  title="Disabled"
                   details="You will not be able to listen to music on ListenBrainz using Funkwhale."
                   handlePermissionChange={handlePermissionChange}
                 />
@@ -993,7 +993,7 @@ export default function MusicServices() {
                   service="navidrome"
                   current={permissions.navidrome}
                   value="disable"
-                  title="Disable"
+                  title="Disabled"
                   details="You will not be able to listen to music on ListenBrainz using Navidrome."
                   handlePermissionChange={handlePermissionChange}
                 />

--- a/frontend/js/src/settings/music-services/details/components/LFMMusicServicePermissions.tsx
+++ b/frontend/js/src/settings/music-services/details/components/LFMMusicServicePermissions.tsx
@@ -139,11 +139,11 @@ export default function LFMMusicServicePermissions({
       toast.success(
         <ToastMsg
           title="Success"
-          message={`${serviceDisplayName} integration has been disabled.`}
+          message={`${serviceDisplayName} integration has been d.`}
         />
       );
 
-      setPermissions("disable");
+      setPermissions("");
     } catch (error) {
       toast.error(
         <ToastMsg
@@ -224,7 +224,7 @@ export default function LFMMusicServicePermissions({
               className="alert alert-warning alert-dismissible fade show"
               role="alert"
             >
-              Before connecting, you must disable the &#34;Hide recent listening
+              Before connecting, you must  the &#34;Hide recent listening
               information&#34; setting in your {serviceDisplayName}{" "}
               <a
                 href={`https://www.${
@@ -352,7 +352,7 @@ export default function LFMMusicServicePermissions({
               service={serviceName}
               current={permissions ?? "disable"}
               value="disable"
-              title="Disable"
+              title="Disabled"
               details={`New scrobbles won't be imported from ${serviceDisplayName}`}
               handlePermissionChange={handleDisconnect}
             />


### PR DESCRIPTION
Changed the text on the Connect Services page from "Disable" to "Disabled" (https://listenbrainz.org/settings/music-services/details/)

After feedback in this reddit post: https://www.reddit.com/r/listenbrainz/comments/1wedjdp/
Although it's a very minor change, it probably does make sense to have it as the present tense, since it's the default/people don't click to enable it (in other words, they may think there are still steps required to actively disable it).

# Solution

* [ ] I have run the code and manually tested the changes

Someone will have to test, sorry!

# AI usage

* [X] I did not use any AI
* [ ] I have used AI in this PR