### PR TITLE
Fix archive file importer names (Spotify and Libre.fm)

### DIFF
--- a/listenbrainz/background/listens_importer/librefm.py
+++ b/listenbrainz/background/listens_importer/librefm.py
@@ -10,6 +10,11 @@ from listenbrainz.webserver.errors import ImportFailedError
 
 
 class LibrefmListensImporter(BaseListensImporter):
+    """Libre.fm-specific listens importer."""
+    def __init__(self, db_conn, ts_conn):
+        super().__init__(db_conn, ts_conn)
+        self.importer_name = "Libre.Fm Archive Importer"
+
     def process_import_file(self, import_task: dict[str, Any]) -> Iterator[list[dict[str, Any]]]:
         """Processes the libre.fm csv archive file and returns a generator of batches of items."""
 

--- a/listenbrainz/background/listens_importer/spotify.py
+++ b/listenbrainz/background/listens_importer/spotify.py
@@ -20,6 +20,7 @@ class SpotifyListensImporter(ZipBaseListensImporter):
 
     def __init__(self, db_conn, ts_conn):
         super().__init__(db_conn, ts_conn)
+        self.importer_name = "Spotify Extended Streaming History Importer"
         self.skipped_incognito_count = 0
         self.skipped_short_plays_count = 0
 


### PR DESCRIPTION
Cleaning up old branches on my computer with unfinished work, Part1

The Spotify and Libre.fm archive importers did not have a name set and were using the default "ListenBrainz Archive Importer".
Did not run it, but simple enough fix that the tests should be enough.

* [ ] I have run the code and manually tested the changes

# AI usage

* [x] I did not use any AI
* [ ] I have used AI in this PR (add more details below)
